### PR TITLE
Add BaaS vulnerability scanner with active validation

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -7,11 +7,53 @@
 
 const MSG_TYPE = '__keyleak_intercepted__';
 
+function safeSendMessage(payload) {
+  try {
+    if (!chrome.runtime?.id) return;
+    chrome.runtime.sendMessage(payload);
+  } catch (_err) {
+    // Extension context invalidated (reload/update) — ignore silently.
+  }
+}
+
+function sendForAnalysis(data) {
+  safeSendMessage({
+    action: 'analyze_content',
+    data: {
+      pageUrl: window.location.href,
+      ...data,
+    },
+  });
+}
+
+function sendRemoteUrl(url, source, captureType) {
+  if (!url) return;
+  try {
+    const resolved = new URL(url, window.location.href).toString();
+    safeSendMessage({
+      action: 'analyze_remote_url',
+      data: {
+        url: resolved,
+        source,
+        pageUrl: window.location.href,
+        captureType,
+      },
+    });
+  } catch (_error) {
+    // Ignore malformed URLs.
+  }
+}
+
 // Forward intercepted network data to service worker
 window.addEventListener('message', (event) => {
   if (event.source !== window || !event.data || event.data.type !== MSG_TYPE) return;
 
-  chrome.runtime.sendMessage({
+  if (event.data.captureType === 'worker-script') {
+    sendRemoteUrl(event.data.url, `Worker Script: ${event.data.url}`, 'external-script');
+    return;
+  }
+
+  safeSendMessage({
     action: 'analyze_intercepted',
     data: {
       source: event.data.source,
@@ -20,6 +62,7 @@ window.addEventListener('message', (event) => {
       contentType: event.data.contentType,
       body: event.data.body,
       headers: event.data.headers,
+      captureType: event.data.captureType,
       pageUrl: window.location.href,
     },
   });
@@ -27,36 +70,38 @@ window.addEventListener('message', (event) => {
 
 // Scan inline scripts and data attributes after page loads
 function scanPageContent() {
-  const findings = [];
-
   // Collect inline script contents
   const scripts = document.querySelectorAll('script:not([src])');
   scripts.forEach((script, idx) => {
     const text = script.textContent;
     if (text && text.trim().length > 20) {
-      chrome.runtime.sendMessage({
-        action: 'analyze_content',
-        data: {
-          content: text,
-          source: `Inline Script #${idx + 1}`,
-          pageUrl: window.location.href,
-        },
+      sendForAnalysis({
+        content: text,
+        source: `Inline Script #${idx + 1}`,
+        captureType: 'inline-script',
       });
+      scanSourceMapReferences(text, window.location.href);
     }
   });
 
+  // Ask the service worker to fetch external browser bundles and source maps.
+  const externalScripts = document.querySelectorAll('script[src]');
+  externalScripts.forEach((script, idx) => {
+    sendRemoteUrl(script.src, `External Script #${idx + 1}: ${script.src}`, 'external-script');
+  });
+
   // Scan data attributes that might contain config/secrets
-  const elements = document.querySelectorAll('[data-config], [data-api-key], [data-token], [data-secret]');
+  const elements = document.querySelectorAll('[data-config], [data-api-key], [data-token], [data-secret], [data-auth], [data-settings]');
   elements.forEach((el) => {
     for (const attr of el.attributes) {
-      if (attr.name.startsWith('data-') && attr.value.length > 20) {
-        chrome.runtime.sendMessage({
-          action: 'analyze_content',
-          data: {
-            content: attr.value,
-            source: `HTML data attribute: ${attr.name}`,
-            pageUrl: window.location.href,
-          },
+      const attrName = attr.name.toLowerCase();
+      const looksSensitive = attrName.startsWith('data-')
+        && /(config|key|token|secret|auth|credential|settings)/.test(attrName);
+      if (looksSensitive && attr.value.length > 20) {
+        sendForAnalysis({
+          content: attr.value,
+          source: `HTML data attribute: ${attr.name}`,
+          captureType: 'data-attribute',
         });
       }
     }
@@ -67,16 +112,43 @@ function scanPageContent() {
   metas.forEach((meta) => {
     const content = meta.getAttribute('content');
     if (content && content.length > 20) {
-      chrome.runtime.sendMessage({
-        action: 'analyze_content',
-        data: {
-          content,
-          source: `Meta tag (${meta.getAttribute('name') || meta.getAttribute('property') || 'unknown'})`,
-          pageUrl: window.location.href,
-        },
+      sendForAnalysis({
+        content,
+        source: `Meta tag (${meta.getAttribute('name') || meta.getAttribute('property') || 'unknown'})`,
+        captureType: 'meta',
       });
     }
   });
+
+  scanBrowserStorage();
+}
+
+function scanSourceMapReferences(content, baseUrl) {
+  const re = /sourceMappingURL=([^\s'"<>]+)/g;
+  let match;
+  while ((match = re.exec(content)) !== null) {
+    sendRemoteUrl(match[1], `Source Map: ${match[1]}`, 'source-map');
+  }
+}
+
+function scanBrowserStorage() {
+  for (const [storageName, storage] of [['localStorage', window.localStorage], ['sessionStorage', window.sessionStorage]]) {
+    try {
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        const value = storage.getItem(key);
+        if (!value || value.length < 20) continue;
+        if (!/(key|token|secret|auth|credential|session|config|jwt)/i.test(`${key} ${value}`)) continue;
+        sendForAnalysis({
+          content: `${key}=${value}`,
+          source: `Browser Storage (${storageName}:${key})`,
+          captureType: 'storage',
+        });
+      }
+    } catch (_error) {
+      // Some sites disable storage access for injected contexts.
+    }
+  }
 }
 
 // Run DOM scan after page loads
@@ -91,14 +163,15 @@ const observer = new MutationObserver((mutations) => {
   for (const mutation of mutations) {
     for (const node of mutation.addedNodes) {
       if (node.nodeName === 'SCRIPT' && !node.src && node.textContent?.trim().length > 20) {
-        chrome.runtime.sendMessage({
-          action: 'analyze_content',
-          data: {
-            content: node.textContent,
-            source: 'Dynamic Inline Script',
-            pageUrl: window.location.href,
-          },
+        sendForAnalysis({
+          content: node.textContent,
+          source: 'Dynamic Inline Script',
+          captureType: 'inline-script',
         });
+        scanSourceMapReferences(node.textContent, window.location.href);
+      }
+      if (node.nodeName === 'SCRIPT' && node.src) {
+        sendRemoteUrl(node.src, `Dynamic External Script: ${node.src}`, 'external-script');
       }
     }
   }

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -83,15 +83,18 @@ export function analyzeContent(content, source = '', meta = {}) {
       // AIza key classification: Maps/Firebase client key vs Gemini API key
       if ((name === 'gemini_api_key' || entry.finding_type === 'gemini_api_key') && value.startsWith('AIza')) {
         const contentLower = content.toLowerCase();
+        const sourceLower = source.toLowerCase();
         const MAPS_MARKERS = [
           'maps.googleapis.com', 'googleapis.com/maps', 'google.maps',
-          'firebaseconfig', 'firebaseapp', 'firebase.google.com',
+          'firebaseconfig', 'firebaseapp', 'firebase.google.com', 'firebase',
           'google-analytics.com', 'googletagmanager.com',
           'gapi.client', 'accounts.google.com',
           'gtag(', 'ga(', 'googleanalyticsobject',
           'youtube.googleapis.com', 'maps.google.com',
+          '@firebase/', 'firebase/performance', 'firebase/auth',
+          'firebase/firestore', 'firebase/storage', 'firebase/messaging',
         ];
-        if (MAPS_MARKERS.some(m => contentLower.includes(m))) {
+        if (MAPS_MARKERS.some(m => contentLower.includes(m) || sourceLower.includes(m))) {
           finding.type = 'google_client_api_key';
           finding.severity = 'medium';
           finding.risk_reason = 'Google Maps/Firebase client API key (referrer-restricted, expected in browser bundles).';

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isPresignedUrlCredential } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -22,6 +22,9 @@ export function analyzeContent(content, source = '', meta = {}) {
 
   // Skip known third-party vendor scripts (Google Analytics, PostHog, etc.)
   if (isVendorScript(source) || isVendorScript(meta.url || '')) return findings;
+
+  // Skip cloud storage signed/pre-signed URLs (AWS S3, GCS, Azure, R2, etc.)
+  if (isCloudStorageSignedUrl('', source, content) || isAzureSasToken(content)) return findings;
 
   const seen = new Set(); // deduplicate by value
 
@@ -43,7 +46,6 @@ export function analyzeContent(content, source = '', meta = {}) {
       // Skip false positives
       if (entry.min_match_length && value.length < entry.min_match_length) continue;
       if (isFalsePositive(value)) continue;
-      if (isPresignedUrlCredential(value, source, content)) continue;
 
       // Get a snippet of surrounding context (up to 100 chars each side)
       const start = Math.max(0, match.index - 60);

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -43,7 +43,7 @@ export function analyzeContent(content, source = '', meta = {}) {
       // Skip false positives
       if (entry.min_match_length && value.length < entry.min_match_length) continue;
       if (isFalsePositive(value)) continue;
-      if (isPresignedUrlCredential(value, source)) continue;
+      if (isPresignedUrlCredential(value, source, content)) continue;
 
       // Get a snippet of surrounding context (up to 100 chars each side)
       const start = Math.max(0, match.index - 60);

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -19,6 +19,9 @@ export function analyzeContent(content, source = '', meta = {}) {
 
   // Skip obviously non-secret content types
   if (content.length > 5 * 1024 * 1024) return findings; // >5MB, skip
+
+  // Skip browser-internal URLs (chrome-extension://, devtools://, etc.)
+  if (isBrowserInternal(source) || isBrowserInternal(meta.url || '')) return findings;
 
   // Skip known third-party vendor scripts (Google Analytics, PostHog, etc.)
   if (isVendorScript(source) || isVendorScript(meta.url || '')) return findings;

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader, isBrowserServiceToken } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -25,6 +25,9 @@ export function analyzeContent(content, source = '', meta = {}) {
 
   // Skip user's own auth headers (Authorization: Bearer, Cookie)
   if (isOwnAuthHeader(source)) return findings;
+
+  // Skip browser-internal service tokens (Translate, reCAPTCHA, Firebase Auth, etc.)
+  if (isBrowserServiceToken(source)) return findings;
 
   // Skip infrastructure response headers (x-amz-cf-id, cf-ray, x-request-id, etc.)
   if (isInfraHeader(source)) return findings;

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,8 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive } from './false-positives.js';
+import { isFalsePositive, isVendorScript } from './false-positives.js';
+import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
  * Analyze text content for potential secrets.
@@ -12,12 +13,15 @@ import { isFalsePositive } from './false-positives.js';
  * @param {string} source - Where the content came from (e.g. 'Response Body', 'Request Header')
  * @returns {Array<Object>} Array of findings
  */
-export function analyzeContent(content, source = '') {
+export function analyzeContent(content, source = '', meta = {}) {
   const findings = [];
   if (!content || typeof content !== 'string' || content.length < 10) return findings;
 
   // Skip obviously non-secret content types
   if (content.length > 5 * 1024 * 1024) return findings; // >5MB, skip
+
+  // Skip known third-party vendor scripts (Google Analytics, PostHog, etc.)
+  if (isVendorScript(source) || isVendorScript(meta.url || '')) return findings;
 
   const seen = new Set(); // deduplicate by value
 
@@ -28,7 +32,8 @@ export function analyzeContent(content, source = '') {
 
     while ((match = regex.exec(content)) !== null) {
       // Extract the captured group or full match
-      const value = (match[1] || match[0]).trim();
+      const captureIndex = entry.capture_group || 0;
+      const value = (match[captureIndex] || match[1] || match[0]).trim();
 
       // Skip duplicates within this content block
       const dedupeKey = `${name}:${value}`;
@@ -36,6 +41,7 @@ export function analyzeContent(content, source = '') {
       seen.add(dedupeKey);
 
       // Skip false positives
+      if (entry.min_match_length && value.length < entry.min_match_length) continue;
       if (isFalsePositive(value)) continue;
 
       // Get a snippet of surrounding context (up to 100 chars each side)
@@ -45,15 +51,22 @@ export function analyzeContent(content, source = '') {
       if (start > 0) context = '...' + context;
       if (end < content.length) context = context + '...';
 
-      findings.push({
-        type: name,
-        value: value.slice(0, 200), // truncate very long matches
+      findings.push(normalizeFinding({
+        type: entry.finding_type || name,
+        raw_value: value.slice(0, 1000),
         severity: entry.severity,
+        detector_id: entry.detector_id || name,
+        category: entry.category || entry.pack || 'leak',
         description: entry.description,
+        risk_reason: entry.description,
+        remediation: entry.remediation,
+        references: entry.references || [],
+        validation_status: entry.validation_status || 'lead',
         source,
-        context,
+        context: redactSnippet(context, value),
         timestamp: Date.now(),
-      });
+        ...meta,
+      }));
 
       // Cap at 50 findings per content block to prevent flooding
       if (findings.length >= 50) return findings;
@@ -69,13 +82,13 @@ export function analyzeContent(content, source = '') {
  * @param {string} source
  * @returns {Array<Object>}
  */
-export function analyzeHeaders(headers, source = 'Headers') {
+export function analyzeHeaders(headers, source = 'Headers', meta = {}) {
   const findings = [];
   if (!headers) return findings;
 
   for (const header of headers) {
     const headerStr = `${header.name}: ${header.value}`;
-    findings.push(...analyzeContent(headerStr, `${source} (${header.name})`));
+    findings.push(...analyzeContent(headerStr, `${source} (${header.name})`, meta));
   }
 
   return findings;
@@ -86,7 +99,7 @@ export function analyzeHeaders(headers, source = 'Headers') {
  * @param {string} url
  * @returns {Array<Object>}
  */
-export function analyzeUrl(url) {
+export function analyzeUrl(url, meta = {}) {
   if (!url) return [];
-  return analyzeContent(url, 'URL');
+  return analyzeContent(url, 'URL', { ...meta, url });
 }

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader, isBrowserServiceToken } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader, isBrowserServiceToken, isGoogleOwnedPage } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -83,8 +83,9 @@ export function analyzeContent(content, source = '', meta = {}) {
         ...meta,
       });
 
-      // AIza key classification: Maps/Firebase client key vs Gemini API key
+      // AIza key classification: skip on Google domains, downgrade for Maps/Firebase
       if ((name === 'gemini_api_key' || entry.finding_type === 'gemini_api_key') && value.startsWith('AIza')) {
+        if (isGoogleOwnedPage(meta.url || '') || isGoogleOwnedPage(source)) continue;
         const contentLower = content.toLowerCase();
         const sourceLower = source.toLowerCase();
         const MAPS_MARKERS = [

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isPresignedUrlCredential } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -43,6 +43,7 @@ export function analyzeContent(content, source = '', meta = {}) {
       // Skip false positives
       if (entry.min_match_length && value.length < entry.min_match_length) continue;
       if (isFalsePositive(value)) continue;
+      if (isPresignedUrlCredential(value, source)) continue;
 
       // Get a snippet of surrounding context (up to 100 chars each side)
       const start = Math.max(0, match.index - 60);

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader, isBrowserServiceToken, isGoogleOwnedPage } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader, isBrowserServiceToken, isFirstPartyDomain } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -19,6 +19,9 @@ export function analyzeContent(content, source = '', meta = {}) {
 
   // Skip obviously non-secret content types
   if (content.length > 5 * 1024 * 1024) return findings; // >5MB, skip
+
+  // Skip first-party domains (Google on google.com, AWS on aws.amazon.com, etc.)
+  if (isFirstPartyDomain(meta.url || '')) return findings;
 
   // Skip browser-internal URLs (chrome-extension://, devtools://, etc.)
   if (isBrowserInternal(source) || isBrowserInternal(meta.url || '')) return findings;
@@ -83,9 +86,8 @@ export function analyzeContent(content, source = '', meta = {}) {
         ...meta,
       });
 
-      // AIza key classification: skip on Google domains, downgrade for Maps/Firebase
+      // AIza key classification: downgrade for Maps/Firebase context
       if ((name === 'gemini_api_key' || entry.finding_type === 'gemini_api_key') && value.startsWith('AIza')) {
-        if (isGoogleOwnedPage(meta.url || '') || isGoogleOwnedPage(source)) continue;
         const contentLower = content.toLowerCase();
         const sourceLower = source.toLowerCase();
         const MAPS_MARKERS = [

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -22,6 +22,9 @@ export function analyzeContent(content, source = '', meta = {}) {
 
   // Skip browser-internal URLs (chrome-extension://, devtools://, etc.)
   if (isBrowserInternal(source) || isBrowserInternal(meta.url || '')) return findings;
+
+  // Skip infrastructure response headers (x-amz-cf-id, cf-ray, x-request-id, etc.)
+  if (isInfraHeader(source)) return findings;
 
   // Skip known third-party vendor scripts (Google Analytics, PostHog, etc.)
   if (isVendorScript(source) || isVendorScript(meta.url || '')) return findings;

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -60,7 +60,7 @@ export function analyzeContent(content, source = '', meta = {}) {
       if (start > 0) context = '...' + context;
       if (end < content.length) context = context + '...';
 
-      findings.push(normalizeFinding({
+      const finding = normalizeFinding({
         type: entry.finding_type || name,
         raw_value: value.slice(0, 1000),
         severity: entry.severity,
@@ -75,7 +75,28 @@ export function analyzeContent(content, source = '', meta = {}) {
         context: redactSnippet(context, value),
         timestamp: Date.now(),
         ...meta,
-      }));
+      });
+
+      // AIza key classification: Maps/Firebase client key vs Gemini API key
+      if ((name === 'gemini_api_key' || entry.finding_type === 'gemini_api_key') && value.startsWith('AIza')) {
+        const contentLower = content.toLowerCase();
+        const MAPS_MARKERS = [
+          'maps.googleapis.com', 'googleapis.com/maps', 'google.maps',
+          'firebaseconfig', 'firebaseapp', 'firebase.google.com',
+          'google-analytics.com', 'googletagmanager.com',
+          'gapi.client', 'accounts.google.com',
+          'gtag(', 'ga(', 'googleanalyticsobject',
+          'youtube.googleapis.com', 'maps.google.com',
+        ];
+        if (MAPS_MARKERS.some(m => contentLower.includes(m))) {
+          finding.type = 'google_client_api_key';
+          finding.severity = 'medium';
+          finding.risk_reason = 'Google Maps/Firebase client API key (referrer-restricted, expected in browser bundles).';
+          finding.remediation = 'Verify the key has referrer restrictions set in Google Cloud Console. Client-side Google API keys are expected but should be locked to your domain.';
+        }
+      }
+
+      findings.push(finding);
 
       // Cap at 50 findings per content block to prevent flooding
       if (findings.length >= 50) return findings;

--- a/extension/lib/analyzer.js
+++ b/extension/lib/analyzer.js
@@ -4,7 +4,7 @@
  */
 
 import { COMPILED_PATTERNS } from './patterns.js';
-import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader } from './false-positives.js';
+import { isFalsePositive, isVendorScript, isCloudStorageSignedUrl, isAzureSasToken, isBrowserInternal, isInfraHeader, isOwnAuthHeader } from './false-positives.js';
 import { normalizeFinding, redactSnippet } from './reporting.js';
 
 /**
@@ -22,6 +22,9 @@ export function analyzeContent(content, source = '', meta = {}) {
 
   // Skip browser-internal URLs (chrome-extension://, devtools://, etc.)
   if (isBrowserInternal(source) || isBrowserInternal(meta.url || '')) return findings;
+
+  // Skip user's own auth headers (Authorization: Bearer, Cookie)
+  if (isOwnAuthHeader(source)) return findings;
 
   // Skip infrastructure response headers (x-amz-cf-id, cf-ray, x-request-id, etc.)
   if (isInfraHeader(source)) return findings;

--- a/extension/lib/baas-detector.js
+++ b/extension/lib/baas-detector.js
@@ -1,0 +1,316 @@
+/**
+ * Real-time BaaS vulnerability detection for Chrome extension.
+ *
+ * Detects Supabase, Firebase, Appwrite, and PocketBase API requests from
+ * intercepted traffic, then probes endpoints with only the anon key
+ * (no user JWT) to test for missing Row-Level Security.
+ *
+ * All probes are read-only GET requests. Never writes, updates, or deletes.
+ */
+
+const SUPABASE_TABLE_RE = /^(https:\/\/[a-z0-9]+\.supabase\.co)\/rest\/v1\/([a-z_][a-z0-9_]*)(?:\?|$)/;
+const SUPABASE_RPC_RE = /^(https:\/\/[a-z0-9]+\.supabase\.co)\/rest\/v1\/rpc\/([a-z_][a-z0-9_]*)(?:\?|$)/;
+const SUPABASE_STORAGE_RE = /^(https:\/\/[a-z0-9]+\.supabase\.co)\/storage\/v1/;
+const FIREBASE_DB_RE = /^(https:\/\/[a-z0-9-]+\.firebaseio\.com)(\/|$)/;
+const FIREBASE_STORAGE_RE = /firebasestorage\.googleapis\.com\/v0\/b\/([^/]+)/;
+
+const SENSITIVE_PREFIXES = [
+  'payout', 'payment', 'billing', 'invoice', 'subscription',
+  'admin', 'auth', 'credential', 'secret', 'token',
+  'user_block', 'report', 'dmca', 'support_ticket',
+  'private', 'internal',
+];
+
+const MAX_PROBES_PER_TAB = 30;
+const PROBE_DELAY_MS = 1000;
+
+export function classifyTable(name) {
+  const lower = (name || '').toLowerCase();
+  for (const prefix of SENSITIVE_PREFIXES) {
+    if (lower.includes(prefix)) return 'critical';
+  }
+  return 'high';
+}
+
+export function detectBaaSRequest(url, headers) {
+  if (!url) return null;
+
+  let m = SUPABASE_TABLE_RE.exec(url);
+  if (m) {
+    const apiKey = extractHeader(headers, 'apikey');
+    return {
+      provider: 'supabase',
+      type: 'table',
+      baseUrl: m[1],
+      endpoint: m[2],
+      apiKey: apiKey || '',
+    };
+  }
+
+  m = SUPABASE_RPC_RE.exec(url);
+  if (m) {
+    const apiKey = extractHeader(headers, 'apikey');
+    return {
+      provider: 'supabase',
+      type: 'rpc',
+      baseUrl: m[1],
+      endpoint: m[2],
+      apiKey: apiKey || '',
+    };
+  }
+
+  m = SUPABASE_STORAGE_RE.exec(url);
+  if (m) {
+    const apiKey = extractHeader(headers, 'apikey');
+    return {
+      provider: 'supabase',
+      type: 'storage',
+      baseUrl: m[1],
+      endpoint: 'storage',
+      apiKey: apiKey || '',
+    };
+  }
+
+  m = FIREBASE_DB_RE.exec(url);
+  if (m) {
+    return {
+      provider: 'firebase',
+      type: 'database',
+      baseUrl: m[1],
+      endpoint: '/',
+      apiKey: '',
+    };
+  }
+
+  m = FIREBASE_STORAGE_RE.exec(url);
+  if (m) {
+    return {
+      provider: 'firebase',
+      type: 'storage',
+      baseUrl: 'https://firebasestorage.googleapis.com',
+      endpoint: m[1],
+      apiKey: '',
+    };
+  }
+
+  return null;
+}
+
+export async function testRLS(baasInfo) {
+  const { provider, type, baseUrl, endpoint, apiKey } = baasInfo;
+
+  if (provider === 'supabase' && type === 'table') {
+    return testSupabaseTable(baseUrl, endpoint, apiKey);
+  }
+  if (provider === 'supabase' && type === 'rpc') {
+    return testSupabaseRPC(baseUrl, endpoint, apiKey);
+  }
+  if (provider === 'supabase' && type === 'storage') {
+    return testSupabaseStorage(baseUrl, apiKey);
+  }
+  if (provider === 'firebase' && type === 'database') {
+    return testFirebaseDB(baseUrl);
+  }
+
+  return { open: false, status: 0, detail: 'unsupported probe type' };
+}
+
+async function testSupabaseTable(baseUrl, table, apiKey) {
+  try {
+    const headers = {};
+    if (apiKey) headers['apikey'] = apiKey;
+    const resp = await fetch(
+      `${baseUrl}/rest/v1/${table}?select=*&limit=1`,
+      { headers, credentials: 'omit' }
+    );
+    if (resp.status === 200) {
+      const body = await resp.json();
+      if (Array.isArray(body)) {
+        const columns = body.length > 0 && typeof body[0] === 'object'
+          ? Object.keys(body[0])
+          : [];
+        return { open: true, status: 200, columns, rowCount: body.length };
+      }
+    }
+    return { open: false, status: resp.status };
+  } catch (err) {
+    return { open: false, status: 0, detail: err.message };
+  }
+}
+
+async function testSupabaseRPC(baseUrl, fn, apiKey) {
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['apikey'] = apiKey;
+    const resp = await fetch(
+      `${baseUrl}/rest/v1/rpc/${fn}`,
+      { method: 'POST', headers, body: '{}', credentials: 'omit' }
+    );
+    return {
+      open: resp.status >= 200 && resp.status < 300,
+      status: resp.status,
+    };
+  } catch (err) {
+    return { open: false, status: 0, detail: err.message };
+  }
+}
+
+async function testSupabaseStorage(baseUrl, apiKey) {
+  try {
+    const headers = {};
+    if (apiKey) {
+      headers['apikey'] = apiKey;
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+    const resp = await fetch(`${baseUrl}/storage/v1/bucket`, { headers, credentials: 'omit' });
+    if (resp.status === 200) {
+      const body = await resp.json();
+      if (Array.isArray(body)) {
+        const publicBuckets = body.filter(b => b.public);
+        return {
+          open: publicBuckets.length > 0,
+          status: 200,
+          buckets: body.map(b => ({ name: b.name || b.id, public: !!b.public })),
+        };
+      }
+    }
+    return { open: false, status: resp.status };
+  } catch (err) {
+    return { open: false, status: 0, detail: err.message };
+  }
+}
+
+async function testFirebaseDB(baseUrl) {
+  try {
+    const resp = await fetch(`${baseUrl}/.json?shallow=true`, { credentials: 'omit' });
+    if (resp.status === 200) {
+      const body = await resp.json();
+      if (body !== null && typeof body === 'object') {
+        return { open: true, status: 200, keys: Object.keys(body).slice(0, 20) };
+      }
+    }
+    return { open: false, status: resp.status };
+  } catch (err) {
+    return { open: false, status: 0, detail: err.message };
+  }
+}
+
+export function buildBaaSFinding(baasInfo, probeResult) {
+  const { provider, type, endpoint } = baasInfo;
+  const severity = type === 'database' ? 'critical'
+    : type === 'table' ? classifyTable(endpoint)
+    : type === 'storage' ? 'high'
+    : 'medium';
+
+  const typeLabels = {
+    table: 'baas_open_table',
+    rpc: 'baas_open_rpc',
+    storage: 'baas_open_storage',
+    database: 'baas_open_table',
+  };
+
+  const snippets = {
+    table: `Table '${endpoint}' readable without user auth (HTTP ${probeResult.status}).${probeResult.columns?.length ? ' Columns: ' + probeResult.columns.slice(0, 8).join(', ') : ''}`,
+    rpc: `RPC function '${endpoint}' callable without user auth (HTTP ${probeResult.status}).`,
+    storage: `Storage bucket${probeResult.buckets ? 's: ' + probeResult.buckets.filter(b => b.public).map(b => b.name).join(', ') : ' accessible'} (HTTP ${probeResult.status}).`,
+    database: `Firebase Realtime Database is publicly readable.${probeResult.keys?.length ? ' Top-level keys: ' + probeResult.keys.join(', ') : ''}`,
+  };
+
+  const remediations = {
+    table: `Enable RLS: ALTER TABLE ${endpoint} ENABLE ROW LEVEL SECURITY; then create appropriate policies.`,
+    rpc: `Add auth.uid() check inside '${endpoint}' or revoke EXECUTE from the anon role.`,
+    storage: `Set public buckets to private in the ${provider} dashboard and configure storage policies.`,
+    database: 'Set Firebase Security Rules to deny public access: {"rules": {".read": "auth != null"}}.',
+  };
+
+  return {
+    type: typeLabels[type] || 'baas_open_table',
+    severity,
+    confidence: 0.95,
+    detector_id: `baas.${typeLabels[type] || 'open_table'}`,
+    source: baasInfo.baseUrl,
+    category: 'baas',
+    validation_status: 'confirmed',
+    evidence: {
+      source: baasInfo.baseUrl,
+      snippet: snippets[type] || `${provider} ${type} '${endpoint}' is open.`,
+      redacted_value: `${type}:${endpoint}`,
+      response_status: probeResult.status,
+    },
+    risk_reason: snippets[type],
+    remediation: remediations[type] || 'Review access policies for this resource.',
+  };
+}
+
+function extractHeader(headers, name) {
+  if (!headers) return '';
+  if (Array.isArray(headers)) {
+    const h = headers.find(h => h.name?.toLowerCase() === name.toLowerCase());
+    return h?.value || '';
+  }
+  if (typeof headers === 'object') {
+    for (const [k, v] of Object.entries(headers)) {
+      if (k.toLowerCase() === name.toLowerCase()) return v;
+    }
+  }
+  return '';
+}
+
+export class BaaSTabState {
+  constructor() {
+    this.provider = null;
+    this.baseUrl = null;
+    this.apiKey = null;
+    this.tested = new Set();
+    this.probeCount = 0;
+    this.probeQueue = [];
+    this.processing = false;
+  }
+
+  shouldProbe(endpoint) {
+    if (this.probeCount >= MAX_PROBES_PER_TAB) return false;
+    if (this.tested.has(endpoint)) return false;
+    return true;
+  }
+
+  markTested(endpoint) {
+    this.tested.add(endpoint);
+    this.probeCount++;
+  }
+
+  async enqueueProbe(baasInfo, addFindingsFn) {
+    if (!this.shouldProbe(baasInfo.endpoint)) return;
+
+    if (!this.provider) {
+      this.provider = baasInfo.provider;
+      this.baseUrl = baasInfo.baseUrl;
+      this.apiKey = baasInfo.apiKey;
+    }
+
+    this.markTested(baasInfo.endpoint);
+
+    this.probeQueue.push({ baasInfo, addFindingsFn });
+    if (!this.processing) {
+      this.processing = true;
+      this._processQueue();
+    }
+  }
+
+  async _processQueue() {
+    while (this.probeQueue.length > 0) {
+      const { baasInfo, addFindingsFn } = this.probeQueue.shift();
+      try {
+        const result = await testRLS(baasInfo);
+        if (result.open) {
+          const finding = buildBaaSFinding(baasInfo, result);
+          addFindingsFn([finding]);
+        }
+      } catch (_err) { /* swallow probe errors */ }
+
+      if (this.probeQueue.length > 0) {
+        await new Promise(resolve => setTimeout(resolve, PROBE_DELAY_MS));
+      }
+    }
+    this.processing = false;
+  }
+}

--- a/extension/lib/baas-detector.js
+++ b/extension/lib/baas-detector.js
@@ -21,7 +21,7 @@ const SENSITIVE_PREFIXES = [
   'private', 'internal',
 ];
 
-const MAX_PROBES_PER_TAB = 30;
+export const MAX_PROBES_PER_TAB = 30;
 const PROBE_DELAY_MS = 1000;
 
 export function classifyTable(name) {
@@ -103,13 +103,16 @@ export async function testRLS(baasInfo) {
     return testSupabaseTable(baseUrl, endpoint, apiKey);
   }
   if (provider === 'supabase' && type === 'rpc') {
-    return testSupabaseRPC(baseUrl, endpoint, apiKey);
+    return testSupabaseRPCReadOnly(baseUrl, endpoint, apiKey);
   }
   if (provider === 'supabase' && type === 'storage') {
     return testSupabaseStorage(baseUrl, apiKey);
   }
   if (provider === 'firebase' && type === 'database') {
     return testFirebaseDB(baseUrl);
+  }
+  if (provider === 'firebase' && type === 'storage') {
+    return testFirebaseStorage(endpoint);
   }
 
   return { open: false, status: 0, detail: 'unsupported probe type' };
@@ -138,18 +141,38 @@ async function testSupabaseTable(baseUrl, table, apiKey) {
   }
 }
 
-async function testSupabaseRPC(baseUrl, fn, apiKey) {
+async function testSupabaseRPCReadOnly(baseUrl, fn, apiKey) {
   try {
-    const headers = { 'Content-Type': 'application/json' };
+    const headers = {};
     if (apiKey) headers['apikey'] = apiKey;
     const resp = await fetch(
       `${baseUrl}/rest/v1/rpc/${fn}`,
-      { method: 'POST', headers, body: '{}', credentials: 'omit' }
+      { method: 'OPTIONS', headers, credentials: 'omit' }
     );
+    // OPTIONS 200 with CORS allow POST means the RPC endpoint exists and is reachable.
+    // A 404 means the function doesn't exist for the anon role.
+    const allow = resp.headers.get('allow') || resp.headers.get('access-control-allow-methods') || '';
     return {
-      open: resp.status >= 200 && resp.status < 300,
+      open: resp.status === 200 && allow.toUpperCase().includes('POST'),
       status: resp.status,
     };
+  } catch (err) {
+    return { open: false, status: 0, detail: err.message };
+  }
+}
+
+async function testFirebaseStorage(bucket) {
+  try {
+    const resp = await fetch(
+      `https://firebasestorage.googleapis.com/v0/b/${bucket}/o?maxResults=1`,
+      { credentials: 'omit' }
+    );
+    if (resp.status === 200) {
+      const body = await resp.json();
+      const items = (body && body.items) || [];
+      return { open: items.length > 0, status: 200, buckets: [{ name: bucket, public: true }] };
+    }
+    return { open: false, status: resp.status };
   } catch (err) {
     return { open: false, status: 0, detail: err.message };
   }
@@ -267,19 +290,23 @@ export class BaaSTabState {
     this.processing = false;
   }
 
-  shouldProbe(endpoint) {
+  _dedupeKey(baasInfo) {
+    return `${baasInfo.provider}|${baasInfo.type || 'unknown'}|${baasInfo.endpoint}`;
+  }
+
+  shouldProbe(baasInfo) {
     if (this.probeCount >= MAX_PROBES_PER_TAB) return false;
-    if (this.tested.has(endpoint)) return false;
+    if (this.tested.has(this._dedupeKey(baasInfo))) return false;
     return true;
   }
 
-  markTested(endpoint) {
-    this.tested.add(endpoint);
+  markTested(baasInfo) {
+    this.tested.add(this._dedupeKey(baasInfo));
     this.probeCount++;
   }
 
   async enqueueProbe(baasInfo, addFindingsFn) {
-    if (!this.shouldProbe(baasInfo.endpoint)) return;
+    if (!this.shouldProbe(baasInfo)) return;
 
     if (!this.provider) {
       this.provider = baasInfo.provider;
@@ -287,7 +314,7 @@ export class BaaSTabState {
       this.apiKey = baasInfo.apiKey;
     }
 
-    this.markTested(baasInfo.endpoint);
+    this.markTested(baasInfo);
 
     this.probeQueue.push({ baasInfo, addFindingsFn });
     if (!this.processing) {

--- a/extension/lib/baas-detector.js
+++ b/extension/lib/baas-detector.js
@@ -142,23 +142,12 @@ async function testSupabaseTable(baseUrl, table, apiKey) {
 }
 
 async function testSupabaseRPCReadOnly(baseUrl, fn, apiKey) {
-  try {
-    const headers = {};
-    if (apiKey) headers['apikey'] = apiKey;
-    const resp = await fetch(
-      `${baseUrl}/rest/v1/rpc/${fn}`,
-      { method: 'OPTIONS', headers, credentials: 'omit' }
-    );
-    // OPTIONS 200 with CORS allow POST means the RPC endpoint exists and is reachable.
-    // A 404 means the function doesn't exist for the anon role.
-    const allow = resp.headers.get('allow') || resp.headers.get('access-control-allow-methods') || '';
-    return {
-      open: resp.status === 200 && allow.toUpperCase().includes('POST'),
-      status: resp.status,
-    };
-  } catch (err) {
-    return { open: false, status: 0, detail: err.message };
-  }
+  // OPTIONS doesn't validate EXECUTE permission on PostgREST — it returns
+  // Allow headers based on function volatility, not per-role grants.
+  // A real POST would mutate state, so we can't safely probe RPCs from the
+  // extension.  Instead, return a "lead" (not confirmed) so it surfaces
+  // in the UI for manual review without making a mutating request.
+  return { open: false, status: 0, detail: 'RPC probing skipped in extension (requires POST)' };
 }
 
 async function testFirebaseStorage(bucket) {

--- a/extension/lib/detector-info.js
+++ b/extension/lib/detector-info.js
@@ -1093,25 +1093,6 @@ export const DETECTOR_INFO = {
     "severity": "critical",
     "validation_status": "validated"
   },
-  "supabase_anon_key": {
-    "attack_scenario": "The anon key grants PostgREST API access with the anon role. Without RLS, any table is fully readable and writable.",
-    "categories": [
-      "sourcemaps",
-      "code",
-      "env"
-    ],
-    "description": "Supabase anon/publishable key (JWT format) exposed in client bundle.",
-    "detector_id": "baas.supabase_anon_key",
-    "finding_type": "supabase_anon_key",
-    "id": "supabase_anon_key",
-    "pack": "baas",
-    "references": [
-      "https://supabase.com/docs/guides/api#api-keys"
-    ],
-    "remediation": "Anon keys are designed for client use, but confirm RLS policies protect every table.",
-    "severity": "medium",
-    "validation_status": "lead"
-  },
   "supabase_publishable_key": {
     "attack_scenario": null,
     "categories": [

--- a/extension/lib/detector-info.js
+++ b/extension/lib/detector-info.js
@@ -1,0 +1,1199 @@
+/**
+ * Generated detector knowledge base for KeyLeak Detector UI.
+ * Source of truth: keyleak.detectors.DETECTORS.
+ * Regenerate with: python3 scripts/generate_extension_patterns.py
+ */
+
+export const DETECTOR_INFO = {
+  "anthropic_api_key": {
+    "attack_scenario": "A leaked Anthropic key lets attackers spin up large Claude jobs on your bill, harvest any prompts or context they replay through it, and probe whatever tools your agent has bound to the same key.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Anthropic API key exposed.",
+    "detector_id": "leak.anthropic_api_key",
+    "finding_type": "anthropic_api_key",
+    "id": "anthropic_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Anthropic key and move model calls behind a trusted server boundary.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "anyscale_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Anyscale API key exposed.",
+    "detector_id": "leak.anyscale_api_key",
+    "finding_type": "anyscale_api_key",
+    "id": "anyscale_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Anyscale key and audit inference endpoint usage.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "appwrite_endpoint": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "Appwrite API endpoint exposed in client bundle.",
+    "detector_id": "baas.appwrite_endpoint",
+    "finding_type": "appwrite_endpoint",
+    "id": "appwrite_endpoint",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify Appwrite collection permissions deny unauthorized access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "auth_bypass_lead": {
+    "attack_scenario": null,
+    "categories": [
+      "code",
+      "env",
+      "ci",
+      "docker",
+      "sourcemaps",
+      "logs",
+      "config"
+    ],
+    "description": "Auth-bypass lead found in shipped code or config.",
+    "detector_id": "appsec.auth_bypass_lead",
+    "finding_type": "auth_bypass",
+    "id": "auth_bypass_lead",
+    "pack": "appsec",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Remove bypass flags from production paths, enforce server-side authorization, and add an auth regression test.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "aws_access_key": {
+    "attack_scenario": "With even a guessable secret nearby, attackers enumerate S3 buckets, mint short-lived credentials via `sts:GetSessionToken`, and pivot into anything the IAM principal can reach. AKIA prefixes appear in honeypots within minutes of being public.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "AWS access key ID exposed.",
+    "detector_id": "leak.aws_access_key",
+    "finding_type": "aws_access_key",
+    "id": "aws_access_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the access key and prefer IAM roles or workload identity over static credentials.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "aws_secret_key": {
+    "attack_scenario": "Paired with the access key ID this is full AWS API access in the principal's scope: dump RDS snapshots, spin up crypto miners on every region's compute quota, or wipe everything and demand ransom for restore.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "AWS secret access key-like value exposed.",
+    "detector_id": "leak.aws_secret_key",
+    "finding_type": "aws_secret_key",
+    "id": "aws_secret_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the AWS secret, review CloudTrail activity, and use IAM roles or a secret manager instead.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "baas_delete_call": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "BaaS delete mutation found in client code.",
+    "detector_id": "baas.baas_delete_call",
+    "finding_type": "baas_delete_call",
+    "id": "baas_delete_call",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify RLS policies restrict who can delete from this table.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "baas_insert_call": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "BaaS insert/upsert mutation found in client code.",
+    "detector_id": "baas.baas_insert_call",
+    "finding_type": "baas_insert_call",
+    "id": "baas_insert_call",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify RLS policies restrict who can write to this table.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "baas_password_auth": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "Password-based authentication flow detected in client code.",
+    "detector_id": "baas.baas_password_auth",
+    "finding_type": "baas_password_auth",
+    "id": "baas_password_auth",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Ensure password policies, rate limiting, and email confirmation are configured.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "baas_realtime_channel": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "Supabase Realtime channel subscription in client code.",
+    "detector_id": "baas.baas_realtime_channel",
+    "finding_type": "baas_realtime_channel",
+    "id": "baas_realtime_channel",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify channel policies restrict who can subscribe.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "baas_realtime_subscribe": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "Supabase Realtime postgres_changes subscription in client code.",
+    "detector_id": "baas.baas_realtime_subscribe",
+    "finding_type": "baas_realtime_subscribe",
+    "id": "baas_realtime_subscribe",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify RLS policies apply to realtime subscriptions.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "baas_rpc_call": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "BaaS RPC function called from client bundle.",
+    "detector_id": "baas.baas_rpc_call",
+    "finding_type": "baas_rpc_call",
+    "id": "baas_rpc_call",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify this RPC function validates caller identity and rate-limits requests.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "baas_select_star": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "BaaS table query uses select('*'), fetching all columns including potentially sensitive ones.",
+    "detector_id": "baas.baas_select_star",
+    "finding_type": "baas_select_star",
+    "id": "baas_select_star",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Specify only the columns you need in select(). This reduces data exposure and improves performance.",
+    "severity": "low",
+    "validation_status": "lead"
+  },
+  "baas_storage_bucket": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "BaaS storage bucket referenced in client bundle.",
+    "detector_id": "baas.baas_storage_bucket",
+    "finding_type": "baas_storage_bucket",
+    "id": "baas_storage_bucket",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify storage bucket policies restrict who can upload, download, and list objects.",
+    "severity": "low",
+    "validation_status": "lead"
+  },
+  "baas_table_reference": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "BaaS table name referenced in client bundle.",
+    "detector_id": "baas.baas_table_reference",
+    "finding_type": "baas_table_reference",
+    "id": "baas_table_reference",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Review whether this table's RLS policies are correctly configured.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "bearer_token": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Bearer token found in browser-visible content.",
+    "detector_id": "leak.bearer_token",
+    "finding_type": "bearer_token",
+    "id": "bearer_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Move bearer tokens out of static content and use short-lived session-bound tokens.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "client_side_admin_check": {
+    "attack_scenario": "An attacker sets is_admin=true in the browser console or modifies the JS bundle. Every admin-gated mutation (payouts, user management, moderation) becomes accessible.",
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "Client-side admin/role check found. Authorization decisions in browser JS are trivially bypassable.",
+    "detector_id": "baas.client_side_admin_check",
+    "finding_type": "client_side_admin_check",
+    "id": "client_side_admin_check",
+    "pack": "baas",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Move all authorization checks to the server. Use Supabase RLS policies or Firebase Security Rules to enforce admin-only access.",
+    "severity": "high",
+    "validation_status": "lead"
+  },
+  "database_url": {
+    "attack_scenario": "The embedded credentials grant whatever role the DB user has \u2014 typically full read of every row. Attackers pull customer PII, payment records, and password hashes for credential stuffing elsewhere; if the DB is internet-reachable it's game over.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Database connection string with credentials exposed.",
+    "detector_id": "leak.database_url",
+    "finding_type": "database_url",
+    "id": "database_url",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate database credentials, restrict network access, and move connection strings to server-only configuration.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "firebase_client_config": {
+    "attack_scenario": "Firebase config grants access to Firestore, Realtime Database, and Storage. Without security rules, an attacker can read all documents, write arbitrary data, and access every file in Cloud Storage.",
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "description": "Firebase client configuration with API key exposed in client bundle.",
+    "detector_id": "baas.firebase_client_config",
+    "finding_type": "firebase_client_config",
+    "id": "firebase_client_config",
+    "pack": "baas",
+    "references": [
+      "https://firebase.google.com/docs/rules"
+    ],
+    "remediation": "Firebase client config is designed for client use, but verify Firestore Security Rules and Storage Rules deny unauthorized access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "firebase_db_url": {
+    "attack_scenario": "The Realtime Database URL allows direct REST API access. Without security rules, all data is readable and writable by anyone.",
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "description": "Firebase Realtime Database URL exposed in client bundle.",
+    "detector_id": "baas.firebase_db_url",
+    "finding_type": "firebase_db_url",
+    "id": "firebase_db_url",
+    "pack": "baas",
+    "references": [
+      "https://firebase.google.com/docs/database/security"
+    ],
+    "remediation": "Verify Firebase Security Rules deny unauthorized read/write access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "firebase_server_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Firebase/FCM server key exposed.",
+    "detector_id": "leak.firebase_server_key",
+    "finding_type": "firebase_server_key",
+    "id": "firebase_server_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Firebase key and confirm Firebase security rules prevent unauthorized access.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "firebase_storage_bucket": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "description": "Firebase/GCP storage bucket referenced in client bundle.",
+    "detector_id": "baas.firebase_storage_bucket",
+    "finding_type": "firebase_storage_bucket",
+    "id": "firebase_storage_bucket",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify Cloud Storage security rules restrict access.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "gemini_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Google Gemini/API key exposed.",
+    "detector_id": "leak.gemini_api_key",
+    "finding_type": "gemini_api_key",
+    "id": "gemini_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate or restrict the Google API key, audit API usage, and keep model/provider credentials server-side.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "gh_actions_pull_request_target": {
+    "attack_scenario": "`pull_request_target` alone is informational \u2014 the worm hit @tanstack via the combination of this trigger AND a checkout of `head.ref` in the same job. Workflows that only read PR metadata (assign reviewers, label PRs, validate CLA) are safe.",
+    "categories": [
+      "ci"
+    ],
+    "description": "GitHub Actions workflow uses pull_request_target. Informational only \u2014 the leak shape is `pull_request_target` + checkout of `head.ref`. See `gh_actions_pwn_request_head_ref`.",
+    "detector_id": "leak.gh_actions_pull_request_target",
+    "finding_type": "gh_actions_pull_request_target",
+    "id": "gh_actions_pull_request_target",
+    "pack": "leak",
+    "references": [
+      "https://securitylab.github.com/research/github-actions-preventing-pwn-requests/"
+    ],
+    "remediation": "If this workflow runs untrusted PR code: switch to `pull_request`. If it only reads PR metadata (labeler, CLA bot), this trigger is fine and you can suppress this notice.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  "gh_actions_pwn_request_head_ref": {
+    "attack_scenario": "A `pull_request_target` workflow that also checks out the head branch runs attacker-controlled code with the base repo's secrets. Mini Shai-Hulud rode this exact combo into TanStack \u2014 a forked PR added a malicious script, the workflow checked it out, and the OIDC + npm tokens left.",
+    "categories": [
+      "ci"
+    ],
+    "description": "GitHub Actions workflow combines pull_request_target with checkout of head.ref/head.sha \u2014 this is the Pwn Request pattern that compromised TanStack/Mini-Shai-Hulud.",
+    "detector_id": "leak.gh_actions_pwn_request_head_ref",
+    "finding_type": "gh_actions_pwn_request_head_ref",
+    "id": "gh_actions_pwn_request_head_ref",
+    "pack": "leak",
+    "references": [
+      "https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"
+    ],
+    "remediation": "Move untrusted-code work into a separate `pull_request`-triggered workflow that has no secrets, and use `workflow_run` to pass artifacts only.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "gh_actions_secrets_tojson": {
+    "attack_scenario": "`toJSON(secrets)` dumps every CI secret the job has into a single blob \u2014 typically logged or passed to a tool. Any later step that writes that blob to disk, logs it, or sends it over the network exfiltrates the entire vault. It's a load-bearing IOC for the Mini Shai-Hulud worm.",
+    "categories": [
+      "ci"
+    ],
+    "description": "GitHub Actions workflow serializes all secrets via toJSON(secrets). Mini Shai-Hulud (2026) used this exact pattern to bulk-exfiltrate CI secrets.",
+    "detector_id": "leak.gh_actions_secrets_tojson",
+    "finding_type": "gh_actions_secrets_tojson",
+    "id": "gh_actions_secrets_tojson",
+    "pack": "leak",
+    "references": [
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"
+    ],
+    "remediation": "Reference only the specific secrets the job needs (`${{ secrets.NPM_TOKEN }}`). Never pass the entire `secrets` object as JSON to a step.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "github_pat": {
+    "attack_scenario": "Attackers clone every private repo the token can read, push malicious commits or workflow files, and harvest CI secrets from workflow logs. Tokens with `repo` scope often own enough of the supply chain to backdoor downstream consumers.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "GitHub token exposed.",
+    "detector_id": "leak.github_pat",
+    "finding_type": "github_pat",
+    "id": "github_pat",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke the token, review repository access, and regenerate with the smallest necessary scope.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "gitlab_token": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "GitLab token exposed.",
+    "detector_id": "leak.gitlab_token",
+    "finding_type": "gitlab_token",
+    "id": "gitlab_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke the GitLab token, review project/group access, and regenerate with the smallest scope possible.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "google_service_account": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Google service account key material exposed.",
+    "detector_id": "leak.google_service_account",
+    "finding_type": "google_service_account",
+    "id": "google_service_account",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke the service account key, audit IAM permissions, and move service credentials to secret storage.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "graphql_introspection_hint": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "GraphQL introspection or schema content exposed.",
+    "detector_id": "leak.graphql_introspection_hint",
+    "finding_type": "graphql_introspection_hint",
+    "id": "graphql_introspection_hint",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Confirm introspection is intentionally exposed and protected on production APIs.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  "groq_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Groq API key exposed.",
+    "detector_id": "leak.groq_api_key",
+    "finding_type": "groq_api_key",
+    "id": "groq_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Groq key and keep inference credentials out of browser and agent config files.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "hidden_prompt_injection": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Prompt-injection style instruction found in content.",
+    "detector_id": "leak.hidden_prompt_injection",
+    "finding_type": "hidden_prompt_injection",
+    "id": "hidden_prompt_injection",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Treat untrusted content as data, isolate agent tools, and avoid giving browsing agents access to secrets.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  "http_basic_auth": {
+    "attack_scenario": "Credentials in URLs land in browser history, web-server logs, HTTP `Referer` headers, and CI logs. Anyone with read access to those logs escalates straight to whatever the credential authenticates against.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "HTTP Basic Auth credentials embedded in a URL.",
+    "detector_id": "leak.http_basic_auth",
+    "finding_type": "http_basic_auth",
+    "id": "http_basic_auth",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the credentials and replace URL-embedded credentials with a safer authentication mechanism.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "huggingface_token": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Hugging Face token exposed.",
+    "detector_id": "leak.huggingface_token",
+    "finding_type": "huggingface_token",
+    "id": "huggingface_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the token, review model/dataset access, and avoid shipping provider tokens in browser bundles.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "idor_direct_object_lead": {
+    "attack_scenario": "If the server doesn't check ownership, swapping `/users/123` for `/users/124` returns another tenant's data. Attackers script through every ID to enumerate the full customer base. Validate with a two-user scan: `keyleak scan ... --bearer $A --bearer-b $B`.",
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Direct object reference lead found in a sensitive resource path or parameter.",
+    "detector_id": "access-control.idor_direct_object_lead",
+    "finding_type": "idor",
+    "id": "idor_direct_object_lead",
+    "pack": "access-control",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Verify object ownership on the server with tenant/user scoped queries and re-test with two throwaway users.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "jwt_token": {
+    "attack_scenario": "A leaked JWT impersonates its subject until expiry. Even without the signing key, the base64 payload usually reveals role, tenant, and internal IDs that accelerate attacks against the rest of the system.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "JWT found in browser-visible content.",
+    "detector_id": "leak.jwt_token",
+    "finding_type": "jwt_token",
+    "id": "jwt_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Confirm the token is short-lived, not logged or embedded, and does not expose sensitive claims.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  "mcp_config_secret": {
+    "attack_scenario": null,
+    "categories": [
+      "mcp",
+      "env",
+      "docker",
+      "logs"
+    ],
+    "description": "MCP or agent tool credential exposed.",
+    "detector_id": "leak.mcp_config_secret",
+    "finding_type": "mcp_config_secret",
+    "id": "mcp_config_secret",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Move agent/tool credentials to local secret storage and review connected tool permissions.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "missing_tenant_check_lead": {
+    "attack_scenario": null,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs",
+      "config"
+    ],
+    "description": "Missing tenant or ownership-check lead found.",
+    "detector_id": "access-control.missing_tenant_check_lead",
+    "finding_type": "missing_tenant_check",
+    "id": "missing_tenant_check_lead",
+    "pack": "access-control",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Make the tenant boundary mandatory in server-side queries and add a cross-tenant negative test.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "npm_optional_dep_git_ref": {
+    "attack_scenario": "An attacker that lands a PR adding `optionalDependencies: { '@x/setup': 'github:org/repo#<sha>' }` runs arbitrary code on every install via the orphan commit's `prepare` hook. This is exactly how Mini Shai-Hulud compromised 42 @tanstack/* packages on 2026-05-11 and stole AWS/GCP/Vault/GitHub/npm credentials from anyone who installed.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs",
+      "code",
+      "config"
+    ],
+    "description": "package.json optionalDependencies points to a git commit SHA. This is the Mini Shai-Hulud (TanStack 2026) attack vector.",
+    "detector_id": "leak.npm_optional_dep_git_ref",
+    "finding_type": "npm_optional_dep_git_ref",
+    "id": "npm_optional_dep_git_ref",
+    "pack": "leak",
+    "references": [
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem",
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"
+    ],
+    "remediation": "Remove the git-ref optionalDependency. Replace with a pinned semver from the registry or vendor the code in-tree.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "npm_prepare_bun_payload": {
+    "attack_scenario": "The TanStack worm executed its payload through `prepare: \"bun run tanstack_runner.js && exit 1\"` in the malicious tarball's package.json. Any install (developer machine or CI runner) immediately ran the harvester. `--ignore-scripts` blocks this vector entirely; pnpm v10 does it by default in CI.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "code",
+      "config"
+    ],
+    "description": "package.json prepare/preinstall/postinstall script runs Bun or a TanStack-style payload file. Mini Shai-Hulud (2026) executed `bun run tanstack_runner.js && exit 1`.",
+    "detector_id": "leak.npm_prepare_bun_payload",
+    "finding_type": "npm_prepare_bun_payload",
+    "id": "npm_prepare_bun_payload",
+    "pack": "leak",
+    "references": [
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem"
+    ],
+    "remediation": "Inspect the script and the referenced JS file. If the file is bundled, opaque, or not in version control, treat the package as compromised. Add `--ignore-scripts` to your install command and switch to pnpm v10+ for default-off lifecycle execution.",
+    "severity": "high",
+    "validation_status": "lead"
+  },
+  "npm_token": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "npm token exposed.",
+    "detector_id": "leak.npm_token",
+    "finding_type": "npm_token",
+    "id": "npm_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke the npm token and audit package publish activity.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "openai_api_key": {
+    "attack_scenario": "Anyone who scrapes the bundle, response, or repo runs inference on your bill. Costs can spike to thousands of dollars within hours, and the key fingerprints your account for follow-up abuse.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "OpenAI API key exposed.",
+    "detector_id": "leak.openai_api_key",
+    "finding_type": "openai_api_key",
+    "id": "openai_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the OpenAI key, remove it from client/config files, and load it server-side from a secret manager.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "openrouter_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "OpenRouter API key exposed.",
+    "detector_id": "leak.openrouter_api_key",
+    "finding_type": "openrouter_api_key",
+    "id": "openrouter_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the OpenRouter key and audit usage because this can proxy access to multiple model providers.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "perplexity_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Perplexity API key exposed.",
+    "detector_id": "leak.perplexity_api_key",
+    "finding_type": "perplexity_api_key",
+    "id": "perplexity_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Perplexity key and keep model-provider credentials out of client-side code.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "pocketbase_url": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "description": "PocketBase instance URL exposed in client bundle.",
+    "detector_id": "baas.pocketbase_url",
+    "finding_type": "pocketbase_url",
+    "id": "pocketbase_url",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Verify PocketBase collection API rules restrict access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "private_ip": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Private network address exposed.",
+    "detector_id": "leak.private_ip",
+    "finding_type": "private_ip",
+    "id": "private_ip",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Review whether internal topology details should be visible in client-side content.",
+    "severity": "low",
+    "validation_status": "validated"
+  },
+  "private_key": {
+    "attack_scenario": "Whoever holds the key can impersonate the server or user it was issued to: sign fake TLS certs, mint JWTs your services already trust, or SSH into every host that trusts this key. Rotation is mandatory; you cannot un-leak a private key.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "logs"
+    ],
+    "description": "Private key exposed.",
+    "detector_id": "leak.private_key",
+    "finding_type": "private_key",
+    "id": "private_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke and rotate the key immediately, then audit every system where it was trusted.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "pypi_upload_token": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "PyPI upload token exposed.",
+    "detector_id": "leak.pypi_upload_token",
+    "finding_type": "pypi_upload_token",
+    "id": "pypi_upload_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke the PyPI token and audit package release history.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "replicate_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Replicate API key exposed.",
+    "detector_id": "leak.replicate_api_key",
+    "finding_type": "replicate_api_key",
+    "id": "replicate_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Replicate key and move inference calls behind a trusted server boundary.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "secret_in_logs_lead": {
+    "attack_scenario": null,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Secret-in-logs lead found.",
+    "detector_id": "leak.secret_in_logs_lead",
+    "finding_type": "secret_in_logs",
+    "id": "secret_in_logs_lead",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Remove secrets from logs, redact sensitive fields at the logger boundary, and rotate any value that may already have been written.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "sendgrid_api_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "SendGrid API key exposed.",
+    "detector_id": "leak.sendgrid_api_key",
+    "finding_type": "sendgrid_api_key",
+    "id": "sendgrid_api_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the SendGrid key and audit mail-sending activity for abuse.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "shai_hulud_c2_domain": {
+    "attack_scenario": "The Mini Shai-Hulud worm sends stolen credentials to the Session/Oxen messenger network (`filev2.getsession.org`, `seed{1,2,3}.getsession.org`) and uses `api.masscan.cloud` and `git-tanstack.com` for C2. If your code, logs, or build artifacts mention any of these, an installed dependency is already exfiltrating data.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs",
+      "code"
+    ],
+    "description": "Mini Shai-Hulud command-and-control or exfiltration domain found.",
+    "detector_id": "leak.shai_hulud_c2_domain",
+    "finding_type": "shai_hulud_c2_domain",
+    "id": "shai_hulud_c2_domain",
+    "pack": "leak",
+    "references": [
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem"
+    ],
+    "remediation": "Treat the host as compromised. Rotate every credential reachable from the affected machine or CI runner: AWS, GCP, Kubernetes, Vault, GitHub, npm, SSH. Then audit egress logs to confirm what left.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "slack_token": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Slack token exposed.",
+    "detector_id": "leak.slack_token",
+    "finding_type": "slack_token",
+    "id": "slack_token",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Revoke the Slack token, review workspace app scopes, and regenerate with least privilege.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "slack_webhook": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Slack webhook URL exposed.",
+    "detector_id": "leak.slack_webhook",
+    "finding_type": "slack_webhook",
+    "id": "slack_webhook",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Regenerate the webhook and keep it out of browser bundles and public config.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  "source_map_reference": {
+    "attack_scenario": "Source maps reveal pre-minified code, in-line API URLs, internal field names, and sometimes secrets injected at build time. Attackers reverse-engineer your auth flow, business rules, and authorization edges much faster than they could from the minified bundle.",
+    "categories": [
+      "sourcemaps"
+    ],
+    "description": "Browser bundle references a source map.",
+    "detector_id": "leak.source_map_reference",
+    "finding_type": "source_map_reference",
+    "id": "source_map_reference",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Review generated source maps for embedded secrets and avoid publishing private source in production.",
+    "severity": "low",
+    "validation_status": "validated"
+  },
+  "sql_injection_lead": {
+    "attack_scenario": null,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "SQL injection lead found in query construction or database error output.",
+    "detector_id": "appsec.sql_injection_lead",
+    "finding_type": "sql_injection",
+    "id": "sql_injection_lead",
+    "pack": "appsec",
+    "references": [
+      "https://owasp.org/www-community/attacks/SQL_Injection"
+    ],
+    "remediation": "Parameterize the query, validate the input at the boundary, and re-test the endpoint with the launch gate after the fix.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "stripe_restricted_key": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Stripe restricted key exposed.",
+    "detector_id": "leak.stripe_restricted_key",
+    "finding_type": "stripe_restricted_key",
+    "id": "stripe_restricted_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Stripe restricted key and move payment operations to server-side endpoints.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "stripe_secret_key": {
+    "attack_scenario": "A `sk_live_` key is direct Stripe API access: attackers refund or void any charge, create payouts to attacker-controlled bank accounts, dump customer payment metadata, and rack up fraudulent transactions before anyone notices.",
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Stripe secret key exposed.",
+    "detector_id": "leak.stripe_secret_key",
+    "finding_type": "stripe_secret_key",
+    "id": "stripe_secret_key",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Rotate the Stripe key and move payment operations behind server-side endpoints.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  "supabase_anon_key": {
+    "attack_scenario": "The anon key grants PostgREST API access with the anon role. Without RLS, any table is fully readable and writable.",
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "description": "Supabase anon/publishable key (JWT format) exposed in client bundle.",
+    "detector_id": "baas.supabase_anon_key",
+    "finding_type": "supabase_anon_key",
+    "id": "supabase_anon_key",
+    "pack": "baas",
+    "references": [
+      "https://supabase.com/docs/guides/api#api-keys"
+    ],
+    "remediation": "Anon keys are designed for client use, but confirm RLS policies protect every table.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "supabase_publishable_key": {
+    "attack_scenario": null,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "description": "Supabase publishable key (non-standard format) exposed in client bundle.",
+    "detector_id": "baas.supabase_publishable_key",
+    "finding_type": "supabase_publishable_key",
+    "id": "supabase_publishable_key",
+    "pack": "baas",
+    "references": [],
+    "remediation": "Confirm RLS policies protect every table. Run BaaS validation to test.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "supabase_url": {
+    "attack_scenario": "Combined with the anon key, the project URL enables direct REST API queries against every table. Missing or misconfigured RLS makes all data readable by anyone.",
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "description": "Supabase project URL exposed in client bundle.",
+    "detector_id": "baas.supabase_url",
+    "finding_type": "supabase_url",
+    "id": "supabase_url",
+    "pack": "baas",
+    "references": [
+      "https://supabase.com/docs/guides/auth/row-level-security"
+    ],
+    "remediation": "Verify RLS policies are enforced on all tables. Run `keyleak browser-scan` with BaaS validation to confirm.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  "webhook_url": {
+    "attack_scenario": null,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "Webhook URL exposed.",
+    "detector_id": "leak.webhook_url",
+    "finding_type": "webhook_url",
+    "id": "webhook_url",
+    "pack": "leak",
+    "references": [],
+    "remediation": "Review whether the webhook is secret-bearing, rotate it if sensitive, and add authentication where possible.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  "xss_sink_lead": {
+    "attack_scenario": null,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "description": "XSS lead found where untrusted input can reach an HTML sink.",
+    "detector_id": "appsec.xss_sink_lead",
+    "finding_type": "xss",
+    "id": "xss_sink_lead",
+    "pack": "appsec",
+    "references": [
+      "https://owasp.org/www-community/attacks/xss/"
+    ],
+    "remediation": "Render untrusted values as text, sanitize unavoidable HTML with an allowlist sanitizer, and add a regression test for the sink.",
+    "severity": "medium",
+    "validation_status": "lead"
+  }
+};
+
+export function getDetectorInfo(detectorId) {
+  if (!detectorId) return null;
+  if (DETECTOR_INFO[detectorId]) return DETECTOR_INFO[detectorId];
+  // Detector IDs surface as either bare ids (`openai_api_key`)
+  // or canonical ids (`leak.openai_api_key`). Fall back to the trailing segment.
+  const tail = String(detectorId).split('.').pop();
+  return DETECTOR_INFO[tail] || null;
+}

--- a/extension/lib/detector-info.js
+++ b/extension/lib/detector-info.js
@@ -664,24 +664,6 @@ export const DETECTOR_INFO = {
     "severity": "medium",
     "validation_status": "validated"
   },
-  "mcp_config_secret": {
-    "attack_scenario": null,
-    "categories": [
-      "mcp",
-      "env",
-      "docker",
-      "logs"
-    ],
-    "description": "MCP or agent tool credential exposed.",
-    "detector_id": "leak.mcp_config_secret",
-    "finding_type": "mcp_config_secret",
-    "id": "mcp_config_secret",
-    "pack": "leak",
-    "references": [],
-    "remediation": "Move agent/tool credentials to local secret storage and review connected tool permissions.",
-    "severity": "high",
-    "validation_status": "validated"
-  },
   "missing_tenant_check_lead": {
     "attack_scenario": null,
     "categories": [
@@ -1035,25 +1017,6 @@ export const DETECTOR_INFO = {
     "remediation": "Review generated source maps for embedded secrets and avoid publishing private source in production.",
     "severity": "low",
     "validation_status": "validated"
-  },
-  "sql_injection_lead": {
-    "attack_scenario": null,
-    "categories": [
-      "code",
-      "sourcemaps",
-      "logs"
-    ],
-    "description": "SQL injection lead found in query construction or database error output.",
-    "detector_id": "appsec.sql_injection_lead",
-    "finding_type": "sql_injection",
-    "id": "sql_injection_lead",
-    "pack": "appsec",
-    "references": [
-      "https://owasp.org/www-community/attacks/SQL_Injection"
-    ],
-    "remediation": "Parameterize the query, validate the input at the boundary, and re-test the endpoint with the launch gate after the fix.",
-    "severity": "medium",
-    "validation_status": "lead"
   },
   "stripe_restricted_key": {
     "attack_scenario": null,

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -286,6 +286,33 @@ export function isOwnAuthHeader(source) {
  * Browser features (translate, sync, extensions) store short-lived
  * JWTs in localStorage that are not user secrets.
  */
+const GOOGLE_OWNED_DOMAINS = [
+  'google.com', 'google.co.', 'google.de', 'google.fr', 'google.co.uk',
+  'googleapis.com', 'gstatic.com', 'googlevideo.com',
+  'youtube.com', 'youtu.be', 'ytimg.com',
+  'gmail.com', 'googlemail.com',
+  'google-analytics.com', 'googletagmanager.com',
+  'firebase.google.com', 'firebaseio.com',
+  'googlesyndication.com', 'googleadservices.com',
+  'doubleclick.net', 'google.cloud',
+  'cloud.google.com', 'console.cloud.google.com',
+  'accounts.google.com', 'meet.google.com',
+  'docs.google.com', 'drive.google.com',
+  'maps.google.com', 'play.google.com',
+  'chromium.org', 'android.com',
+];
+
+/**
+ * Check if AIza keys should be suppressed because the user is on
+ * a Google-owned domain. Google's own keys on their own sites are
+ * expected — not leaked third-party credentials.
+ */
+export function isGoogleOwnedPage(pageUrl) {
+  if (!pageUrl) return false;
+  const lower = String(pageUrl).toLowerCase();
+  return GOOGLE_OWNED_DOMAINS.some(d => lower.includes(d));
+}
+
 export function isBrowserServiceToken(source) {
   if (!source) return false;
   const s = String(source).toLowerCase();

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -281,6 +281,25 @@ export function isOwnAuthHeader(source) {
   return s.includes('request header') && (s.includes('authorization') || s.includes('cookie'));
 }
 
+/**
+ * Check if a finding is from a browser-internal service token.
+ * Browser features (translate, sync, extensions) store short-lived
+ * JWTs in localStorage that are not user secrets.
+ */
+export function isBrowserServiceToken(source) {
+  if (!source) return false;
+  const s = String(source).toLowerCase();
+  return s.includes('translate') ||
+         s.includes('microsofttranslator') ||
+         s.includes('cognitiveservices') ||
+         s.includes('_grecaptcha') ||
+         s.includes('firebaseinstallations') ||
+         s.includes('firebase:authuser') ||
+         s.includes('__clerk') ||
+         s.includes('auth0') ||
+         s.includes('supabase.auth.token');
+}
+
 export function isInfraHeader(source) {
   if (!source || typeof source !== 'string') return false;
   const lower = source.toLowerCase();

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -270,6 +270,17 @@ const INFRA_HEADER_PATTERNS = [
  * @param {string} source - The source label (e.g., "Response Header (x-amz-cf-id)")
  * @returns {boolean}
  */
+/**
+ * Check if a finding is from the user's own Authorization request header.
+ * Bearer/JWT tokens in outgoing Authorization headers are the user's own
+ * session tokens — they're supposed to be there, not leaked secrets.
+ */
+export function isOwnAuthHeader(source) {
+  if (!source) return false;
+  const s = String(source).toLowerCase();
+  return s.includes('request header') && (s.includes('authorization') || s.includes('cookie'));
+}
+
 export function isInfraHeader(source) {
   if (!source || typeof source !== 'string') return false;
   const lower = source.toLowerCase();

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -286,31 +286,197 @@ export function isOwnAuthHeader(source) {
  * Browser features (translate, sync, extensions) store short-lived
  * JWTs in localStorage that are not user secrets.
  */
-const GOOGLE_OWNED_DOMAINS = [
+// First-party domains: when browsing these sites, ALL findings are
+// suppressed because any keys/tokens found are the provider's own
+// credentials used internally — not third-party leaks.
+const FIRST_PARTY_DOMAINS = [
+  // Google
   'google.com', 'google.co.', 'google.de', 'google.fr', 'google.co.uk',
-  'googleapis.com', 'gstatic.com', 'googlevideo.com',
-  'youtube.com', 'youtu.be', 'ytimg.com',
-  'gmail.com', 'googlemail.com',
-  'google-analytics.com', 'googletagmanager.com',
-  'firebase.google.com', 'firebaseio.com',
-  'googlesyndication.com', 'googleadservices.com',
-  'doubleclick.net', 'google.cloud',
-  'cloud.google.com', 'console.cloud.google.com',
-  'accounts.google.com', 'meet.google.com',
-  'docs.google.com', 'drive.google.com',
-  'maps.google.com', 'play.google.com',
-  'chromium.org', 'android.com',
+  'google.ca', 'google.com.au', 'google.co.jp', 'google.co.in',
+  'googleapis.com', 'gstatic.com', 'googlevideo.com', 'googleusercontent.com',
+  'youtube.com', 'youtu.be', 'ytimg.com', 'yt.be',
+  'gmail.com', 'googlemail.com', 'inbox.google.com',
+  'google-analytics.com', 'googletagmanager.com', 'googlesyndication.com',
+  'googleadservices.com', 'doubleclick.net', 'google.cloud',
+  'firebase.google.com', 'firebaseio.com', 'firebaseapp.com',
+  'chromium.org', 'android.com', 'withgoogle.com', 'googleblog.com',
+  'googledomains.com', 'registry.google', 'abc.xyz',
+  'waze.com', 'blogger.com', 'blogspot.com',
+
+  // Microsoft / Azure
+  'microsoft.com', 'microsoftonline.com', 'live.com', 'outlook.com',
+  'office.com', 'office365.com', 'sharepoint.com', 'onedrive.com',
+  'azure.com', 'azure.net', 'azurewebsites.net', 'azure-api.net',
+  'windows.net', 'windowsazure.com', 'msftauth.net', 'msauth.net',
+  'bing.com', 'msn.com', 'skype.com', 'teams.microsoft.com',
+  'visualstudio.com', 'dev.azure.com', 'github.com', 'github.io',
+  'npmjs.com', 'npmjs.org', 'linkedin.com', 'linkedin.cn',
+  'xbox.com', 'minecraft.net', 'mojang.com',
+  'copilot.microsoft.com', 'oai.azure.com',
+  'portal.azure.com', 'management.azure.com',
+
+  // Amazon / AWS
+  'amazon.com', 'amazon.co.uk', 'amazon.de', 'amazon.co.jp', 'amazon.in',
+  'amazonaws.com', 'aws.amazon.com', 'console.aws.amazon.com',
+  'cloudfront.net', 'elasticbeanstalk.com',
+  'awsstatic.com', 'awsapps.com',
+  'twitch.tv', 'twitchcdn.net', 'audible.com', 'alexa.com',
+  'primevideo.com', 'aboutamazon.com',
+
+  // Apple
+  'apple.com', 'icloud.com', 'me.com', 'mac.com',
+  'mzstatic.com', 'apple-dns.net', 'cdn-apple.com',
+  'developer.apple.com', 'apps.apple.com', 'testflight.apple.com',
+
+  // Meta / Facebook
+  'facebook.com', 'fb.com', 'fbcdn.net', 'fbsbx.com',
+  'instagram.com', 'cdninstagram.com',
+  'whatsapp.com', 'whatsapp.net',
+  'messenger.com', 'threads.net',
+  'meta.com', 'oculus.com', 'workplace.com',
+
+  // OpenAI
+  'openai.com', 'chatgpt.com', 'oaiusercontent.com',
+  'platform.openai.com', 'api.openai.com',
+
+  // Anthropic
+  'anthropic.com', 'claude.ai', 'console.anthropic.com',
+
+  // Stripe
+  'stripe.com', 'stripe.network', 'stripecdn.com',
+  'dashboard.stripe.com', 'js.stripe.com',
+
+  // Cloudflare
+  'cloudflare.com', 'cloudflareinsights.com', 'cloudflareworkers.com',
+  'cloudflarestream.com', 'cloudflare-dns.com',
+  'dash.cloudflare.com', 'one.dash.cloudflare.com',
+  'workers.dev', 'pages.dev',
+
+  // Vercel / Next.js
+  'vercel.com', 'vercel.app', 'nextjs.org', 'now.sh',
+
+  // Netlify
+  'netlify.com', 'netlify.app', 'netlifyglobal.com',
+
+  // Supabase
+  'supabase.com', 'supabase.co', 'supabase.io',
+
+  // Firebase (standalone)
+  'firebase.com', 'firebaseio.com', 'appspot.com',
+
+  // Datadog / Monitoring
+  'datadoghq.com', 'datadoghq.eu', 'ddog-gov.com',
+
+  // Sentry
+  'sentry.io', 'sentry-cdn.com',
+
+  // Atlassian
+  'atlassian.com', 'atlassian.net', 'bitbucket.org', 'trello.com',
+  'jira.com', 'confluence.com', 'statuspage.io',
+
+  // Salesforce
+  'salesforce.com', 'force.com', 'sfdc.net', 'lightning.force.com',
+  'heroku.com', 'herokuapp.com',
+
+  // Twilio / SendGrid
+  'twilio.com', 'sendgrid.com', 'sendgrid.net',
+
+  // Slack
+  'slack.com', 'slack-edge.com', 'slack-msgs.com',
+
+  // HubSpot
+  'hubspot.com', 'hubapi.com', 'hs-analytics.net', 'hsforms.net',
+
+  // Notion
+  'notion.so', 'notion.site', 'notion-static.com',
+
+  // Figma
+  'figma.com', 'figmacdn.com',
+
+  // GitLab
+  'gitlab.com', 'gitlab.io',
+
+  // DigitalOcean
+  'digitalocean.com', 'digitaloceanspaces.com',
+
+  // MongoDB
+  'mongodb.com', 'mongodb.net',
+
+  // Redis
+  'redis.io', 'redis.com', 'redislabs.com',
+
+  // PlanetScale
+  'planetscale.com',
+
+  // Neon
+  'neon.tech',
+
+  // Auth providers
+  'auth0.com', 'okta.com', 'clerk.com', 'clerk.dev',
+  'stytch.com', 'kinde.com', 'descope.com',
+
+  // Payment providers
+  'paypal.com', 'braintreegateway.com', 'braintree-api.com',
+  'razorpay.com', 'chargebee.com', 'recurly.com', 'paddle.com',
+  'gocardless.com', 'adyen.com', 'mollie.com',
+
+  // CI/CD
+  'circleci.com', 'travis-ci.com', 'travis-ci.org',
+  'semaphoreci.com', 'buildkite.com',
+
+  // Misc major platforms
+  'twitter.com', 'x.com', 't.co',
+  'reddit.com', 'redditstatic.com',
+  'discord.com', 'discord.gg', 'discordapp.com',
+  'spotify.com', 'scdn.co',
+  'zoom.us', 'zoom.com',
+  'dropbox.com', 'dropboxapi.com',
+  'box.com', 'boxcdn.net',
+  'airtable.com',
+  'linear.app',
+  'retool.com',
+  'vercel.com',
+  'render.com',
+  'fly.io',
+  'railway.app',
+  'deno.com', 'deno.land',
+  'bun.sh',
+  'docker.com', 'docker.io',
+  'hashicorp.com', 'terraform.io', 'vagrantup.com',
+  'pagerduty.com',
+  'launchdarkly.com',
+  'segment.com', 'segment.io',
+  'mixpanel.com',
+  'amplitude.com',
+  'heap.io', 'heapanalytics.com',
+  'fullstory.com',
+  'hotjar.com',
+  'intercom.com', 'intercom.io',
+  'zendesk.com', 'zdassets.com',
+  'freshdesk.com', 'freshworks.com',
+  'crisp.chat',
+  'tawk.to',
+  'hubspot.com',
+  'mailchimp.com', 'mailchimp.co',
+  'sendgrid.com',
+  'postmarkapp.com',
+  'mailtrap.io',
+  'resend.com',
+  'plausible.io',
+  'pirsch.io',
+  'fathom.com',
+  'simpleanalytics.com',
 ];
 
 /**
- * Check if AIza keys should be suppressed because the user is on
- * a Google-owned domain. Google's own keys on their own sites are
- * expected — not leaked third-party credentials.
+ * Check if the user is browsing a first-party domain where findings
+ * should be suppressed. A provider's own keys on their own pages are
+ * not leaked credentials.
  */
-export function isGoogleOwnedPage(pageUrl) {
+export function isFirstPartyDomain(pageUrl) {
   if (!pageUrl) return false;
   const lower = String(pageUrl).toLowerCase();
-  return GOOGLE_OWNED_DOMAINS.some(d => lower.includes(d));
+  return FIRST_PARTY_DOMAINS.some(d => lower.includes(d));
 }
 
 export function isBrowserServiceToken(source) {

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -103,7 +103,43 @@ export function isFalsePositive(value) {
     if ([0, 10, 127, 169, 172, 192, 224, 240, 255].includes(first)) return true;
   }
 
+  // Base64-encoded short values (common in minified JS, not secrets)
+  // Exclude values with path separators (like /users/123456)
+  if (/^[A-Za-z0-9+/]{10,}={0,2}$/.test(value) && value.length < 20 && !value.includes('/')) return true;
+
+  // Version strings and semver
+  if (/^\d+\.\d+\.\d+/.test(value)) return true;
+
+  // UUIDs (not secrets — identifiers)
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)) return true;
+
+  // Package names / npm scoped packages
+  if (/^@[a-z0-9-]+\/[a-z0-9-]+$/.test(lower)) return true;
+
+  // Common minified JS operator sequences matched by broad detectors
+  if (/^(?:delete|select|update|insert)\s+[a-z]\.[_$a-z]/i.test(value) && value.length < 40) return true;
+
+  // JWT-shaped strings that are actually just base64 config blobs (too short to be real JWTs)
+  if (/^eyJ/.test(value) && value.length < 50) return true;
+
   return false;
+}
+
+/**
+ * Check if a finding source is a browser-internal or extension-internal URL.
+ * @param {string} source
+ * @returns {boolean}
+ */
+export function isBrowserInternal(source) {
+  if (!source) return false;
+  const s = String(source).toLowerCase();
+  return s.startsWith('chrome-extension://') ||
+         s.startsWith('chrome://') ||
+         s.startsWith('moz-extension://') ||
+         s.startsWith('about:') ||
+         s.startsWith('edge://') ||
+         s.startsWith('brave://') ||
+         s.includes('devtools://');
 }
 
 const VENDOR_SCRIPT_DOMAINS = [

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -105,3 +105,44 @@ export function isFalsePositive(value) {
 
   return false;
 }
+
+const VENDOR_SCRIPT_DOMAINS = [
+  'google-analytics.com',
+  'googletagmanager.com',
+  'googleapis.com',
+  'gstatic.com',
+  'google.com/maps',
+  'maps.google.com',
+  'posthog.com',
+  'cdn.segment.com',
+  'cdn.mxpnl.com',
+  'js.intercomcdn.com',
+  'widget.intercom.io',
+  'js.stripe.com',
+  'cdn.amplitude.com',
+  'cdn.heapanalytics.com',
+  'static.hotjar.com',
+  'plausible.io',
+  'cdn.lr-intake.com',
+  'cdn.rudderlabs.com',
+  'cdn.cookielaw.org',
+  'js.hs-scripts.com',
+  'js.hs-analytics.net',
+  'connect.facebook.net',
+  'snap.licdn.com',
+  'static.ads-twitter.com',
+  'bat.bing.com',
+];
+
+/**
+ * Check if a finding source is a known third-party vendor script.
+ * Keys found in vendor CDN scripts are the vendor's own internal keys
+ * (e.g., Google's AIza key in analytics.js), not user-leaked secrets.
+ * @param {string} source - The source URL or description
+ * @returns {boolean} true if from a vendor script
+ */
+export function isVendorScript(source) {
+  if (!source || typeof source !== 'string') return false;
+  const lower = source.toLowerCase();
+  return VENDOR_SCRIPT_DOMAINS.some(domain => lower.includes(domain));
+}

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -156,12 +156,14 @@ export function isVendorScript(source) {
  * @param {string} source - Where it was found
  * @returns {boolean} true if likely a pre-signed URL credential
  */
-export function isPresignedUrlCredential(value, source) {
-  if (!value || !source) return false;
+export function isPresignedUrlCredential(value, source, content) {
+  if (!value) return false;
   const v = String(value);
-  const s = String(source).toLowerCase();
   if (!/^A[SK]IA[A-Z0-9]{16}$/.test(v)) return false;
-  if (s.includes('meta tag') || s.includes('x-amz-credential') || s.includes('presigned')) return true;
-  if (/s3[.-]|cloudfront|amazonaws\.com/.test(s)) return true;
+  const s = String(source || '').toLowerCase();
+  const c = String(content || '').toLowerCase();
+  if (s.includes('meta tag') || s.includes('presigned')) return true;
+  if (/x-amz-credential|x-amz-signature|x-amz-date|x-amz-expires/i.test(c)) return true;
+  if (/s3[.-]|cloudfront|amazonaws\.com/i.test(s) || /s3[.-]|cloudfront|amazonaws\.com/i.test(c)) return true;
   return false;
 }

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -132,6 +132,23 @@ const VENDOR_SCRIPT_DOMAINS = [
   'snap.licdn.com',
   'static.ads-twitter.com',
   'bat.bing.com',
+  'cdn.datadog-static.com',
+  'browser-intake-datadoghq.com',
+  'cdn.pendo.io',
+  'js.sentry-cdn.com',
+  'cdn.logrocket.io',
+  'cdn.mouseflow.com',
+  'static.cloudflareinsights.com',
+  'challenges.cloudflare.com',
+  'cdn.optimizely.com',
+  'cdn.launchdarkly.com',
+  'js.driftt.com',
+  'widget.freshdesk.com',
+  'js.chargebee.com',
+  'js.recurly.com',
+  'js.braintreegateway.com',
+  'checkout.razorpay.com',
+  'cdn.paddle.com',
 ];
 
 /**
@@ -147,23 +164,108 @@ export function isVendorScript(source) {
   return VENDOR_SCRIPT_DOMAINS.some(domain => lower.includes(domain));
 }
 
+// Cloud storage signed/pre-signed URL patterns.
+// These embed credentials or tokens in the URL for time-limited, scoped
+// access to a single object.  They are designed to be shared publicly
+// (in meta tags, image src, API responses) and are NOT leaked secrets.
+const CLOUD_STORAGE_SIGNED_URL_MARKERS = [
+  // AWS S3 / CloudFront pre-signed URLs
+  'x-amz-credential',
+  'x-amz-signature',
+  'x-amz-date',
+  'x-amz-expires',
+  'x-amz-security-token',
+  'x-amz-algorithm',
+  'amazonaws.com',
+  '.s3.',
+  's3-',
+  'cloudfront.net',
+
+  // Google Cloud Storage signed URLs
+  'x-goog-credential',
+  'x-goog-signature',
+  'x-goog-date',
+  'x-goog-expires',
+  'x-goog-algorithm',
+  'storage.googleapis.com',
+  'storage.cloud.google.com',
+
+  // Azure Blob Storage SAS tokens
+  'blob.core.windows.net',
+  'blob.storage.azure.net',
+
+  // Cloudflare R2 (uses S3-compatible signed URLs)
+  'r2.dev',
+  'r2.cloudflarestorage.com',
+
+  // DigitalOcean Spaces (S3-compatible)
+  'digitaloceanspaces.com',
+
+  // Backblaze B2
+  'backblazeb2.com',
+  'f000.backblazeb2.com',
+
+  // Wasabi
+  'wasabisys.com',
+
+  // Supabase Storage
+  'supabase.co/storage',
+
+  // Firebase Storage
+  'firebasestorage.googleapis.com',
+
+  // Vercel Blob
+  'vercel-storage.com',
+  'blob.vercel-storage.com',
+
+  // Uploadthing / other upload services
+  'uploadthing.com',
+  'utfs.io',
+];
+
+// Patterns in the source label that indicate cloud storage / CDN context
+const CLOUD_STORAGE_SOURCE_PATTERNS = [
+  'meta tag',
+  'presigned',
+  'signed url',
+  'og:image',
+  'twitter:image',
+];
+
 /**
- * Check if an AWS access key finding is from a pre-signed URL context.
- * Pre-signed S3/CloudFront URLs embed temporary credentials (ASIA prefix)
- * in URL query parameters — these are designed to be shared publicly,
- * are time-limited, and scoped to a single object.
- * @param {string} value - The matched key value
- * @param {string} source - Where it was found
- * @returns {boolean} true if likely a pre-signed URL credential
+ * Check if a finding is from a cloud storage signed/pre-signed URL.
+ * Covers AWS S3, GCS, Azure Blob, Cloudflare R2, DigitalOcean Spaces,
+ * Backblaze B2, Wasabi, Supabase Storage, Firebase Storage, and Vercel Blob.
+ * @param {string} value - The matched secret value
+ * @param {string} source - Where it was found (source label)
+ * @param {string} content - The full text being scanned
+ * @returns {boolean} true if from a cloud storage signed URL context
  */
-export function isPresignedUrlCredential(value, source, content) {
-  if (!value) return false;
-  const v = String(value);
-  if (!/^A[SK]IA[A-Z0-9]{16}$/.test(v)) return false;
+export function isCloudStorageSignedUrl(value, source, content) {
   const s = String(source || '').toLowerCase();
   const c = String(content || '').toLowerCase();
-  if (s.includes('meta tag') || s.includes('presigned')) return true;
-  if (/x-amz-credential|x-amz-signature|x-amz-date|x-amz-expires/i.test(c)) return true;
-  if (/s3[.-]|cloudfront|amazonaws\.com/i.test(s) || /s3[.-]|cloudfront|amazonaws\.com/i.test(c)) return true;
+
+  // Check source label
+  for (const pattern of CLOUD_STORAGE_SOURCE_PATTERNS) {
+    if (s.includes(pattern)) return true;
+  }
+
+  // Check content and source for any cloud storage marker
+  for (const marker of CLOUD_STORAGE_SIGNED_URL_MARKERS) {
+    if (c.includes(marker) || s.includes(marker)) return true;
+  }
+
   return false;
+}
+
+// Azure SAS token patterns — sv=, sig=, se=, sp= in query strings
+const AZURE_SAS_RE = /[?&](?:sv|sig|se|sp|spr|srt)=/i;
+
+/**
+ * Check if a finding is from an Azure SAS token URL.
+ * @param {string} content - The full text being scanned
+ * @returns {boolean}
+ */
+export function isAzureSasToken(content) {
+  return AZURE_SAS_RE.test(String(content || ''));
 }

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -209,6 +209,7 @@ const VENDOR_SCRIPT_DOMAINS = [
   'embed.tawk.to',
   'static.zdassets.com',
   'widget.crisp.chat',
+  'client.crisp.chat',
   // HubSpot
   'js.hscollectedforms.net',
   'js.hsforms.net',

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -209,6 +209,34 @@ const VENDOR_SCRIPT_DOMAINS = [
   'embed.tawk.to',
   'static.zdassets.com',
   'widget.crisp.chat',
+  // HubSpot
+  'js.hscollectedforms.net',
+  'js.hsforms.net',
+  'js.hubspot.com',
+  'js.hs-banner.com',
+  'js.usemessages.com',
+  // Widget / embed CDNs
+  'elfsightcdn.com',
+  'static.elfsight.com',
+  'cdn.embedly.com',
+  'platform.twitter.com',
+  'platform.instagram.com',
+  'connect.facebook.net',
+  'apis.google.com',
+  'www.youtube.com/iframe_api',
+  'player.vimeo.com',
+  'fast.wistia.com',
+  // CMS / site builder
+  'cdn.shopify.com/s',
+  'assets.squarespace.com',
+  'static.parastorage.com',
+  'static.wixstatic.com',
+  'cdn.webflow.com',
+  // Consent / cookie managers
+  'cdn.cookiebot.com',
+  'consent.cookiebot.com',
+  'cdn.iubenda.com',
+  'cdn.onetrust.com',
 ];
 
 /**
@@ -218,6 +246,36 @@ const VENDOR_SCRIPT_DOMAINS = [
  * @param {string} source - The source URL or description
  * @returns {boolean} true if from a vendor script
  */
+// Infrastructure response headers whose values look like secrets but aren't.
+// CloudFront x-amz-cf-id often starts with HF_ (matches HuggingFace regex),
+// cf-ray contains hex tokens, x-request-id contains UUIDs, etc.
+const INFRA_HEADER_PATTERNS = [
+  'x-amz-cf-id', 'x-amz-cf-pop', 'x-amz-request-id', 'x-amz-id-2',
+  'x-cache', 'x-served-by', 'x-timer', 'x-request-id', 'x-trace-id',
+  'x-cloud-trace-context', 'x-b3-traceid', 'x-b3-spanid',
+  'cf-ray', 'cf-cache-status', 'cf-request-id',
+  'x-vercel-id', 'x-vercel-cache',
+  'x-fly-request-id', 'x-render-origin-server',
+  'x-powered-by', 'server', 'via', 'x-cdn',
+  'nel', 'report-to', 'reporting-endpoints',
+  'x-nf-request-id',
+  'etag', 'x-correlation-id',
+];
+
+/**
+ * Check if a finding source is an infrastructure response header.
+ * Values from these headers (trace IDs, cache keys, CDN identifiers)
+ * often match secret patterns but are not credentials.
+ * @param {string} source - The source label (e.g., "Response Header (x-amz-cf-id)")
+ * @returns {boolean}
+ */
+export function isInfraHeader(source) {
+  if (!source || typeof source !== 'string') return false;
+  const lower = source.toLowerCase();
+  if (!lower.includes('header')) return false;
+  return INFRA_HEADER_PATTERNS.some(h => lower.includes(h));
+}
+
 export function isVendorScript(source) {
   if (!source || typeof source !== 'string') return false;
   const lower = source.toLowerCase();

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -146,3 +146,22 @@ export function isVendorScript(source) {
   const lower = source.toLowerCase();
   return VENDOR_SCRIPT_DOMAINS.some(domain => lower.includes(domain));
 }
+
+/**
+ * Check if an AWS access key finding is from a pre-signed URL context.
+ * Pre-signed S3/CloudFront URLs embed temporary credentials (ASIA prefix)
+ * in URL query parameters — these are designed to be shared publicly,
+ * are time-limited, and scoped to a single object.
+ * @param {string} value - The matched key value
+ * @param {string} source - Where it was found
+ * @returns {boolean} true if likely a pre-signed URL credential
+ */
+export function isPresignedUrlCredential(value, source) {
+  if (!value || !source) return false;
+  const v = String(value);
+  const s = String(source).toLowerCase();
+  if (!/^A[SK]IA[A-Z0-9]{16}$/.test(v)) return false;
+  if (s.includes('meta tag') || s.includes('x-amz-credential') || s.includes('presigned')) return true;
+  if (/s3[.-]|cloudfront|amazonaws\.com/.test(s)) return true;
+  return false;
+}

--- a/extension/lib/false-positives.js
+++ b/extension/lib/false-positives.js
@@ -149,6 +149,30 @@ const VENDOR_SCRIPT_DOMAINS = [
   'js.braintreegateway.com',
   'checkout.razorpay.com',
   'cdn.paddle.com',
+  // Public CDNs serving open-source libraries
+  'cdn.jsdelivr.net',
+  'unpkg.com',
+  'cdnjs.cloudflare.com',
+  'esm.sh',
+  'esm.run',
+  'cdn.skypack.dev',
+  'ga.jspm.io',
+  'jspm.dev',
+  'deno.land',
+  // Framework-specific CDNs
+  'ajax.googleapis.com/ajax/libs',
+  'code.jquery.com',
+  'cdn.tailwindcss.com',
+  'cdn.shopify.com',
+  // Error tracking / monitoring
+  'js.bugsnag.com',
+  'cdn.rollbar.com',
+  'browser.sentry-cdn.com',
+  // Chat / support widgets
+  'cdn.zendesk.com',
+  'embed.tawk.to',
+  'static.zdassets.com',
+  'widget.crisp.chat',
 ];
 
 /**

--- a/extension/lib/key-tester.js
+++ b/extension/lib/key-tester.js
@@ -1,0 +1,109 @@
+/**
+ * Live key validation for KeyLeak Detector.
+ * Tests whether a detected credential is still active by making a single
+ * read-only API call to the provider. All requests are GETs that return
+ * metadata (model lists, user info, scopes) — never mutating operations.
+ */
+
+const TESTERS = {
+  gemini_api_key: testGemini,
+  google_client_api_key: testGemini,
+  openai_api_key: testOpenAI,
+  anthropic_api_key: testAnthropic,
+  github_pat: testGitHub,
+  stripe_secret_key: testStripe,
+  stripe_restricted_key: testStripe,
+  openrouter_api_key: testOpenRouter,
+  huggingface_token: testHuggingFace,
+  sendgrid_api_key: testSendGrid,
+  groq_api_key: testGroq,
+  replicate_api_key: testReplicate,
+};
+
+export const TESTABLE_TYPES = new Set(Object.keys(TESTERS));
+
+export async function testKey(type, rawValue) {
+  const tester = TESTERS[type];
+  if (!tester) return { status: 'unsupported', detail: 'No test available for this key type.' };
+  if (!rawValue) return { status: 'error', detail: 'No raw value available. Enable Reveal mode first.' };
+  try {
+    return await tester(rawValue);
+  } catch (err) {
+    return { status: 'error', detail: err.message || 'Request failed' };
+  }
+}
+
+async function probe(url, headers = {}) {
+  const resp = await fetch(url, { headers, credentials: 'omit' });
+  return { status: resp.status, ok: resp.ok, body: await resp.json().catch(() => null) };
+}
+
+async function testGemini(key) {
+  const r = await probe(`https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`);
+  if (r.ok) {
+    const count = r.body?.models?.length || 0;
+    return { status: 'valid', detail: `Key is active. ${count} models accessible.` };
+  }
+  if (r.status === 400 || r.status === 403) return { status: 'invalid', detail: `HTTP ${r.status} — key rejected or restricted.` };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testOpenAI(key) {
+  const r = await probe('https://api.openai.com/v1/models', { Authorization: `Bearer ${key}` });
+  if (r.ok) return { status: 'valid', detail: `Key is active. ${r.body?.data?.length || '?'} models.` };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testAnthropic(key) {
+  const r = await probe('https://api.anthropic.com/v1/models', { 'x-api-key': key, 'anthropic-version': '2023-06-01' });
+  if (r.ok) return { status: 'valid', detail: 'Key is active.' };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testGitHub(key) {
+  const r = await probe('https://api.github.com/user', { Authorization: `token ${key}`, Accept: 'application/vnd.github+json' });
+  if (r.ok) {
+    const scopes = '';
+    return { status: 'valid', detail: `Key is active. User: ${r.body?.login || 'unknown'}.` };
+  }
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testStripe(key) {
+  const r = await fetch('https://api.stripe.com/v1/balance', {
+    headers: { Authorization: `Basic ${btoa(key + ':')}` },
+    credentials: 'omit',
+  });
+  if (r.ok) return { status: 'valid', detail: 'Key is active (Stripe balance endpoint accessible).' };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testOpenRouter(key) {
+  const r = await probe('https://openrouter.ai/api/v1/models', { Authorization: `Bearer ${key}` });
+  if (r.ok) return { status: 'valid', detail: `Key is active. ${r.body?.data?.length || '?'} models.` };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testHuggingFace(key) {
+  const r = await probe('https://huggingface.co/api/whoami-v2', { Authorization: `Bearer ${key}` });
+  if (r.ok) return { status: 'valid', detail: `Key is active. User: ${r.body?.name || 'unknown'}.` };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testSendGrid(key) {
+  const r = await probe('https://api.sendgrid.com/v3/scopes', { Authorization: `Bearer ${key}` });
+  if (r.ok) return { status: 'valid', detail: 'Key is active (SendGrid scopes accessible).' };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testGroq(key) {
+  const r = await probe('https://api.groq.com/openai/v1/models', { Authorization: `Bearer ${key}` });
+  if (r.ok) return { status: 'valid', detail: `Key is active. ${r.body?.data?.length || '?'} models.` };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+async function testReplicate(key) {
+  const r = await probe('https://api.replicate.com/v1/models', { Authorization: `Token ${key}` });
+  if (r.ok) return { status: 'valid', detail: 'Key is active.' };
+  return { status: 'invalid', detail: `HTTP ${r.status}` };
+}

--- a/extension/lib/key-tester.js
+++ b/extension/lib/key-tester.js
@@ -46,9 +46,10 @@ async function testGemini(key) {
   const r = await probe(`https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`);
   if (r.ok) {
     const count = r.body?.models?.length || 0;
-    return { status: 'valid', detail: `Key is active. ${count} models accessible.` };
+    return { status: 'valid', detail: `Key is active for Gemini AI. ${count} models accessible.` };
   }
-  if (r.status === 400 || r.status === 403) return { status: 'invalid', detail: `HTTP ${r.status} — key rejected or restricted.` };
+  if (r.status === 403) return { status: 'invalid', detail: 'HTTP 403 — not a Gemini key (likely a restricted Firebase/Maps key).' };
+  if (r.status === 400) return { status: 'invalid', detail: 'HTTP 400 — key format rejected.' };
   return { status: 'invalid', detail: `HTTP ${r.status}` };
 }
 

--- a/extension/lib/key-tester.js
+++ b/extension/lib/key-tester.js
@@ -18,6 +18,10 @@ const TESTERS = {
   sendgrid_api_key: testSendGrid,
   groq_api_key: testGroq,
   replicate_api_key: testReplicate,
+  bearer_token: testJWT,
+  jwt_token: testJWT,
+  supabase_anon_key: testJWT,
+  supabase_publishable_key: testJWT,
 };
 
 export const TESTABLE_TYPES = new Set(Object.keys(TESTERS));
@@ -106,4 +110,93 @@ async function testReplicate(key) {
   const r = await probe('https://api.replicate.com/v1/models', { Authorization: `Token ${key}` });
   if (r.ok) return { status: 'valid', detail: 'Key is active.' };
   return { status: 'invalid', detail: `HTTP ${r.status}` };
+}
+
+function decodeJwtPayload(token) {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = payload + '='.repeat((4 - payload.length % 4) % 4);
+    return JSON.parse(atob(padded));
+  } catch (_) {
+    return null;
+  }
+}
+
+const DANGEROUS_SCOPES = ['admin', 'write', 'delete', 'manage', 'superuser', 'root', 'full_access'];
+
+function analyzeJwtClaims(claims) {
+  const flags = [];
+
+  const role = claims.role || claims.roles || '';
+  const roleStr = Array.isArray(role) ? role.join(',') : String(role);
+  if (/service.?role/i.test(roleStr)) {
+    flags.push({ level: 'critical', claim: 'role', message: `service_role — bypasses all Row-Level Security` });
+  } else if (/admin|superuser|root/i.test(roleStr)) {
+    flags.push({ level: 'high', claim: 'role', message: `${roleStr} — elevated privileges` });
+  }
+
+  if (claims.is_admin === true || claims.admin === true || claims.isAdmin === true) {
+    flags.push({ level: 'high', claim: 'is_admin', message: 'Admin flag is true — elevated privileges' });
+  }
+
+  const scope = claims.scope || claims.scp || claims.scopes || '';
+  const scopeStr = Array.isArray(scope) ? scope.join(' ') : String(scope);
+  if (scopeStr) {
+    const dangerousFound = DANGEROUS_SCOPES.filter(s => scopeStr.toLowerCase().includes(s));
+    if (dangerousFound.length > 0) {
+      flags.push({ level: 'high', claim: 'scope', message: `Broad scope: ${dangerousFound.join(', ')}` });
+    }
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.exp) {
+    const remaining = claims.exp - now;
+    if (remaining < 0) {
+      flags.push({ level: 'info', claim: 'exp', message: `Expired ${formatDuration(-remaining)} ago` });
+    } else if (remaining > 365 * 24 * 3600) {
+      flags.push({ level: 'medium', claim: 'exp', message: `Expires in ${formatDuration(remaining)} — very long-lived` });
+    } else {
+      flags.push({ level: 'info', claim: 'exp', message: `Expires in ${formatDuration(remaining)}` });
+    }
+  } else {
+    flags.push({ level: 'medium', claim: 'exp', message: 'No expiry set — token never expires' });
+  }
+
+  if (claims.iss) flags.push({ level: 'info', claim: 'iss', message: `Issuer: ${claims.iss}` });
+  if (claims.aud) flags.push({ level: 'info', claim: 'aud', message: `Audience: ${Array.isArray(claims.aud) ? claims.aud.join(', ') : claims.aud}` });
+  if (claims.sub) flags.push({ level: 'info', claim: 'sub', message: `Subject: ${claims.sub}` });
+  if (claims.email) flags.push({ level: 'info', claim: 'email', message: `Email: ${claims.email}` });
+
+  return flags;
+}
+
+function formatDuration(seconds) {
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  if (seconds < 365 * 86400) return `${Math.floor(seconds / 86400)}d`;
+  return `${(seconds / (365 * 86400)).toFixed(1)}y`;
+}
+
+async function testJWT(token) {
+  const claims = decodeJwtPayload(token);
+  if (!claims) return { status: 'error', detail: 'Not a valid JWT — could not decode payload.' };
+
+  const flags = analyzeJwtClaims(claims);
+  const hasCritical = flags.some(f => f.level === 'critical');
+  const hasHigh = flags.some(f => f.level === 'high');
+
+  const summaryParts = [];
+  if (claims.iss) summaryParts.push(`iss=${claims.iss}`);
+  if (claims.role) summaryParts.push(`role=${claims.role}`);
+  if (claims.sub) summaryParts.push(`sub=${String(claims.sub).slice(0, 20)}`);
+
+  return {
+    status: 'decoded',
+    detail: `JWT decoded. ${summaryParts.join(', ') || 'No notable claims.'}`,
+    claims,
+    flags,
+    severity: hasCritical ? 'critical' : hasHigh ? 'high' : 'info',
+  };
 }

--- a/extension/lib/patterns.js
+++ b/extension/lib/patterns.js
@@ -651,28 +651,6 @@ const PATTERN_DEFINITIONS = [
     "validation_status": "validated"
   },
   {
-    "capture_group": 1,
-    "categories": [
-      "mcp",
-      "env",
-      "docker",
-      "logs"
-    ],
-    "category": "leak",
-    "description": "MCP or agent tool credential exposed.",
-    "detector_id": "leak.mcp_config_secret",
-    "finding_type": "mcp_config_secret",
-    "flags": "gim",
-    "id": "mcp_config_secret",
-    "min_match_length": 8,
-    "pack": "leak",
-    "pattern": "(?:mcp|modelcontextprotocol|tool|server).{0,80}(?:api[_-]?key|token|secret|password)[\\\"'\\s:=]+[\\\"']?([A-Za-z0-9_\\-./+=]{20,})",
-    "references": [],
-    "remediation": "Move agent/tool credentials to local secret storage and review connected tool permissions.",
-    "severity": "high",
-    "validation_status": "validated"
-  },
-  {
     "capture_group": 0,
     "categories": [
       "sourcemaps",
@@ -940,29 +918,6 @@ const PATTERN_DEFINITIONS = [
     "pattern": "(?:console\\.log|logger\\.(?:debug|info|warn|error)|print\\s*\\()[\\s\\S]{0,120}(?:api[_-]?key|secret|token|password|authorization|cookie)",
     "references": [],
     "remediation": "Remove secrets from logs, redact sensitive fields at the logger boundary, and rotate any value that may already have been written.",
-    "severity": "medium",
-    "validation_status": "lead"
-  },
-  {
-    "capture_group": 0,
-    "categories": [
-      "code",
-      "sourcemaps",
-      "logs"
-    ],
-    "category": "appsec",
-    "description": "SQL injection lead found in query construction or database error output.",
-    "detector_id": "appsec.sql_injection_lead",
-    "finding_type": "sql_injection",
-    "flags": "gim",
-    "id": "sql_injection_lead",
-    "min_match_length": 12,
-    "pack": "appsec",
-    "pattern": "(?:\\b(?:SELECT|UPDATE|DELETE|INSERT)\\b[\\s\\S]{0,160}(?:\\+\\s*(?:req|request|params|query|body|input|user)|\\$\\{[^}]+\\})|(?:sql|query)\\s*[:=]\\s*[`'\\\"][\\s\\S]{0,120}\\$\\{[^}]+\\}|(?:SQL syntax|mysql_fetch|PostgreSQL query failed|SQLiteException|ODBC SQL Server Driver))",
-    "references": [
-      "https://owasp.org/www-community/attacks/SQL_Injection"
-    ],
-    "remediation": "Parameterize the query, validate the input at the boundary, and re-test the endpoint with the launch gate after the fix.",
     "severity": "medium",
     "validation_status": "lead"
   },

--- a/extension/lib/patterns.js
+++ b/extension/lib/patterns.js
@@ -1094,29 +1094,6 @@ const PATTERN_DEFINITIONS = [
       "env"
     ],
     "category": "baas",
-    "description": "Supabase anon/publishable key (JWT format) exposed in client bundle.",
-    "detector_id": "baas.supabase_anon_key",
-    "finding_type": "supabase_anon_key",
-    "flags": "gim",
-    "id": "supabase_anon_key",
-    "min_match_length": 8,
-    "pack": "baas",
-    "pattern": "\\beyJ[A-Za-z0-9_-]{30,}\\.eyJ[A-Za-z0-9_-]{30,}\\.[A-Za-z0-9_-]{20,}\\b",
-    "references": [
-      "https://supabase.com/docs/guides/api#api-keys"
-    ],
-    "remediation": "Anon keys are designed for client use, but confirm RLS policies protect every table.",
-    "severity": "medium",
-    "validation_status": "lead"
-  },
-  {
-    "capture_group": 0,
-    "categories": [
-      "sourcemaps",
-      "code",
-      "env"
-    ],
-    "category": "baas",
     "description": "Supabase publishable key (non-standard format) exposed in client bundle.",
     "detector_id": "baas.supabase_publishable_key",
     "finding_type": "supabase_publishable_key",

--- a/extension/lib/patterns.js
+++ b/extension/lib/patterns.js
@@ -1,81 +1,1472 @@
 /**
- * Secret detection patterns for KeyLeak Detector.
- * Ported from the Python web app + GitLeaks patterns.
- *
- * Each entry: { pattern: RegExp, severity: 'high'|'medium'|'low', description: string }
+ * Generated detector bundle for KeyLeak Detector.
+ * Source of truth: keyleak.detectors.DETECTORS.
+ * Regenerate with: python3 scripts/generate_extension_patterns.py
  */
 
-const PATTERNS = {
-  // --- Cloud Provider Credentials ---
-  aws_key:                { pattern: /AKIA[0-9A-Z]{16}/g, severity: 'high', description: 'AWS Access Key ID' },
-  aws_secret:             { pattern: /(?:aws)(.{0,20})?['"][0-9a-zA-Z/+]{40}['"]/gi, severity: 'high', description: 'AWS Secret Access Key' },
-  aws_account_id:         { pattern: /\b(?:aws[_-]?account[_-]?id|account[_-]?id|aws[_-]?id)[=: ]*['"]?([0-9]{4}[-]?[0-9]{4}[-]?[0-9]{4})['"]?/gi, severity: 'medium', description: 'AWS Account ID' },
-  google_api_key:         { pattern: /AIza[0-9A-Za-z\-_]{35}/g, severity: 'high', description: 'Google API Key' },
-  google_oauth:           { pattern: /ya29\.[0-9A-Za-z\-_]+/g, severity: 'medium', description: 'Google OAuth Token' },
-  google_service_account: { pattern: /"type":\s*"service_account"[\s\S]*?"project_id":\s*"[^"]*"[\s\S]*?"private_key":\s*"-----BEGIN PRIVATE KEY-----/g, severity: 'high', description: 'Google Cloud Service Account Key' },
-  firebase:               { pattern: /AAAA[A-Za-z0-9_-]{7}:[A-Za-z0-9_-]{140}/g, severity: 'high', description: 'Firebase API Key' },
-  heroku_api_key:         { pattern: /[hH][eE][rR][oO][kK][uU][\s-]?[aA][pP][iI][\s-]?[kK][eE][yY][\s-:]*['"]?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}['"]?/g, severity: 'high', description: 'Heroku API Key' },
+const PATTERN_DEFINITIONS = [
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "OpenAI API key exposed.",
+    "detector_id": "leak.openai_api_key",
+    "finding_type": "openai_api_key",
+    "flags": "gim",
+    "id": "openai_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bsk-(?!(?:ant|or)-)(?:proj-)?[A-Za-z0-9_-]{20,}\\b",
+    "references": [],
+    "remediation": "Rotate the OpenAI key, remove it from client/config files, and load it server-side from a secret manager.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Anthropic API key exposed.",
+    "detector_id": "leak.anthropic_api_key",
+    "finding_type": "anthropic_api_key",
+    "flags": "gim",
+    "id": "anthropic_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bsk-ant-[A-Za-z0-9_-]{80,}\\b",
+    "references": [],
+    "remediation": "Rotate the Anthropic key and move model calls behind a trusted server boundary.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "OpenRouter API key exposed.",
+    "detector_id": "leak.openrouter_api_key",
+    "finding_type": "openrouter_api_key",
+    "flags": "gim",
+    "id": "openrouter_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bsk-or-v1-[A-Za-z0-9]{48,}\\b",
+    "references": [],
+    "remediation": "Rotate the OpenRouter key and audit usage because this can proxy access to multiple model providers.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Google Gemini/API key exposed.",
+    "detector_id": "leak.gemini_api_key",
+    "finding_type": "gemini_api_key",
+    "flags": "gim",
+    "id": "gemini_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bAIza[0-9A-Za-z\\-_]{35}\\b",
+    "references": [],
+    "remediation": "Rotate or restrict the Google API key, audit API usage, and keep model/provider credentials server-side.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Hugging Face token exposed.",
+    "detector_id": "leak.huggingface_token",
+    "finding_type": "huggingface_token",
+    "flags": "gim",
+    "id": "huggingface_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bhf_[A-Za-z0-9]{32,}\\b",
+    "references": [],
+    "remediation": "Rotate the token, review model/dataset access, and avoid shipping provider tokens in browser bundles.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Replicate API key exposed.",
+    "detector_id": "leak.replicate_api_key",
+    "finding_type": "replicate_api_key",
+    "flags": "gim",
+    "id": "replicate_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\br8_[A-Za-z0-9]{40,}\\b",
+    "references": [],
+    "remediation": "Rotate the Replicate key and move inference calls behind a trusted server boundary.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Perplexity API key exposed.",
+    "detector_id": "leak.perplexity_api_key",
+    "finding_type": "perplexity_api_key",
+    "flags": "gim",
+    "id": "perplexity_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bpplx-[A-Za-z0-9]{40,}\\b",
+    "references": [],
+    "remediation": "Rotate the Perplexity key and keep model-provider credentials out of client-side code.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Anyscale API key exposed.",
+    "detector_id": "leak.anyscale_api_key",
+    "finding_type": "anyscale_api_key",
+    "flags": "gim",
+    "id": "anyscale_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\besecret_[A-Za-z0-9]{40,}\\b",
+    "references": [],
+    "remediation": "Rotate the Anyscale key and audit inference endpoint usage.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Groq API key exposed.",
+    "detector_id": "leak.groq_api_key",
+    "finding_type": "groq_api_key",
+    "flags": "gim",
+    "id": "groq_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bgsk_[A-Za-z0-9]{40,}\\b",
+    "references": [],
+    "remediation": "Rotate the Groq key and keep inference credentials out of browser and agent config files.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "GitHub token exposed.",
+    "detector_id": "leak.github_pat",
+    "finding_type": "github_pat",
+    "flags": "gim",
+    "id": "github_pat",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\\b|\\bgithub_pat_[A-Za-z0-9_]{70,}\\b",
+    "references": [],
+    "remediation": "Revoke the token, review repository access, and regenerate with the smallest necessary scope.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "AWS access key ID exposed.",
+    "detector_id": "leak.aws_access_key",
+    "finding_type": "aws_access_key",
+    "flags": "gim",
+    "id": "aws_access_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\b(?:AKIA|ASIA)[0-9A-Z]{16}\\b",
+    "references": [],
+    "remediation": "Rotate the access key and prefer IAM roles or workload identity over static credentials.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "AWS secret access key-like value exposed.",
+    "detector_id": "leak.aws_secret_key",
+    "finding_type": "aws_secret_key",
+    "flags": "gim",
+    "id": "aws_secret_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\baws.{0,30}(?:secret|access).{0,20}[\\\"'\\s:=]+([A-Za-z0-9/+=]{40})",
+    "references": [],
+    "remediation": "Rotate the AWS secret, review CloudTrail activity, and use IAM roles or a secret manager instead.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Google service account key material exposed.",
+    "detector_id": "leak.google_service_account",
+    "finding_type": "google_service_account",
+    "flags": "gim",
+    "id": "google_service_account",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\\"type\\\":\\s*\\\"service_account\\\"[\\s\\S]*?\\\"private_key\\\":\\s*\\\"-----BEGIN PRIVATE KEY-----",
+    "references": [],
+    "remediation": "Revoke the service account key, audit IAM permissions, and move service credentials to secret storage.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Firebase/FCM server key exposed.",
+    "detector_id": "leak.firebase_server_key",
+    "finding_type": "firebase_server_key",
+    "flags": "gim",
+    "id": "firebase_server_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bAAAA[A-Za-z0-9_-]{7}:[A-Za-z0-9_-]{120,}\\b",
+    "references": [],
+    "remediation": "Rotate the Firebase key and confirm Firebase security rules prevent unauthorized access.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Stripe secret key exposed.",
+    "detector_id": "leak.stripe_secret_key",
+    "finding_type": "stripe_secret_key",
+    "flags": "gim",
+    "id": "stripe_secret_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bsk_(?:live|test)_[0-9A-Za-z]{24,}\\b",
+    "references": [],
+    "remediation": "Rotate the Stripe key and move payment operations behind server-side endpoints.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Stripe restricted key exposed.",
+    "detector_id": "leak.stripe_restricted_key",
+    "finding_type": "stripe_restricted_key",
+    "flags": "gim",
+    "id": "stripe_restricted_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\brk_(?:live|test)_[0-9A-Za-z]{24,}\\b",
+    "references": [],
+    "remediation": "Rotate the Stripe restricted key and move payment operations to server-side endpoints.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Slack token exposed.",
+    "detector_id": "leak.slack_token",
+    "finding_type": "slack_token",
+    "flags": "gim",
+    "id": "slack_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bxox[baprs]-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{24,32}\\b",
+    "references": [],
+    "remediation": "Revoke the Slack token, review workspace app scopes, and regenerate with least privilege.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Slack webhook URL exposed.",
+    "detector_id": "leak.slack_webhook",
+    "finding_type": "slack_webhook",
+    "flags": "gim",
+    "id": "slack_webhook",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "https://hooks\\.slack\\.com/services/[A-Za-z0-9_/-]{20,}",
+    "references": [],
+    "remediation": "Regenerate the webhook and keep it out of browser bundles and public config.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "GitLab token exposed.",
+    "detector_id": "leak.gitlab_token",
+    "finding_type": "gitlab_token",
+    "flags": "gim",
+    "id": "gitlab_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bglpat-[A-Za-z0-9\\-]{20,}\\b",
+    "references": [],
+    "remediation": "Revoke the GitLab token, review project/group access, and regenerate with the smallest scope possible.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "npm token exposed.",
+    "detector_id": "leak.npm_token",
+    "finding_type": "npm_token",
+    "flags": "gim",
+    "id": "npm_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bnpm_[A-Za-z0-9\\-_]{36}\\b",
+    "references": [],
+    "remediation": "Revoke the npm token and audit package publish activity.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "SendGrid API key exposed.",
+    "detector_id": "leak.sendgrid_api_key",
+    "finding_type": "sendgrid_api_key",
+    "flags": "gim",
+    "id": "sendgrid_api_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bSG\\.[A-Za-z0-9_-]{22}\\.[A-Za-z0-9_-]{43}\\b",
+    "references": [],
+    "remediation": "Rotate the SendGrid key and audit mail-sending activity for abuse.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "PyPI upload token exposed.",
+    "detector_id": "leak.pypi_upload_token",
+    "finding_type": "pypi_upload_token",
+    "flags": "gim",
+    "id": "pypi_upload_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9\\-_]{50,}\\b",
+    "references": [],
+    "remediation": "Revoke the PyPI token and audit package release history.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Database connection string with credentials exposed.",
+    "detector_id": "leak.database_url",
+    "finding_type": "database_url",
+    "flags": "gim",
+    "id": "database_url",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\b(?:postgres(?:ql)?|mysql(?:2)?|mongodb(?:\\+srv)?|redis)://[^\\s'\\\"<>]+:[^\\s'\\\"<>]+@[^\\s'\\\"<>]+",
+    "references": [],
+    "remediation": "Rotate database credentials, restrict network access, and move connection strings to server-only configuration.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Private key exposed.",
+    "detector_id": "leak.private_key",
+    "finding_type": "private_key",
+    "flags": "gim",
+    "id": "private_key",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "-----BEGIN (?:(?:RSA|DSA|EC|OPENSSH) )?PRIVATE KEY-----[\\s\\S]+?-----END (?:(?:RSA|DSA|EC|OPENSSH) )?PRIVATE KEY-----",
+    "references": [],
+    "remediation": "Revoke and rotate the key immediately, then audit every system where it was trusted.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "JWT found in browser-visible content.",
+    "detector_id": "leak.jwt_token",
+    "finding_type": "jwt_token",
+    "flags": "gim",
+    "id": "jwt_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\beyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b",
+    "references": [],
+    "remediation": "Confirm the token is short-lived, not logged or embedded, and does not expose sensitive claims.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Bearer token found in browser-visible content.",
+    "detector_id": "leak.bearer_token",
+    "finding_type": "bearer_token",
+    "flags": "gim",
+    "id": "bearer_token",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bbearer[\\s:=]+([A-Za-z0-9_\\-.]{20,})\\b",
+    "references": [],
+    "remediation": "Move bearer tokens out of static content and use short-lived session-bound tokens.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "HTTP Basic Auth credentials embedded in a URL.",
+    "detector_id": "leak.http_basic_auth",
+    "finding_type": "http_basic_auth",
+    "flags": "gim",
+    "id": "http_basic_auth",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bhttps?://([A-Za-z0-9_-]+):([^@\\s]+)@",
+    "references": [],
+    "remediation": "Rotate the credentials and replace URL-embedded credentials with a safer authentication mechanism.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "mcp",
+      "env",
+      "docker",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "MCP or agent tool credential exposed.",
+    "detector_id": "leak.mcp_config_secret",
+    "finding_type": "mcp_config_secret",
+    "flags": "gim",
+    "id": "mcp_config_secret",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "(?:mcp|modelcontextprotocol|tool|server).{0,80}(?:api[_-]?key|token|secret|password)[\\\"'\\s:=]+[\\\"']?([A-Za-z0-9_\\-./+=]{20,})",
+    "references": [],
+    "remediation": "Move agent/tool credentials to local secret storage and review connected tool permissions.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Prompt-injection style instruction found in content.",
+    "detector_id": "leak.hidden_prompt_injection",
+    "finding_type": "hidden_prompt_injection",
+    "flags": "gim",
+    "id": "hidden_prompt_injection",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "(?:ignore (?:all )?previous instructions|system prompt|developer message|exfiltrate|send (?:the )?(?:token|secret|api key)|hidden instruction)",
+    "references": [],
+    "remediation": "Treat untrusted content as data, isolate agent tools, and avoid giving browsing agents access to secrets.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "GraphQL introspection or schema content exposed.",
+    "detector_id": "leak.graphql_introspection_hint",
+    "finding_type": "graphql_introspection_hint",
+    "flags": "gim",
+    "id": "graphql_introspection_hint",
+    "min_match_length": 1,
+    "pack": "leak",
+    "pattern": "\\b(?:__schema|__type|IntrospectionQuery)\\b",
+    "references": [],
+    "remediation": "Confirm introspection is intentionally exposed and protected on production APIs.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps"
+    ],
+    "category": "leak",
+    "description": "Browser bundle references a source map.",
+    "detector_id": "leak.source_map_reference",
+    "finding_type": "source_map_reference",
+    "flags": "gim",
+    "id": "source_map_reference",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "sourceMappingURL=[^\\s'\\\"<>]+\\.map\\b",
+    "references": [],
+    "remediation": "Review generated source maps for embedded secrets and avoid publishing private source in production.",
+    "severity": "low",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs",
+      "code",
+      "config"
+    ],
+    "category": "leak",
+    "description": "package.json optionalDependencies points to a git commit SHA. This is the Mini Shai-Hulud (TanStack 2026) attack vector.",
+    "detector_id": "leak.npm_optional_dep_git_ref",
+    "finding_type": "npm_optional_dep_git_ref",
+    "flags": "gim",
+    "id": "npm_optional_dep_git_ref",
+    "min_match_length": 20,
+    "pack": "leak",
+    "pattern": "\\\"optionalDependencies\\\"\\s*:\\s*\\{[^}]*\\\"[^\\\"]+\\\"\\s*:\\s*\\\"(?:github:[^\\\"]+|git\\+(?:https?|ssh)://[^\\\"]+)#[a-f0-9]{7,40}",
+    "references": [
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem",
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"
+    ],
+    "remediation": "Remove the git-ref optionalDependency. Replace with a pinned semver from the registry or vendor the code in-tree.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "ci"
+    ],
+    "category": "leak",
+    "description": "GitHub Actions workflow uses pull_request_target. Informational only \u2014 the leak shape is `pull_request_target` + checkout of `head.ref`. See `gh_actions_pwn_request_head_ref`.",
+    "detector_id": "leak.gh_actions_pull_request_target",
+    "finding_type": "gh_actions_pull_request_target",
+    "flags": "gim",
+    "id": "gh_actions_pull_request_target",
+    "min_match_length": 12,
+    "pack": "leak",
+    "pattern": "(?:^|\\n)\\s*on\\s*:[\\s\\S]{0,400}\\bpull_request_target\\b",
+    "references": [
+      "https://securitylab.github.com/research/github-actions-preventing-pwn-requests/"
+    ],
+    "remediation": "If this workflow runs untrusted PR code: switch to `pull_request`. If it only reads PR metadata (labeler, CLA bot), this trigger is fine and you can suppress this notice.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "ci"
+    ],
+    "category": "leak",
+    "description": "GitHub Actions workflow combines pull_request_target with checkout of head.ref/head.sha \u2014 this is the Pwn Request pattern that compromised TanStack/Mini-Shai-Hulud.",
+    "detector_id": "leak.gh_actions_pwn_request_head_ref",
+    "finding_type": "gh_actions_pwn_request_head_ref",
+    "flags": "gim",
+    "id": "gh_actions_pwn_request_head_ref",
+    "min_match_length": 24,
+    "pack": "leak",
+    "pattern": "\\bpull_request_target\\b[\\s\\S]{0,4000}?actions/checkout[\\s\\S]{0,400}?ref\\s*:\\s*\\$\\{\\{\\s*github\\.event\\.pull_request\\.head\\.(?:ref|sha)\\s*\\}\\}",
+    "references": [
+      "https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"
+    ],
+    "remediation": "Move untrusted-code work into a separate `pull_request`-triggered workflow that has no secrets, and use `workflow_run` to pass artifacts only.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "ci"
+    ],
+    "category": "leak",
+    "description": "GitHub Actions workflow serializes all secrets via toJSON(secrets). Mini Shai-Hulud (2026) used this exact pattern to bulk-exfiltrate CI secrets.",
+    "detector_id": "leak.gh_actions_secrets_tojson",
+    "finding_type": "gh_actions_secrets_tojson",
+    "flags": "gim",
+    "id": "gh_actions_secrets_tojson",
+    "min_match_length": 12,
+    "pack": "leak",
+    "pattern": "toJSON\\(\\s*secrets\\s*\\)",
+    "references": [
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"
+    ],
+    "remediation": "Reference only the specific secrets the job needs (`${{ secrets.NPM_TOKEN }}`). Never pass the entire `secrets` object as JSON to a step.",
+    "severity": "high",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs",
+      "code"
+    ],
+    "category": "leak",
+    "description": "Mini Shai-Hulud command-and-control or exfiltration domain found.",
+    "detector_id": "leak.shai_hulud_c2_domain",
+    "finding_type": "shai_hulud_c2_domain",
+    "flags": "gim",
+    "id": "shai_hulud_c2_domain",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\b(?:filev2\\.getsession\\.org|seed[1-3]\\.getsession\\.org|api\\.masscan\\.cloud|git-tanstack\\.com)\\b",
+    "references": [
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem"
+    ],
+    "remediation": "Treat the host as compromised. Rotate every credential reachable from the affected machine or CI runner: AWS, GCP, Kubernetes, Vault, GitHub, npm, SSH. Then audit egress logs to confirm what left.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "code",
+      "config"
+    ],
+    "category": "leak",
+    "description": "package.json prepare/preinstall/postinstall script runs Bun or a TanStack-style payload file. Mini Shai-Hulud (2026) executed `bun run tanstack_runner.js && exit 1`.",
+    "detector_id": "leak.npm_prepare_bun_payload",
+    "finding_type": "npm_prepare_bun_payload",
+    "flags": "gim",
+    "id": "npm_prepare_bun_payload",
+    "min_match_length": 18,
+    "pack": "leak",
+    "pattern": "\\\"(?:prepare|preinstall|postinstall)\\\"\\s*:\\s*\\\"[^\\\"]*\\b(?:bun\\s+run|node\\s+(?:\\./)?(?:tanstack_runner|router_init|router_runtime))[^\\\"]*\\\"",
+    "references": [
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem"
+    ],
+    "remediation": "Inspect the script and the referenced JS file. If the file is bundled, opaque, or not in version control, treat the package as compromised. Add `--ignore-scripts` to your install command and switch to pnpm v10+ for default-off lifecycle execution.",
+    "severity": "high",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "env",
+      "ci",
+      "docker",
+      "mcp",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Webhook URL exposed.",
+    "detector_id": "leak.webhook_url",
+    "finding_type": "webhook_url",
+    "flags": "gim",
+    "id": "webhook_url",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\bhttps?://[^\\s'\\\"<>]+webhook[^\\s'\\\"<>]*",
+    "references": [],
+    "remediation": "Review whether the webhook is secret-bearing, rotate it if sensitive, and add authentication where possible.",
+    "severity": "medium",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Private network address exposed.",
+    "detector_id": "leak.private_ip",
+    "finding_type": "private_ip",
+    "flags": "gim",
+    "id": "private_ip",
+    "min_match_length": 8,
+    "pack": "leak",
+    "pattern": "\\b(?:10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.(?:1[6-9]|2[0-9]|3[0-1])\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3})\\b",
+    "references": [],
+    "remediation": "Review whether internal topology details should be visible in client-side content.",
+    "severity": "low",
+    "validation_status": "validated"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "leak",
+    "description": "Secret-in-logs lead found.",
+    "detector_id": "leak.secret_in_logs_lead",
+    "finding_type": "secret_in_logs",
+    "flags": "gim",
+    "id": "secret_in_logs_lead",
+    "min_match_length": 12,
+    "pack": "leak",
+    "pattern": "(?:console\\.log|logger\\.(?:debug|info|warn|error)|print\\s*\\()[\\s\\S]{0,120}(?:api[_-]?key|secret|token|password|authorization|cookie)",
+    "references": [],
+    "remediation": "Remove secrets from logs, redact sensitive fields at the logger boundary, and rotate any value that may already have been written.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "appsec",
+    "description": "SQL injection lead found in query construction or database error output.",
+    "detector_id": "appsec.sql_injection_lead",
+    "finding_type": "sql_injection",
+    "flags": "gim",
+    "id": "sql_injection_lead",
+    "min_match_length": 12,
+    "pack": "appsec",
+    "pattern": "(?:\\b(?:SELECT|UPDATE|DELETE|INSERT)\\b[\\s\\S]{0,160}(?:\\+\\s*(?:req|request|params|query|body|input|user)|\\$\\{[^}]+\\})|(?:sql|query)\\s*[:=]\\s*[`'\\\"][\\s\\S]{0,120}\\$\\{[^}]+\\}|(?:SQL syntax|mysql_fetch|PostgreSQL query failed|SQLiteException|ODBC SQL Server Driver))",
+    "references": [
+      "https://owasp.org/www-community/attacks/SQL_Injection"
+    ],
+    "remediation": "Parameterize the query, validate the input at the boundary, and re-test the endpoint with the launch gate after the fix.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "appsec",
+    "description": "XSS lead found where untrusted input can reach an HTML sink.",
+    "detector_id": "appsec.xss_sink_lead",
+    "finding_type": "xss",
+    "flags": "gim",
+    "id": "xss_sink_lead",
+    "min_match_length": 12,
+    "pack": "appsec",
+    "pattern": "(?:\\b(?:innerHTML|outerHTML)\\s*=\\s*(?:location|window\\.location|document\\.URL|[\\s\\S]{0,80}(?:searchParams|location\\.hash|message\\.data|postMessage))|document\\.write\\s*\\([\\s\\S]{0,120}(?:location|document\\.URL|message\\.data)|insertAdjacentHTML\\s*\\([\\s\\S]{0,160}(?:location|message\\.data|query|hash)|dangerouslySetInnerHTML\\s*=\\s*\\{\\{)",
+    "references": [
+      "https://owasp.org/www-community/attacks/xss/"
+    ],
+    "remediation": "Render untrusted values as text, sanitize unavoidable HTML with an allowlist sanitizer, and add a regression test for the sink.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "code",
+      "env",
+      "ci",
+      "docker",
+      "sourcemaps",
+      "logs",
+      "config"
+    ],
+    "category": "appsec",
+    "description": "Auth-bypass lead found in shipped code or config.",
+    "detector_id": "appsec.auth_bypass_lead",
+    "finding_type": "auth_bypass",
+    "flags": "gim",
+    "id": "auth_bypass_lead",
+    "min_match_length": 8,
+    "pack": "appsec",
+    "pattern": "\\b(?:disable[_-]?auth|skip[_-]?auth|bypass[_-]?auth|auth[_-]?disabled|ALLOW_ALL_USERS|requireAuth\\s*[:=]\\s*false|isAdmin\\s*[:=]\\s*true|TODO:?[\\s\\S]{0,60}(?:auth|authorization|permission))\\b",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Remove bypass flags from production paths, enforce server-side authorization, and add an auth regression test.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs"
+    ],
+    "category": "access-control",
+    "description": "Direct object reference lead found in a sensitive resource path or parameter.",
+    "detector_id": "access-control.idor_direct_object_lead",
+    "finding_type": "idor",
+    "flags": "gim",
+    "id": "idor_direct_object_lead",
+    "min_match_length": 6,
+    "pack": "access-control",
+    "pattern": "(?:/(?:users?|accounts?|customers?|tenants?|organizations?|orgs?|projects?|orders?)/[0-9a-fA-F-]{6,}|(?:user|account|customer|tenant|organization|project|order)[_-]?id\\s*[:=]\\s*[`'\\\"]?\\$\\{?[^`'\\\"\\s}]+)",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Verify object ownership on the server with tenant/user scoped queries and re-test with two throwaway users.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "code",
+      "sourcemaps",
+      "logs",
+      "config"
+    ],
+    "category": "access-control",
+    "description": "Missing tenant or ownership-check lead found.",
+    "detector_id": "access-control.missing_tenant_check_lead",
+    "finding_type": "missing_tenant_check",
+    "flags": "gim",
+    "id": "missing_tenant_check_lead",
+    "min_match_length": 8,
+    "pack": "access-control",
+    "pattern": "(?:TODO:?[\\s\\S]{0,80}(?:tenant|ownership|authorization|permission)|(?:tenant|org|organization|workspace|account)[_-]?id[\\s\\S]{0,80}(?:optional|nullable|skip|TODO|FIXME))",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Make the tenant boundary mandatory in server-side queries and add a cross-tenant negative test.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "category": "baas",
+    "description": "Supabase project URL exposed in client bundle.",
+    "detector_id": "baas.supabase_url",
+    "finding_type": "supabase_url",
+    "flags": "gim",
+    "id": "supabase_url",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\bhttps://[a-z0-9]{20,}\\.supabase\\.co\\b",
+    "references": [
+      "https://supabase.com/docs/guides/auth/row-level-security"
+    ],
+    "remediation": "Verify RLS policies are enforced on all tables. Run `keyleak browser-scan` with BaaS validation to confirm.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "category": "baas",
+    "description": "Supabase anon/publishable key (JWT format) exposed in client bundle.",
+    "detector_id": "baas.supabase_anon_key",
+    "finding_type": "supabase_anon_key",
+    "flags": "gim",
+    "id": "supabase_anon_key",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\beyJ[A-Za-z0-9_-]{30,}\\.eyJ[A-Za-z0-9_-]{30,}\\.[A-Za-z0-9_-]{20,}\\b",
+    "references": [
+      "https://supabase.com/docs/guides/api#api-keys"
+    ],
+    "remediation": "Anon keys are designed for client use, but confirm RLS policies protect every table.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "category": "baas",
+    "description": "Supabase publishable key (non-standard format) exposed in client bundle.",
+    "detector_id": "baas.supabase_publishable_key",
+    "finding_type": "supabase_publishable_key",
+    "flags": "gim",
+    "id": "supabase_publishable_key",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\bsb_publishable_[A-Za-z0-9_-]{20,}\\b",
+    "references": [],
+    "remediation": "Confirm RLS policies protect every table. Run BaaS validation to test.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "category": "baas",
+    "description": "Firebase client configuration with API key exposed in client bundle.",
+    "detector_id": "baas.firebase_client_config",
+    "finding_type": "firebase_client_config",
+    "flags": "gim",
+    "id": "firebase_client_config",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "apiKey['\\\"\\s:=]+AIza[0-9A-Za-z_-]{35}",
+    "references": [
+      "https://firebase.google.com/docs/rules"
+    ],
+    "remediation": "Firebase client config is designed for client use, but verify Firestore Security Rules and Storage Rules deny unauthorized access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "Client-side admin/role check found. Authorization decisions in browser JS are trivially bypassable.",
+    "detector_id": "baas.client_side_admin_check",
+    "finding_type": "client_side_admin_check",
+    "flags": "gim",
+    "id": "client_side_admin_check",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "(?:is_admin|isAdmin|is_superuser|isSuperuser)\\s*(?:===?\\s*(?:true|!0)|!==?\\s*(?:false|!1))",
+    "references": [
+      "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"
+    ],
+    "remediation": "Move all authorization checks to the server. Use Supabase RLS policies or Firebase Security Rules to enforce admin-only access.",
+    "severity": "high",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "BaaS table query uses select('*'), fetching all columns including potentially sensitive ones.",
+    "detector_id": "baas.baas_select_star",
+    "finding_type": "baas_select_star",
+    "flags": "gim",
+    "id": "baas_select_star",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\.from\\(['\\\"][a-z_][a-z0-9_]*['\\\"]\\)[\\s\\S]{0,60}\\.select\\(['\\\"]?\\*['\\\"]?\\)",
+    "references": [],
+    "remediation": "Specify only the columns you need in select(). This reduces data exposure and improves performance.",
+    "severity": "low",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "BaaS table name referenced in client bundle.",
+    "detector_id": "baas.baas_table_reference",
+    "finding_type": "baas_table_reference",
+    "flags": "gim",
+    "id": "baas_table_reference",
+    "min_match_length": 1,
+    "pack": "baas",
+    "pattern": "\\.from\\(['\\\"]([a-z_][a-z0-9_]{1,62})['\\\"]\\)",
+    "references": [],
+    "remediation": "Review whether this table's RLS policies are correctly configured.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "BaaS RPC function called from client bundle.",
+    "detector_id": "baas.baas_rpc_call",
+    "finding_type": "baas_rpc_call",
+    "flags": "gim",
+    "id": "baas_rpc_call",
+    "min_match_length": 1,
+    "pack": "baas",
+    "pattern": "\\.rpc\\(['\\\"]([a-z_][a-z0-9_]{1,62})['\\\"]",
+    "references": [],
+    "remediation": "Verify this RPC function validates caller identity and rate-limits requests.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "BaaS storage bucket referenced in client bundle.",
+    "detector_id": "baas.baas_storage_bucket",
+    "finding_type": "baas_storage_bucket",
+    "flags": "gim",
+    "id": "baas_storage_bucket",
+    "min_match_length": 1,
+    "pack": "baas",
+    "pattern": "\\.storage\\.from\\(['\\\"]([a-z0-9_-]{1,62})['\\\"]\\)",
+    "references": [],
+    "remediation": "Verify storage bucket policies restrict who can upload, download, and list objects.",
+    "severity": "low",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "category": "baas",
+    "description": "Firebase Realtime Database URL exposed in client bundle.",
+    "detector_id": "baas.firebase_db_url",
+    "finding_type": "firebase_db_url",
+    "flags": "gim",
+    "id": "firebase_db_url",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\bhttps://[a-z0-9-]+\\.firebaseio\\.com\\b",
+    "references": [
+      "https://firebase.google.com/docs/database/security"
+    ],
+    "remediation": "Verify Firebase Security Rules deny unauthorized read/write access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "env"
+    ],
+    "category": "baas",
+    "description": "Firebase/GCP storage bucket referenced in client bundle.",
+    "detector_id": "baas.firebase_storage_bucket",
+    "finding_type": "firebase_storage_bucket",
+    "flags": "gim",
+    "id": "firebase_storage_bucket",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\b[a-z0-9-]+\\.appspot\\.com\\b",
+    "references": [],
+    "remediation": "Verify Cloud Storage security rules restrict access.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "Appwrite API endpoint exposed in client bundle.",
+    "detector_id": "baas.appwrite_endpoint",
+    "finding_type": "appwrite_endpoint",
+    "flags": "gim",
+    "id": "appwrite_endpoint",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\.setEndpoint\\(['\\\"]https?://[^'\\\"]+/v1['\\\"]\\)",
+    "references": [],
+    "remediation": "Verify Appwrite collection permissions deny unauthorized access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "PocketBase instance URL exposed in client bundle.",
+    "detector_id": "baas.pocketbase_url",
+    "finding_type": "pocketbase_url",
+    "flags": "gim",
+    "id": "pocketbase_url",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "new PocketBase\\(['\\\"]https?://[^'\\\"]+['\\\"]\\)",
+    "references": [],
+    "remediation": "Verify PocketBase collection API rules restrict access.",
+    "severity": "medium",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "BaaS insert/upsert mutation found in client code.",
+    "detector_id": "baas.baas_insert_call",
+    "finding_type": "baas_insert_call",
+    "flags": "gim",
+    "id": "baas_insert_call",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\.(?:insert|upsert)\\(",
+    "references": [],
+    "remediation": "Verify RLS policies restrict who can write to this table.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "BaaS delete mutation found in client code.",
+    "detector_id": "baas.baas_delete_call",
+    "finding_type": "baas_delete_call",
+    "flags": "gim",
+    "id": "baas_delete_call",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\.delete\\(\\)",
+    "references": [],
+    "remediation": "Verify RLS policies restrict who can delete from this table.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "Password-based authentication flow detected in client code.",
+    "detector_id": "baas.baas_password_auth",
+    "finding_type": "baas_password_auth",
+    "flags": "gim",
+    "id": "baas_password_auth",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "signInWithPassword",
+    "references": [],
+    "remediation": "Ensure password policies, rate limiting, and email confirmation are configured.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "Supabase Realtime channel subscription in client code.",
+    "detector_id": "baas.baas_realtime_channel",
+    "finding_type": "baas_realtime_channel",
+    "flags": "gim",
+    "id": "baas_realtime_channel",
+    "min_match_length": 1,
+    "pack": "baas",
+    "pattern": "\\.channel\\(['\\\"]([^'\\\"]+)['\\\"]\\)",
+    "references": [],
+    "remediation": "Verify channel policies restrict who can subscribe.",
+    "severity": "info",
+    "validation_status": "lead"
+  },
+  {
+    "capture_group": 0,
+    "categories": [
+      "sourcemaps",
+      "code"
+    ],
+    "category": "baas",
+    "description": "Supabase Realtime postgres_changes subscription in client code.",
+    "detector_id": "baas.baas_realtime_subscribe",
+    "finding_type": "baas_realtime_subscribe",
+    "flags": "gim",
+    "id": "baas_realtime_subscribe",
+    "min_match_length": 8,
+    "pack": "baas",
+    "pattern": "\\.on\\(['\\\"]postgres_changes['\\\"]",
+    "references": [],
+    "remediation": "Verify RLS policies apply to realtime subscriptions.",
+    "severity": "info",
+    "validation_status": "lead"
+  }
+];
 
-  // --- Service Credentials ---
-  stripe_key:             { pattern: /(?:sk|pk)_(?:test|live)_[0-9a-zA-Z]{24,99}/g, severity: 'high', description: 'Stripe API Key' },
-  stripe_restricted_key:  { pattern: /rk_(?:test|live)_[0-9a-zA-Z]{24,}/g, severity: 'high', description: 'Stripe Restricted Key' },
-  slack_token:            { pattern: /xox[baprs]-[0-9]{10,13}-[0-9]{10,13}-[a-zA-Z0-9]{24,32}/g, severity: 'high', description: 'Slack Token' },
-  slack_webhook:          { pattern: /https:\/\/hooks\.slack\.com\/services\/T[a-zA-Z0-9_]+\/B[a-zA-Z0-9_]+\/[a-zA-Z0-9_]+/g, severity: 'high', description: 'Slack Webhook URL' },
-  github_pat:             { pattern: /ghp_[0-9a-zA-Z]{36}/g, severity: 'high', description: 'GitHub Personal Access Token' },
-  github_fine_grained_pat:{ pattern: /github_pat_[0-9a-zA-Z_]{82}/g, severity: 'high', description: 'GitHub Fine-Grained PAT' },
-  github_oauth:           { pattern: /gho_[0-9a-zA-Z]{36}/g, severity: 'high', description: 'GitHub OAuth Token' },
-  gitlab_token:           { pattern: /glpat-[0-9a-zA-Z\-]{20}/g, severity: 'high', description: 'GitLab Token' },
-  npm_token:              { pattern: /npm_[a-zA-Z0-9\-_]{36}/g, severity: 'high', description: 'npm Token' },
-  sendgrid_api_key:       { pattern: /SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}/g, severity: 'high', description: 'SendGrid API Key' },
-  square_access_token:    { pattern: /sq0atp-[0-9A-Za-z\-_]{22}/g, severity: 'high', description: 'Square Access Token' },
-  square_oauth_secret:    { pattern: /sq0csp-[0-9A-Za-z\-_]{43}/g, severity: 'high', description: 'Square OAuth Secret' },
-  pypi_upload_token:      { pattern: /pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,}/g, severity: 'high', description: 'PyPI Upload Token' },
-  mailgun_api_key:        { pattern: /key-[0-9a-zA-Z]{32}/g, severity: 'high', description: 'Mailgun API Key' },
-  mailchimp_api_key:      { pattern: /[0-9a-f]{32}-us[0-9]{1,2}/g, severity: 'high', description: 'Mailchimp API Key' },
-  twilio_api_key:         { pattern: /SK[0-9a-fA-F]{32}/g, severity: 'high', description: 'Twilio API Key' },
-
-  // --- LLM / AI Provider Keys ---
-  openai_api_key:         { pattern: /sk-(?:proj-)?[a-zA-Z0-9]{20,}/g, severity: 'high', description: 'OpenAI API Key' },
-  anthropic_api_key:      { pattern: /sk-ant-[a-zA-Z0-9\-_]{95,}/g, severity: 'high', description: 'Anthropic API Key' },
-  huggingface_token:      { pattern: /hf_[a-zA-Z0-9]{32,}/g, severity: 'high', description: 'Hugging Face Token' },
-  openrouter_api_key:     { pattern: /sk-or-v1-[a-zA-Z0-9]{64,}/g, severity: 'high', description: 'OpenRouter API Key' },
-  replicate_api_key:      { pattern: /r8_[a-zA-Z0-9]{40,}/g, severity: 'high', description: 'Replicate API Key' },
-  perplexity_api_key:     { pattern: /pplx-[a-zA-Z0-9]{40,}/g, severity: 'high', description: 'Perplexity AI API Key' },
-  anyscale_api_key:       { pattern: /esecret_[a-zA-Z0-9]{40,}/g, severity: 'high', description: 'Anyscale API Key' },
-  groq_api_key:           { pattern: /gsk_[a-zA-Z0-9]{52}/g, severity: 'high', description: 'Groq API Key' },
-
-  // --- Database Credentials ---
-  mongo_uri:              { pattern: /mongodb(?:\+srv)?:\/\/[a-zA-Z0-9_]+:[a-zA-Z0-9_]+@[a-zA-Z0-9\-.]+\/\w+/g, severity: 'medium', description: 'MongoDB Connection String' },
-  postgres_uri:           { pattern: /postgres(?:ql)?:\/\/[a-zA-Z0-9_]+:[^@\s]+@[a-zA-Z0-9\-.]+:[0-9]+\/\w+/g, severity: 'medium', description: 'PostgreSQL Connection String' },
-  mysql_uri:              { pattern: /mysql(?:2)?:\/\/[a-zA-Z0-9_]+:[^@\s]+@[a-zA-Z0-9\-.]+:[0-9]+\/\w+/g, severity: 'medium', description: 'MySQL Connection String' },
-  redis_uri:              { pattern: /redis(?:\+srv)?:\/\/[a-zA-Z0-9_]+:[^@\s]+@[a-zA-Z0-9\-.]+:[0-9]+\/\w+/g, severity: 'medium', description: 'Redis Connection String' },
-
-  // --- Authentication ---
-  jwt_token:              { pattern: /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, severity: 'medium', description: 'JWT Token' },
-  bearer_token:           { pattern: /bearer[\s=:]+([a-zA-Z0-9_\-]{20,})/gi, severity: 'medium', description: 'Bearer Token' },
-  basic_auth:             { pattern: /basic[\s=:]+([a-zA-Z0-9+/=]+)/gi, severity: 'medium', description: 'Basic Auth Credentials' },
-  api_key:                { pattern: /(?:api[_-]?key|apikey|api[_-]?token|api[_-]?secret)[=: ]*['"]?([a-z0-9_\-]{20,})['"]?/gi, severity: 'medium', description: 'API Key' },
-  session_token:          { pattern: /session[_-]?token[=: ]*['"]?([a-f0-9]{64})['"]?/gi, severity: 'medium', description: 'Session Token' },
-
-  // --- Sensitive Data ---
-  private_key:            { pattern: /-----BEGIN (?:RSA|DSA|EC|PGP|OPENSSH) PRIVATE KEY[\s\S]*?-----END (?:RSA|DSA|EC|PGP|OPENSSH) PRIVATE KEY-----/g, severity: 'high', description: 'Private Key' },
-  credit_card:            { pattern: /\b(?:4[0-9]{12}(?:[0-9]{3})?|(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})\b/g, severity: 'high', description: 'Credit Card Number' },
-  private_ip:             { pattern: /\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g, severity: 'medium', description: 'Private IP Address' },
-
-  // --- Sensitive URLs ---
-  webhook_url:            { pattern: /https?:\/\/[^\s'"]+webhook[^\s'"]+/gi, severity: 'medium', description: 'Webhook URL' },
-  http_basic_auth:        { pattern: /(?:https?:\/\/)([a-zA-Z0-9_-]+):([^@\s]+)@/gi, severity: 'medium', description: 'HTTP Basic Auth in URL' },
-};
-
-// Pre-compile all patterns once
+const PATTERNS = {};
 const COMPILED_PATTERNS = {};
-for (const [name, entry] of Object.entries(PATTERNS)) {
+
+for (const definition of PATTERN_DEFINITIONS) {
   try {
-    // Clone the regex to ensure fresh lastIndex on each use
-    COMPILED_PATTERNS[name] = entry;
-  } catch (e) {
-    console.warn(`[KeyLeak] Skipping invalid pattern: ${name}`, e);
+    const entry = {
+      id: definition.id,
+      detector_id: definition.detector_id,
+      finding_type: definition.finding_type || definition.id,
+      pattern: new RegExp(definition.pattern, definition.flags),
+      severity: definition.severity,
+      description: definition.description,
+      remediation: definition.remediation,
+      pack: definition.pack || definition.category || 'leak',
+      category: definition.category || definition.pack || 'leak',
+      categories: definition.categories || [],
+      min_match_length: definition.min_match_length || 8,
+      capture_group: definition.capture_group || 0,
+      validation_status: definition.validation_status || 'lead',
+      references: definition.references || [],
+    };
+    PATTERNS[definition.id] = entry;
+    COMPILED_PATTERNS[definition.id] = entry;
+  } catch (error) {
+    console.warn(`[KeyLeak] Skipping invalid detector pattern: ${definition.id}`, error);
   }
 }
 
-export { PATTERNS, COMPILED_PATTERNS };
+export { PATTERN_DEFINITIONS, PATTERNS, COMPILED_PATTERNS };

--- a/extension/lib/reporting.js
+++ b/extension/lib/reporting.js
@@ -1,0 +1,334 @@
+const SEVERITY_ORDER = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+const SECRET_QUERY_KEYS = new Set([
+  'access_token',
+  'api_key',
+  'apikey',
+  'auth',
+  'authorization',
+  'client_secret',
+  'code',
+  'cookie',
+  'key',
+  'password',
+  'refresh_token',
+  'secret',
+  'session',
+  'token',
+]);
+
+export function normalizeSeverity(severity) {
+  const value = String(severity || 'info').toLowerCase();
+  return Object.prototype.hasOwnProperty.call(SEVERITY_ORDER, value) ? value : 'info';
+}
+
+export function severityRank(severity) {
+  return SEVERITY_ORDER[normalizeSeverity(severity)];
+}
+
+export function confidenceForSeverity(severity, source = '') {
+  const normalized = normalizeSeverity(severity);
+  if (normalized === 'critical' || normalized === 'high') return 0.9;
+  if (normalized === 'medium') return 0.7;
+  const sourceText = String(source || '').toLowerCase();
+  if (sourceText.includes('url') || sourceText.includes('header')) return 0.65;
+  return 0.55;
+}
+
+export function redactValue(value, keepStart = 12, keepEnd = 6) {
+  if (value === undefined || value === null) return '';
+  const text = String(value).trim();
+  if (!text) return '';
+  if (text.length <= 24) return text;
+  return `${text.slice(0, keepStart)}...${text.slice(-keepEnd)}`;
+}
+
+export function redactSnippet(snippet, rawValue = '') {
+  const text = String(snippet || '');
+  const rawText = String(rawValue || '');
+  if (!text) return '';
+  if (rawText && text.includes(rawText)) {
+    return text.split(rawText).join(redactValue(rawText));
+  }
+  return text;
+}
+
+export function redactUrl(url) {
+  const text = String(url || '');
+  if (!text) return '';
+  return text.replace(/([?&])([^=&]+)=([^&#]+)/g, (match, separator, key, rawValue) => {
+    if (!SECRET_QUERY_KEYS.has(String(key).toLowerCase())) return match;
+    return `${separator}${key}=${redactValue(rawValue)}`;
+  });
+}
+
+export function stableId(parts, prefix = 'finding') {
+  const payload = parts.map(part => (part === undefined || part === null ? '' : String(part))).join('\n');
+  let hash = 2166136261;
+  for (let index = 0; index < payload.length; index += 1) {
+    hash ^= payload.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${prefix}_${(hash >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+export function normalizeFinding(raw) {
+  const severity = normalizeSeverity(raw.severity);
+  const source = raw.source || raw.evidence?.source || 'unknown';
+  const rawValue = raw.raw_value ?? raw.value ?? raw.match ?? '';
+  const redactedValue = raw.redacted_value || raw.evidence?.redacted_value || redactValue(rawValue);
+  const requestUrl = redactUrl(raw.url || raw.request_url || raw.evidence?.request_url || '');
+  const snippet = redactSnippet(raw.context || raw.snippet || raw.evidence?.snippet || '', rawValue);
+  const detectorId = raw.detector_id || `runtime:${raw.type || 'unknown'}`;
+  const category = raw.category || raw.pack || (String(detectorId).includes('.') ? String(detectorId).split('.')[0] : 'leak');
+
+  const evidence = {
+    source,
+    snippet,
+    line: raw.line ?? null,
+    request_url: requestUrl,
+    response_status: raw.status ?? raw.status_code ?? raw.evidence?.response_status ?? null,
+    redacted_value: redactedValue,
+  };
+
+  const id = raw.id || stableId([
+    raw.type || 'unknown',
+    detectorId,
+    source,
+    redactedValue,
+    evidence.line,
+    requestUrl,
+  ]);
+
+  return {
+    id,
+    type: raw.type || 'unknown',
+    severity,
+    confidence: raw.confidence ?? confidenceForSeverity(severity, source),
+    detector_id: detectorId,
+    category,
+    source,
+    evidence,
+    redacted_value: redactedValue,
+    raw_value: rawValue ? String(rawValue).slice(0, 1000) : '',
+    risk_reason: raw.risk_reason || raw.description || `${raw.type || 'Secret'} detected in ${source}.`,
+    remediation: raw.remediation || raw.recommendation || 'Review this finding and remove exposed sensitive data.',
+    references: raw.references || [],
+    validation_status: raw.validation_status || 'lead',
+    timestamp: raw.timestamp || Date.now(),
+    content_type: raw.contentType || raw.content_type || '',
+    url: requestUrl,
+    capture_type: raw.capture_type || raw.captureType || '',
+  };
+}
+
+export function summarizeFindings(findings) {
+  const summary = {
+    total_findings: findings.length,
+    critical_severity: 0,
+    high_severity: 0,
+    medium_severity: 0,
+    low_severity: 0,
+    info_severity: 0,
+  };
+
+  for (const finding of findings) {
+    const key = `${normalizeSeverity(finding.severity)}_severity`;
+    summary[key] = (summary[key] || 0) + 1;
+  }
+  return summary;
+}
+
+export function verdictForFindings(findings) {
+  const summary = summarizeFindings(findings);
+  if (summary.critical_severity || summary.high_severity) {
+    return {
+      status: 'BLOCK_SHIP',
+      label: 'BLOCK SHIP',
+      reason: 'Critical or high-confidence exposures need fixing before release.',
+    };
+  }
+  if (summary.medium_severity) {
+    return {
+      status: 'REVIEW',
+      label: 'REVIEW',
+      reason: 'Potential exposures or launch risks need human review.',
+    };
+  }
+  return {
+    status: 'SAFE_TO_SHIP',
+    label: 'SAFE TO SHIP',
+    reason: 'No medium, high, or critical findings were detected in the covered browser surfaces.',
+  };
+}
+
+export function buildReport(target, findings, stats = {}, extra = {}) {
+  const normalizedFindings = findings.map(finding => normalizeFinding(finding))
+    .sort((left, right) => severityRank(right.severity) - severityRank(left.severity));
+  const reportFindings = normalizedFindings.map((finding) => {
+    const { raw_value: _rawValue, ...safeFinding } = finding;
+    return safeFinding;
+  });
+
+  const packs = extra.packs || ['leak', 'appsec', 'access-control'];
+  return {
+    target: redactUrl(target || ''),
+    scan_mode: 'extension-launch-gate',
+    generated_at: new Date().toISOString(),
+    verdict: verdictForFindings(reportFindings),
+    summary: summarizeFindings(reportFindings),
+    retest_command: target ? `keyleak scan ${redactUrl(target)}` : 'keyleak scan <url>',
+    findings: reportFindings,
+    coverage: coverageForStats(stats),
+    packs,
+    pack_summary: summarizeByCategory(reportFindings, packs),
+    profile: 'launch-gate',
+    ...extra,
+  };
+}
+
+export function summarizeByCategory(findings, packs = []) {
+  const summary = {};
+  for (const pack of packs) {
+    summary[pack] = {
+      total_findings: 0,
+      critical_severity: 0,
+      high_severity: 0,
+      medium_severity: 0,
+      low_severity: 0,
+      info_severity: 0,
+    };
+  }
+  for (const finding of findings) {
+    const category = finding.category || 'leak';
+    if (!summary[category]) {
+      summary[category] = {
+        total_findings: 0,
+        critical_severity: 0,
+        high_severity: 0,
+        medium_severity: 0,
+        low_severity: 0,
+        info_severity: 0,
+      };
+    }
+    summary[category].total_findings += 1;
+    const key = `${normalizeSeverity(finding.severity)}_severity`;
+    summary[category][key] = (summary[category][key] || 0) + 1;
+  }
+  return summary;
+}
+
+export function coverageForStats(stats = {}) {
+  const covered = [];
+  if (stats.requests) covered.push('headers and URLs');
+  if (stats.bodies) covered.push('fetch/XHR bodies');
+  if (stats.externalScripts) covered.push('external scripts');
+  if (stats.sourceMaps) covered.push('source maps');
+  if (stats.scripts) covered.push('inline scripts');
+  if (stats.dataAttrs) covered.push('data attributes');
+  if (stats.metaTags) covered.push('meta tags');
+  if (stats.storage) covered.push('browser storage');
+  if (stats.websockets) covered.push('WebSocket messages');
+  if (stats.eventStreams) covered.push('EventSource/SSE messages');
+  if (stats.devtoolsBodies) covered.push('DevTools network bodies');
+
+  return {
+    level: covered.length >= 4 ? 'strong' : covered.length > 0 ? 'partial' : 'waiting',
+    covered,
+    note: covered.length
+      ? 'Extension results are based on covered browser runtime surfaces; use full scan for attack surface checks.'
+      : 'Browse or run a full local scan to collect launch-gate evidence.',
+  };
+}
+
+export function formatMarkdownReport(report) {
+  const lines = [
+    `# KeyLeak Extension Report: ${report.verdict.label}`,
+    '',
+    `- Target: \`${report.target || 'unknown'}\``,
+    `- Packs: \`${(report.packs || []).join(', ') || 'none'}\``,
+    `- Generated: \`${report.generated_at}\``,
+    `- Reason: ${report.verdict.reason}`,
+    `- Re-test: \`${report.retest_command}\``,
+    '',
+    '## Coverage',
+    report.coverage.covered.length ? report.coverage.covered.map(item => `- ${item}`).join('\n') : '- No browser surfaces covered yet.',
+    '',
+    '## Findings',
+  ];
+
+  if (!report.findings.length) {
+    lines.push('No findings detected in covered browser surfaces.');
+    return lines.join('\n');
+  }
+
+  for (const finding of report.findings) {
+    lines.push(
+      '',
+      `### ${finding.severity.toUpperCase()}: ${finding.type}`,
+      `- ID: \`${finding.id}\``,
+      `- Detector: \`${finding.detector_id}\``,
+      `- Pack: \`${finding.category || 'unknown'}\``,
+      `- Source: \`${finding.source}\``,
+      `- Evidence: \`${finding.evidence.redacted_value}\``,
+      `- Why it matters: ${finding.risk_reason}`,
+      `- Fix: ${finding.remediation}`,
+      `- Validation: \`${finding.validation_status}\``,
+    );
+  }
+  return lines.join('\n');
+}
+
+export function formatSarifReport(report) {
+  const rules = new Map();
+  const results = [];
+
+  for (const finding of report.findings) {
+    rules.set(finding.detector_id, {
+      id: finding.detector_id,
+      name: finding.type,
+      shortDescription: { text: finding.type },
+      fullDescription: { text: finding.risk_reason },
+      help: { text: finding.remediation },
+      properties: { category: finding.category || '' },
+    });
+    results.push({
+      ruleId: finding.detector_id,
+      level: finding.severity === 'critical' || finding.severity === 'high' ? 'error' : finding.severity === 'medium' ? 'warning' : 'note',
+      message: { text: finding.risk_reason },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: { uri: finding.source },
+            region: { startLine: finding.evidence.line || 1 },
+          },
+        },
+      ],
+      partialFingerprints: { findingId: finding.id },
+      properties: { category: finding.category || '' },
+    });
+  }
+
+  return JSON.stringify({
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    version: '2.1.0',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'KeyLeak Detector Chrome Extension',
+            informationUri: 'https://github.com/Amal-David/keyleak-detector',
+            rules: Array.from(rules.values()),
+          },
+        },
+        results,
+      },
+    ],
+  }, null, 2);
+}

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -172,6 +172,19 @@
     .test-error { color: #fca5a5; }
     .test-pending { color: #fcd34d; }
     .test-btn { color: #34d399 !important; border-color: #059669 !important; font-weight: 700; }
+    .jwt-decode { margin-top: 4px; padding: 6px 8px; background: #0c1222; border-radius: 4px; border: 1px solid #1e293b; }
+    .jwt-header { font-size: 9px; font-weight: 700; color: #4dabf7; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
+    .jwt-flag { font-size: 10px; line-height: 1.5; padding: 1px 0; }
+    .flag-level { font-size: 8px; font-weight: 700; padding: 1px 4px; border-radius: 2px; margin-right: 4px; }
+    .flag-claim { color: #94a3b8; margin-right: 4px; }
+    .flag-critical { color: #fca5a5; }
+    .flag-critical .flag-level { background: #7f1d1d; color: #fca5a5; }
+    .flag-high { color: #fcd34d; }
+    .flag-high .flag-level { background: #78350f; color: #fcd34d; }
+    .flag-medium { color: #93c5fd; }
+    .flag-medium .flag-level { background: #1e3a5f; color: #93c5fd; }
+    .flag-info { color: #64748b; }
+    .flag-info .flag-level { background: #1e293b; color: #64748b; }
     .fix {
       margin-top: 6px;
       padding: 7px;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -166,6 +166,12 @@
     .finding-locations li { margin: 2px 0; line-height: 1.4; }
     .finding-locations .source-link { color: #4dabf7; text-decoration: none; font-size: 10px; }
     .finding-locations .source-link:hover { text-decoration: underline; }
+    .test-result { margin-top: 6px; font-size: 10px; line-height: 1.4; }
+    .test-valid { color: #34d399; font-weight: 700; }
+    .test-invalid { color: #94a3b8; }
+    .test-error { color: #fca5a5; }
+    .test-pending { color: #fcd34d; }
+    .test-btn { color: #34d399 !important; border-color: #059669 !important; font-weight: 700; }
     .fix {
       margin-top: 6px;
       padding: 7px;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -5,8 +5,8 @@
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      width: 400px;
-      max-height: 500px;
+      width: 430px;
+      max-height: 620px;
       font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
       font-size: 12px;
       background: #0f172a;
@@ -19,17 +19,14 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 8px;
       background: #0f172a;
       position: sticky;
       top: 0;
       z-index: 10;
     }
-    .header h1 {
-      font-size: 13px;
-      font-weight: 700;
-      color: #34d399;
-    }
-    .header .count {
+    h1 { font-size: 13px; font-weight: 700; color: #34d399; }
+    .count {
       font-size: 11px;
       padding: 2px 8px;
       border-radius: 4px;
@@ -38,65 +35,73 @@
     .count-zero { background: #064e3b; color: #34d399; }
     .count-warn { background: #78350f; color: #fbbf24; }
     .count-danger { background: #7f1d1d; color: #f87171; }
-    .clear-btn {
+    button {
       background: none;
       border: 1px solid #334155;
-      color: #64748b;
-      padding: 2px 8px;
+      color: #94a3b8;
+      padding: 4px 8px;
       border-radius: 4px;
       cursor: pointer;
       font-family: inherit;
       font-size: 10px;
     }
-    .clear-btn:hover { border-color: #64748b; color: #94a3b8; }
-    .status {
-      padding: 16px;
-      text-align: center;
-      color: #64748b;
+    button:hover { border-color: #64748b; color: #e2e8f0; }
+    button.primary { background: #059669; border-color: #34d399; color: #031412; font-weight: 700; }
+    button.danger { color: #fca5a5; border-color: #7f1d1d; }
+    .verdict {
+      padding: 12px 16px;
+      border-bottom: 1px solid #1e293b;
+      display: grid;
+      gap: 8px;
     }
-    .status .icon { font-size: 24px; margin-bottom: 8px; }
-    .finding {
+    .verdict-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
+    .verdict-badge {
+      display: inline-block;
+      padding: 3px 8px;
+      border-radius: 999px;
+      border: 1px solid #334155;
+      font-size: 10px;
+      font-weight: 700;
+    }
+    .verdict-safe { background: #064e3b; color: #6ee7b7; border-color: #059669; }
+    .verdict-review { background: #78350f; color: #fcd34d; border-color: #d97706; }
+    .verdict-block { background: #7f1d1d; color: #fca5a5; border-color: #dc2626; }
+    .reason { color: #cbd5e1; line-height: 1.4; }
+    .target { color: #64748b; word-break: break-all; font-size: 10px; }
+    .actions {
       padding: 10px 16px;
       border-bottom: 1px solid #1e293b;
-      cursor: default;
-    }
-    .finding:hover { background: #1e293b; }
-    .finding-header {
       display: flex;
-      align-items: center;
-      gap: 8px;
-      margin-bottom: 4px;
+      flex-wrap: wrap;
+      gap: 6px;
     }
-    .severity-badge {
-      font-size: 9px;
+    .status-line {
+      padding: 8px 16px;
+      border-bottom: 1px solid #1e293b;
+      color: #64748b;
+      font-size: 10px;
+      line-height: 1.4;
+      display: none;
+    }
+    .coverage, .scan-stats {
+      padding: 10px 16px;
+      border-bottom: 1px solid #1e293b;
+      font-size: 10px;
+      line-height: 1.5;
+    }
+    .section-label {
+      color: #475569;
       font-weight: 700;
-      padding: 1px 6px;
-      border-radius: 3px;
       text-transform: uppercase;
       letter-spacing: 0.5px;
+      margin-bottom: 5px;
     }
-    .sev-high { background: #7f1d1d; color: #fca5a5; }
-    .sev-medium { background: #78350f; color: #fcd34d; }
-    .sev-low { background: #1e3a5f; color: #93c5fd; }
-    .finding-type {
-      font-size: 11px;
-      font-weight: 600;
-      color: #e2e8f0;
-    }
-    .finding-value {
-      font-size: 10px;
-      color: #34d399;
-      background: #0c1222;
-      padding: 4px 8px;
-      border-radius: 4px;
-      margin: 4px 0;
-      word-break: break-all;
-      max-height: 40px;
-      overflow: hidden;
-    }
-    .finding-source {
-      font-size: 10px;
-      color: #475569;
+    .pill-row { display: flex; flex-wrap: wrap; gap: 4px; }
+    .pill {
+      border: 1px solid #334155;
+      border-radius: 999px;
+      padding: 2px 7px;
+      color: #94a3b8;
     }
     .filters {
       padding: 8px 16px;
@@ -105,70 +110,157 @@
       border-bottom: 1px solid #1e293b;
       background: #0f172a;
       position: sticky;
-      top: 40px;
-      z-index: 9;
+      top: 74px;
+      z-index: 8;
     }
-    .filter-btn {
-      font-family: inherit;
-      font-size: 9px;
-      padding: 2px 8px;
-      border-radius: 3px;
-      border: 1px solid #334155;
-      background: none;
-      cursor: pointer;
-      font-weight: 600;
-    }
+    .filter-btn { font-weight: 700; }
     .filter-btn.active { opacity: 1; }
     .filter-btn.inactive { opacity: 0.35; }
-    .filter-high { color: #fca5a5; border-color: #7f1d1d; }
+    .filter-critical, .filter-high { color: #fca5a5; border-color: #7f1d1d; }
     .filter-medium { color: #fcd34d; border-color: #78350f; }
     .filter-low { color: #93c5fd; border-color: #1e3a5f; }
-    .scan-stats {
-      padding: 10px 16px;
-      border-bottom: 1px solid #1e293b;
-      font-size: 10px;
+    .status {
+      padding: 18px;
+      text-align: center;
+      color: #64748b;
+      line-height: 1.5;
     }
-    .stats-header {
-      color: #475569;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
+    .finding {
+      padding: 12px 16px;
+      border-bottom: 1px solid #1e293b;
+    }
+    .finding:hover { background: #1e293b; }
+    .finding-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
       margin-bottom: 6px;
     }
-    .stat-line {
-      display: flex;
-      justify-content: space-between;
-      padding: 1px 0;
+    .severity-badge {
+      font-size: 9px;
+      font-weight: 700;
+      padding: 1px 6px;
+      border-radius: 3px;
+      text-transform: uppercase;
     }
-    .stat-count { color: #34d399; font-weight: 600; min-width: 28px; }
-    .stat-label { color: #475569; }
-    .all-clean {
+    .sev-critical, .sev-high { background: #7f1d1d; color: #fca5a5; }
+    .sev-medium { background: #78350f; color: #fcd34d; }
+    .sev-low { background: #1e3a5f; color: #93c5fd; }
+    .finding-type { font-size: 11px; font-weight: 700; color: #e2e8f0; }
+    .finding-value {
+      font-size: 10px;
       color: #34d399;
-      font-weight: 600;
+      background: #0c1222;
+      padding: 5px 8px;
+      border-radius: 4px;
+      margin: 5px 0;
+      word-break: break-all;
+      max-height: 48px;
+      overflow: hidden;
+    }
+    .finding-detail { font-size: 10px; color: #64748b; line-height: 1.5; margin-top: 4px; }
+    .source-link { color: #4dabf7; text-decoration: none; cursor: pointer; }
+    .source-link:hover { text-decoration: underline; }
+    .fix {
       margin-top: 6px;
-      padding-top: 6px;
-      border-top: 1px solid #1e293b;
+      padding: 7px;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      background: #0c1222;
+      color: #cbd5e1;
+      line-height: 1.45;
+    }
+    .finding-actions {
+      margin-top: 7px;
+      display: flex;
+      justify-content: flex-end;
+      gap: 6px;
+    }
+    .tabstrip {
+      display: flex;
+      padding: 0 16px;
+      gap: 4px;
+      border-bottom: 1px solid #1e293b;
+      background: #0f172a;
+      position: sticky;
+      top: 42px;
+      z-index: 9;
+    }
+    .tab-btn {
+      border: none;
+      border-bottom: 2px solid transparent;
+      background: none;
+      color: #64748b;
+      padding: 8px 4px;
+      font-family: inherit;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      cursor: pointer;
+    }
+    .tab-btn:hover { color: #cbd5e1; }
+    .tab-btn.active {
+      color: #34d399;
+      border-bottom-color: #34d399;
+    }
+    .ref-empty-status {
+      padding: 18px;
+      text-align: center;
+      color: #64748b;
+      line-height: 1.5;
+      font-size: 11px;
     }
   </style>
 </head>
 <body>
   <div class="header">
-    <h1>keyleak-detector</h1>
+    <h1>keyleak launch gate</h1>
     <span id="findingCount" class="count count-zero">0</span>
-    <button id="clearBtn" class="clear-btn">CLEAR</button>
+    <button id="clearBtn" class="danger">CLEAR</button>
   </div>
-  <div id="filters" class="filters" style="display: none;">
-    <button class="filter-btn filter-high active" data-severity="high">HIGH</button>
-    <button class="filter-btn filter-medium active" data-severity="medium">MED</button>
-    <button class="filter-btn filter-low active" data-severity="low">LOW</button>
-  </div>
-  <div id="scanStats" class="scan-stats" style="display: none;"></div>
-  <div id="content">
-    <div class="status">
-      <div class="icon">&#x2714;</div>
-      <div>Monitoring active. Browse normally.</div>
+
+  <div id="verdictPanel" class="verdict">
+    <div class="verdict-row">
+      <span id="verdictBadge" class="verdict-badge verdict-safe">SAFE TO SHIP</span>
+      <button id="revealBtn" title="Temporarily reveal raw values in this popup">REVEAL</button>
     </div>
+    <div id="verdictReason" class="reason">Monitoring covered browser surfaces.</div>
+    <div id="targetUrl" class="target"></div>
   </div>
-  <script src="popup.js"></script>
+
+  <div class="tabstrip" id="tabstrip">
+    <button class="tab-btn active" data-view="findings">Findings</button>
+    <button class="tab-btn" data-view="reference">Reference</button>
+  </div>
+
+  <section id="findingsView">
+    <div class="actions">
+      <button id="fullScanBtn" class="primary">RUN FULL SCAN</button>
+      <button id="copyJsonBtn">COPY JSON</button>
+      <button id="copyMarkdownBtn">COPY MD</button>
+    </div>
+    <div id="actionStatus" class="status-line"></div>
+
+    <div id="coverage" class="coverage"></div>
+    <div id="scanStats" class="scan-stats" style="display: none;"></div>
+
+    <div id="filters" class="filters" style="display: none;">
+      <button class="filter-btn filter-critical active" data-severity="critical">CRIT</button>
+      <button class="filter-btn filter-high active" data-severity="high">HIGH</button>
+      <button class="filter-btn filter-medium active" data-severity="medium">MED</button>
+      <button class="filter-btn filter-low active" data-severity="low">LOW</button>
+    </div>
+
+    <div id="content">
+      <div class="status">Monitoring active. Browse an app you own, then use the verdict here as a launch-gate signal.</div>
+    </div>
+  </section>
+
+  <section id="referenceView" style="display: none;">
+    <div class="ref-empty-status">Loading detector reference...</div>
+  </section>
+
+  <script type="module" src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -161,6 +161,11 @@
     .finding-detail { font-size: 10px; color: #64748b; line-height: 1.5; margin-top: 4px; }
     .source-link { color: #4dabf7; text-decoration: none; cursor: pointer; }
     .source-link:hover { text-decoration: underline; }
+    .finding-locations { margin-top: 6px; font-size: 10px; color: #64748b; }
+    .finding-locations ul { margin: 4px 0 0 16px; padding: 0; list-style: disc; }
+    .finding-locations li { margin: 2px 0; line-height: 1.4; }
+    .finding-locations .source-link { color: #4dabf7; text-decoration: none; font-size: 10px; }
+    .finding-locations .source-link:hover { text-decoration: underline; }
     .fix {
       margin-top: 6px;
       padding: 7px;

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,76 +1,144 @@
+import { DETECTOR_INFO, getDetectorInfo } from '../lib/detector-info.js';
+import { renderLearnPanel, LEARN_PANEL_CSS } from '../lib/learn-panel.js';
+import { mountReferenceView, REFERENCE_VIEW_CSS } from '../lib/reference-view.js';
+
 const content = document.getElementById('content');
 const findingCount = document.getElementById('findingCount');
 const clearBtn = document.getElementById('clearBtn');
 const filtersEl = document.getElementById('filters');
 const scanStatsEl = document.getElementById('scanStats');
+const verdictBadge = document.getElementById('verdictBadge');
+const verdictReason = document.getElementById('verdictReason');
+const targetUrl = document.getElementById('targetUrl');
+const coverageEl = document.getElementById('coverage');
+const actionStatus = document.getElementById('actionStatus');
+const fullScanBtn = document.getElementById('fullScanBtn');
+const copyJsonBtn = document.getElementById('copyJsonBtn');
+const copyMarkdownBtn = document.getElementById('copyMarkdownBtn');
+const revealBtn = document.getElementById('revealBtn');
+const tabstripEl = document.getElementById('tabstrip');
+const findingsViewEl = document.getElementById('findingsView');
+const referenceViewEl = document.getElementById('referenceView');
 
-const activeFilters = new Set(['high', 'medium', 'low']);
+const activeFilters = new Set(['critical', 'high', 'medium', 'low']);
+let activeTab = null;
+let latestData = null;
+let revealRaw = false;
+let referenceMounted = false;
+
+const sharedStyle = document.createElement('style');
+sharedStyle.textContent = `${LEARN_PANEL_CSS}\n${REFERENCE_VIEW_CSS}`;
+document.head.appendChild(sharedStyle);
+
+async function currentTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab || null;
+}
 
 async function loadFindings() {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!tab) return;
+  activeTab = await currentTab();
+  if (!activeTab) return;
 
-  chrome.runtime.sendMessage({ action: 'get_findings', tabId: tab.id }, (data) => {
-    if (chrome.runtime.lastError || !data) return;
-
-    const findings = data.findings || [];
-    const stats = data.stats || { requests: 0, bodies: 0, scripts: 0, dataAttrs: 0, metaTags: 0 };
-
-    updateCount(findings);
-    renderStats(stats, findings.length);
-
-    if (findings.length === 0) {
-      const totalScanned = stats.requests + stats.bodies + stats.scripts + stats.dataAttrs + stats.metaTags;
-      if (totalScanned > 0) {
-        content.innerHTML = `
-          <div class="status">
-            <div class="icon">&#x2714;</div>
-            <div>No secrets detected</div>
-          </div>`;
-      } else {
-        content.innerHTML = `
-          <div class="status">
-            <div class="icon">&#x2714;</div>
-            <div>Monitoring active. Browse normally.</div>
-          </div>`;
-      }
-      filtersEl.style.display = 'none';
+  chrome.runtime.sendMessage({ action: 'get_findings', tabId: activeTab.id }, (data) => {
+    if (chrome.runtime.lastError || !data) {
+      showStatus('Unable to read extension findings yet.');
       return;
     }
 
-    filtersEl.style.display = 'flex';
-    renderFindings(findings);
+    latestData = data;
+    render(data);
   });
 }
 
+function render(data) {
+  const findings = data.findings || [];
+  const stats = data.stats || {};
+  const report = data.report || {};
+
+  updateVerdict(report, data.url || activeTab?.url || '');
+  updateCount(findings);
+  renderCoverage(report.coverage || {}, stats, report.packs || []);
+  renderStats(stats, findings.length);
+
+  if (findings.length === 0) {
+    filtersEl.style.display = 'none';
+    content.innerHTML = `
+      <div class="status">
+        <strong>${escapeHtml(report.verdict?.label || 'SAFE TO SHIP')}</strong><br>
+        No findings detected in covered browser surfaces. Run the full local scan before release.
+      </div>`;
+    return;
+  }
+
+  filtersEl.style.display = 'flex';
+  renderFindings(findings);
+}
+
+function updateVerdict(report, url) {
+  const verdict = report.verdict || {
+    label: 'SAFE TO SHIP',
+    status: 'SAFE_TO_SHIP',
+    reason: 'No findings detected in covered browser surfaces.',
+  };
+
+  verdictBadge.textContent = verdict.label || 'REVIEW';
+  verdictBadge.className = 'verdict-badge';
+  if (verdict.status === 'BLOCK_SHIP') {
+    verdictBadge.classList.add('verdict-block');
+  } else if (verdict.status === 'SAFE_TO_SHIP') {
+    verdictBadge.classList.add('verdict-safe');
+  } else {
+    verdictBadge.classList.add('verdict-review');
+  }
+  verdictReason.textContent = verdict.reason || '';
+  targetUrl.textContent = url || '';
+}
+
+function renderCoverage(coverage, stats, packs = []) {
+  const covered = coverage.covered || [];
+  const totalScanned = Object.values(stats || {}).reduce((sum, value) => sum + (Number(value) || 0), 0);
+  const pills = covered.length
+    ? covered.map(item => `<span class="pill">${escapeHtml(item)}</span>`).join('')
+    : '<span class="pill">waiting for browser activity</span>';
+  coverageEl.innerHTML = `
+    <div class="section-label">coverage: ${escapeHtml(coverage.level || (totalScanned ? 'partial' : 'waiting'))}</div>
+    <div class="pill-row">${pills}</div>
+    <div class="pill-row">${packs.map(pack => `<span class="pill">${escapeHtml(pack)}</span>`).join('')}</div>
+    <div class="finding-detail">${escapeHtml(coverage.note || 'Run the full local scan for attack-surface coverage.')}</div>
+  `;
+}
+
 function renderStats(stats, findingsCount) {
-  const totalScanned = stats.requests + stats.bodies + stats.scripts + stats.dataAttrs + stats.metaTags;
-  if (totalScanned === 0) {
+  const lines = [];
+  const labels = {
+    requests: 'headers/URLs',
+    bodies: 'fetch/XHR bodies',
+    scripts: 'inline scripts',
+    externalScripts: 'external scripts',
+    sourceMaps: 'source maps',
+    dataAttrs: 'data attributes',
+    metaTags: 'meta tags',
+    storage: 'browser storage',
+    websockets: 'WebSocket messages',
+    eventStreams: 'SSE messages',
+    devtoolsBodies: 'DevTools bodies',
+    fullScans: 'full scans',
+  };
+
+  for (const [key, label] of Object.entries(labels)) {
+    if (stats[key] > 0) lines.push({ count: stats[key], label });
+  }
+
+  if (lines.length === 0) {
     scanStatsEl.style.display = 'none';
     return;
   }
 
   scanStatsEl.style.display = 'block';
-
-  const lines = [];
-  if (stats.requests > 0) lines.push({ count: stats.requests, label: 'network requests' });
-  if (stats.bodies > 0)   lines.push({ count: stats.bodies, label: 'response bodies' });
-  if (stats.scripts > 0)  lines.push({ count: stats.scripts, label: 'inline scripts' });
-  if (stats.dataAttrs > 0) lines.push({ count: stats.dataAttrs, label: 'data attributes' });
-  if (stats.metaTags > 0) lines.push({ count: stats.metaTags, label: 'meta tags' });
-
-  const statsHtml = lines.map(l =>
-    `<div class="stat-line"><span class="stat-count">${l.count}</span><span class="stat-label">${l.label}</span></div>`
-  ).join('');
-
-  const cleanLine = findingsCount === 0
-    ? '<div class="all-clean">all clean</div>'
-    : '';
-
   scanStatsEl.innerHTML = `
-    <div class="stats-header">scan activity</div>
-    ${statsHtml}
-    ${cleanLine}
+    <div class="section-label">scan activity</div>
+    ${lines.map(l => `<div><span style="color:#34d399;font-weight:700;">${l.count}</span> ${escapeHtml(l.label)}</div>`).join('')}
+    ${findingsCount === 0 ? '<div style="color:#34d399;margin-top:5px;">all clean in covered surfaces</div>' : ''}
   `;
 }
 
@@ -81,7 +149,7 @@ function updateCount(findings) {
 
   if (count === 0) {
     findingCount.classList.add('count-zero');
-  } else if (findings.some(f => f.severity === 'high')) {
+  } else if (findings.some(f => ['critical', 'high'].includes(f.severity))) {
     findingCount.classList.add('count-danger');
   } else {
     findingCount.classList.add('count-warn');
@@ -92,23 +160,33 @@ function renderFindings(findings) {
   const filtered = findings.filter(f => activeFilters.has(f.severity));
 
   if (filtered.length === 0) {
-    content.innerHTML = `
-      <div class="status">
-        <div style="color: #475569;">All findings filtered out.</div>
-      </div>`;
+    content.innerHTML = '<div class="status">All findings filtered out.</div>';
     return;
   }
 
-  content.innerHTML = filtered.map(f => `
-    <div class="finding" data-severity="${f.severity}">
-      <div class="finding-header">
-        <span class="severity-badge sev-${f.severity}">${f.severity}</span>
-        <span class="finding-type">${formatType(f.type)}</span>
+  content.innerHTML = filtered.map(f => {
+    const evidence = f.evidence || {};
+    const value = revealRaw && f.raw_value ? f.raw_value : evidence.redacted_value || f.redacted_value || '[redacted]';
+    return `
+      <div class="finding" data-severity="${escapeHtml(f.severity)}">
+        <div class="finding-header">
+          <span class="severity-badge sev-${escapeHtml(f.severity)}">${escapeHtml(f.severity)}</span>
+          <span class="finding-type">${escapeHtml(formatType(f.type))}</span>
+        </div>
+        <div class="finding-value">${escapeHtml(value)}</div>
+        <div class="finding-detail"><strong>source:</strong> <a class="source-link" href="#" data-url="${escapeHtml(f.url || evidence.request_url || '')}" data-source="${escapeHtml(evidence.source || f.source)}">${escapeHtml(evidence.source || f.source)}</a></div>
+        <div class="finding-detail"><strong>pack:</strong> ${escapeHtml(f.category || 'unknown')}</div>
+        <div class="finding-detail"><strong>confidence:</strong> ${escapeHtml(String(f.confidence || 'n/a'))} | <strong>status:</strong> ${escapeHtml(f.validation_status || 'detected')}</div>
+        <div class="finding-detail">${escapeHtml(f.risk_reason || '')}</div>
+        <div class="fix"><strong>fix:</strong> ${escapeHtml(f.remediation || 'Review and remove exposed sensitive data.')}</div>
+        <div class="finding-actions">
+          <button class="learn-btn" data-id="${escapeHtml(f.id)}" data-detector="${escapeHtml(f.detector_id || '')}">LEARN</button>
+          <button class="suppress-btn" data-id="${escapeHtml(f.id)}">SUPPRESS ID</button>
+        </div>
+        <div class="learn-mount" data-mount-for="${escapeHtml(f.id)}"></div>
       </div>
-      <div class="finding-value">${escapeHtml(f.value)}</div>
-      <div class="finding-source">${escapeHtml(f.source)}</div>
-    </div>
-  `).join('');
+    `;
+  }).join('');
 }
 
 function formatType(type) {
@@ -121,9 +199,29 @@ function escapeHtml(text) {
   return div.innerHTML;
 }
 
-// Filter toggles
-filtersEl.addEventListener('click', (e) => {
-  const btn = e.target.closest('.filter-btn');
+function showStatus(message) {
+  actionStatus.style.display = 'block';
+  actionStatus.textContent = message;
+}
+
+async function copyReport(format) {
+  if (!activeTab) return;
+  chrome.runtime.sendMessage({ action: 'export_report', tabId: activeTab.id, format }, async (response) => {
+    if (chrome.runtime.lastError || !response?.ok) {
+      showStatus(response?.error || 'Unable to export report.');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(response.content);
+      showStatus(`Copied ${format.toUpperCase()} report with redacted evidence.`);
+    } catch (_error) {
+      showStatus('Clipboard permission was denied. Open DevTools panel and export from there.');
+    }
+  });
+}
+
+filtersEl.addEventListener('click', (event) => {
+  const btn = event.target.closest('.filter-btn');
   if (!btn) return;
 
   const sev = btn.dataset.severity;
@@ -137,17 +235,108 @@ filtersEl.addEventListener('click', (e) => {
     btn.classList.add('active');
   }
 
-  loadFindings();
+  if (latestData) renderFindings(latestData.findings || []);
 });
 
-// Clear button
-clearBtn.addEventListener('click', async () => {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!tab) return;
-  chrome.runtime.sendMessage({ action: 'clear_findings', tabId: tab.id }, () => {
+content.addEventListener('click', (event) => {
+  const sourceLink = event.target.closest('.source-link');
+  if (sourceLink) {
+    event.preventDefault();
+    const url = sourceLink.dataset.url;
+    if (url && url.startsWith('http')) {
+      chrome.tabs.create({ url });
+    }
+    return;
+  }
+
+  const learnBtn = event.target.closest('.learn-btn');
+  if (learnBtn) {
+    const findingId = learnBtn.dataset.id;
+    const detectorId = learnBtn.dataset.detector;
+    const mount = content.querySelector(`.learn-mount[data-mount-for="${CSS.escape(findingId)}"]`);
+    if (!mount) return;
+    if (mount.dataset.open === '1') {
+      mount.innerHTML = '';
+      mount.dataset.open = '0';
+      learnBtn.textContent = 'LEARN';
+      return;
+    }
+    const finding = (latestData?.findings || []).find(f => f.id === findingId);
+    const info = getDetectorInfo(detectorId) || (finding && getDetectorInfo(finding.type)) || null;
+    if (!info) {
+      mount.innerHTML = '<div class="learn-panel"><div class="learn-body">No reference content for this detector yet.</div></div>';
+    } else {
+      mount.innerHTML = renderLearnPanel(finding || null, info);
+    }
+    mount.dataset.open = '1';
+    learnBtn.textContent = 'HIDE';
+    return;
+  }
+
+  const button = event.target.closest('.suppress-btn');
+  if (!button || !activeTab) return;
+  chrome.runtime.sendMessage({
+    action: 'suppress_finding',
+    tabId: activeTab.id,
+    findingId: button.dataset.id,
+  }, (response) => {
+    if (chrome.runtime.lastError || !response?.ok) {
+      showStatus(response?.error || 'Unable to suppress finding.');
+      return;
+    }
+    showStatus('Suppressed this finding ID for future extension reports.');
     loadFindings();
   });
 });
 
-// Load on open
+tabstripEl.addEventListener('click', (event) => {
+  const btn = event.target.closest('.tab-btn');
+  if (!btn) return;
+  const view = btn.dataset.view;
+  tabstripEl.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b === btn));
+  if (view === 'reference') {
+    findingsViewEl.style.display = 'none';
+    referenceViewEl.style.display = 'block';
+    if (!referenceMounted) {
+      mountReferenceView(referenceViewEl, DETECTOR_INFO);
+      referenceMounted = true;
+    }
+  } else {
+    findingsViewEl.style.display = '';
+    referenceViewEl.style.display = 'none';
+  }
+});
+
+clearBtn.addEventListener('click', async () => {
+  activeTab = activeTab || await currentTab();
+  if (!activeTab) return;
+  chrome.runtime.sendMessage({ action: 'clear_findings', tabId: activeTab.id }, () => {
+    loadFindings();
+  });
+});
+
+fullScanBtn.addEventListener('click', async () => {
+  activeTab = activeTab || await currentTab();
+  if (!activeTab) return;
+  showStatus('Running full local scan through http://127.0.0.1:5002 ...');
+  chrome.runtime.sendMessage({ action: 'run_full_scan', tabId: activeTab.id, url: activeTab.url }, (response) => {
+    if (chrome.runtime.lastError || !response?.ok) {
+      showStatus(response?.error || 'Start the local scanner with `poetry run python app.py` or `docker compose up -d`.');
+      loadFindings();
+      return;
+    }
+    showStatus('Full local scan completed. Results are attached to this tab report.');
+    loadFindings();
+  });
+});
+
+copyJsonBtn.addEventListener('click', () => copyReport('json'));
+copyMarkdownBtn.addEventListener('click', () => copyReport('markdown'));
+
+revealBtn.addEventListener('click', () => {
+  revealRaw = !revealRaw;
+  revealBtn.textContent = revealRaw ? 'HIDE RAW' : 'REVEAL';
+  if (latestData) renderFindings(latestData.findings || []);
+});
+
 loadFindings();

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,6 +1,7 @@
 import { DETECTOR_INFO, getDetectorInfo } from '../lib/detector-info.js';
 import { renderLearnPanel, LEARN_PANEL_CSS } from '../lib/learn-panel.js';
 import { mountReferenceView, REFERENCE_VIEW_CSS } from '../lib/reference-view.js';
+import { TESTABLE_TYPES } from '../lib/key-tester.js';
 
 const content = document.getElementById('content');
 const findingCount = document.getElementById('findingCount');
@@ -206,9 +207,11 @@ function renderFindings(findings) {
         <div class="finding-detail">${escapeHtml(f.risk_reason || '')}</div>
         <div class="fix"><strong>fix:</strong> ${escapeHtml(f.remediation || 'Review and remove exposed sensitive data.')}</div>
         <div class="finding-actions">
+          ${TESTABLE_TYPES.has(f.type) && f.raw_value ? `<button class="test-btn primary" data-id="${escapeHtml(f.id)}" data-type="${escapeHtml(f.type)}" data-raw="${escapeHtml(f.raw_value)}">TEST</button>` : ''}
           <button class="learn-btn" data-id="${escapeHtml(f.id)}" data-detector="${escapeHtml(f.detector_id || '')}">LEARN</button>
           <button class="suppress-btn" data-id="${escapeHtml(f.id)}">SUPPRESS ID</button>
         </div>
+        <div class="test-result" data-test-for="${escapeHtml(f.id)}"></div>
         <div class="learn-mount" data-mount-for="${escapeHtml(f.id)}"></div>
       </div>
     `;
@@ -272,6 +275,34 @@ content.addEventListener('click', (event) => {
     if (url && url.startsWith('http')) {
       chrome.tabs.create({ url });
     }
+    return;
+  }
+
+  const testBtn = event.target.closest('.test-btn');
+  if (testBtn) {
+    const findingId = testBtn.dataset.id;
+    const type = testBtn.dataset.type;
+    const rawValue = testBtn.dataset.raw;
+    const resultEl = content.querySelector(`.test-result[data-test-for="${CSS.escape(findingId)}"]`);
+    if (!resultEl) return;
+    testBtn.disabled = true;
+    testBtn.textContent = 'TESTING...';
+    resultEl.innerHTML = '<span class="test-pending">Testing key...</span>';
+    chrome.runtime.sendMessage({ action: 'test_key', type, raw_value: rawValue }, (response) => {
+      testBtn.disabled = false;
+      testBtn.textContent = 'TEST';
+      if (!response) {
+        resultEl.innerHTML = '<span class="test-error">Test failed — no response.</span>';
+        return;
+      }
+      if (response.status === 'valid') {
+        resultEl.innerHTML = `<span class="test-valid">VALID — ${escapeHtml(response.detail)}</span>`;
+      } else if (response.status === 'invalid') {
+        resultEl.innerHTML = `<span class="test-invalid">INVALID — ${escapeHtml(response.detail)}</span>`;
+      } else {
+        resultEl.innerHTML = `<span class="test-error">${escapeHtml(response.detail || 'Unknown result')}</span>`;
+      }
+    });
     return;
   }
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -164,9 +164,34 @@ function renderFindings(findings) {
     return;
   }
 
-  content.innerHTML = filtered.map(f => {
+  // Group findings with identical key values
+  const groups = new Map();
+  for (const f of filtered) {
+    const key = `${f.type}:${f.evidence?.redacted_value || f.redacted_value || ''}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(f);
+  }
+
+  content.innerHTML = Array.from(groups.values()).map(group => {
+    const f = group[0]; // Representative finding (highest severity first since findings are sorted)
     const evidence = f.evidence || {};
     const value = revealRaw && f.raw_value ? f.raw_value : evidence.redacted_value || f.redacted_value || '[redacted]';
+
+    let locationsHtml = '';
+    if (group.length > 1) {
+      const locationItems = group.map(g => {
+        const src = g.evidence?.source || g.source || 'unknown';
+        const url = g.url || g.evidence?.request_url || '';
+        const isClickable = url && url.startsWith('http');
+        return `<li>${isClickable ? `<a class="source-link" href="#" data-url="${escapeHtml(url)}" data-source="${escapeHtml(src)}">${escapeHtml(src)}</a>` : escapeHtml(src)}</li>`;
+      }).join('');
+      locationsHtml = `<div class="finding-locations"><strong>Found in ${group.length} locations:</strong><ul>${locationItems}</ul></div>`;
+    }
+
+    const sourceDisplay = group.length === 1
+      ? `<a class="source-link" href="#" data-url="${escapeHtml(f.url || evidence.request_url || '')}" data-source="${escapeHtml(evidence.source || f.source)}">${escapeHtml(evidence.source || f.source)}</a>`
+      : `${group.length} locations`;
+
     return `
       <div class="finding" data-severity="${escapeHtml(f.severity)}">
         <div class="finding-header">
@@ -174,7 +199,8 @@ function renderFindings(findings) {
           <span class="finding-type">${escapeHtml(formatType(f.type))}</span>
         </div>
         <div class="finding-value">${escapeHtml(value)}</div>
-        <div class="finding-detail"><strong>source:</strong> <a class="source-link" href="#" data-url="${escapeHtml(f.url || evidence.request_url || '')}" data-source="${escapeHtml(evidence.source || f.source)}">${escapeHtml(evidence.source || f.source)}</a></div>
+        <div class="finding-detail"><strong>source:</strong> ${sourceDisplay}</div>
+        ${locationsHtml}
         <div class="finding-detail"><strong>pack:</strong> ${escapeHtml(f.category || 'unknown')}</div>
         <div class="finding-detail"><strong>confidence:</strong> ${escapeHtml(String(f.confidence || 'n/a'))} | <strong>status:</strong> ${escapeHtml(f.validation_status || 'detected')}</div>
         <div class="finding-detail">${escapeHtml(f.risk_reason || '')}</div>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -299,6 +299,12 @@ content.addEventListener('click', (event) => {
         resultEl.innerHTML = `<span class="test-valid">VALID — ${escapeHtml(response.detail)}</span>`;
       } else if (response.status === 'invalid') {
         resultEl.innerHTML = `<span class="test-invalid">INVALID — ${escapeHtml(response.detail)}</span>`;
+      } else if (response.status === 'decoded' && response.flags) {
+        const flagRows = response.flags.map(f => {
+          const cls = f.level === 'critical' ? 'flag-critical' : f.level === 'high' ? 'flag-high' : f.level === 'medium' ? 'flag-medium' : 'flag-info';
+          return `<div class="jwt-flag ${cls}"><span class="flag-level">${escapeHtml(f.level.toUpperCase())}</span> <span class="flag-claim">${escapeHtml(f.claim)}</span> ${escapeHtml(f.message)}</div>`;
+        }).join('');
+        resultEl.innerHTML = `<div class="jwt-decode"><div class="jwt-header">JWT DECODED</div>${flagRows}</div>`;
       } else {
         resultEl.innerHTML = `<span class="test-error">${escapeHtml(response.detail || 'Unknown result')}</span>`;
       }

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -1,168 +1,529 @@
 /**
  * Service worker for KeyLeak Detector.
- * Coordinates analysis, stores findings per tab, updates badge.
+ * Coordinates analysis, stores normalized findings per tab, and builds launch-gate reports.
  */
 
 import { analyzeContent, analyzeHeaders, analyzeUrl } from './lib/analyzer.js';
+import {
+  buildReport,
+  formatMarkdownReport,
+  formatSarifReport,
+  normalizeFinding,
+  severityRank,
+} from './lib/reporting.js';
+import { detectBaaSRequest, BaaSTabState } from './lib/baas-detector.js';
 
-// Per-tab findings + stats storage
-const tabFindings = new Map(); // tabId -> { findings: [], url: '', stats: {...} }
+const STORAGE_PREFIX = 'keyleak_tab_';
+const SETTINGS_KEY = 'keyleak_settings';
+const MAX_FINDINGS_PER_TAB = 300;
+const MAX_REMOTE_BODY_SIZE = 2 * 1024 * 1024;
+const LOCAL_SERVER = 'http://127.0.0.1:5002';
+const START_SERVER_COMMAND = 'poetry run python app.py';
+const DEFAULT_PACKS = ['leak', 'appsec', 'access-control', 'baas'];
 
-const EMPTY_STATS = { requests: 0, bodies: 0, scripts: 0, dataAttrs: 0, metaTags: 0 };
+const baasTabStates = new Map();
 
-function ensureTabData(tabId, pageUrl) {
-  if (!tabFindings.has(tabId)) {
-    tabFindings.set(tabId, { findings: [], url: pageUrl || '', stats: { ...EMPTY_STATS } });
-  }
-  const data = tabFindings.get(tabId);
-  if (pageUrl) data.url = pageUrl;
+const EMPTY_STATS = {
+  requests: 0,
+  bodies: 0,
+  scripts: 0,
+  dataAttrs: 0,
+  metaTags: 0,
+  externalScripts: 0,
+  sourceMaps: 0,
+  storage: 0,
+  websockets: 0,
+  eventStreams: 0,
+  devtoolsBodies: 0,
+  fullScans: 0,
+};
+
+const tabCache = new Map();
+
+function storageKey(tabId) {
+  return `${STORAGE_PREFIX}${tabId}`;
+}
+
+function storageGet(key) {
+  return new Promise(resolve => chrome.storage.local.get(key, resolve));
+}
+
+function storageSet(payload) {
+  return new Promise(resolve => chrome.storage.local.set(payload, resolve));
+}
+
+function storageRemove(key) {
+  return new Promise(resolve => chrome.storage.local.remove(key, resolve));
+}
+
+function cloneStats(stats = {}) {
+  return { ...EMPTY_STATS, ...stats };
+}
+
+async function readSettings() {
+  const stored = await storageGet(SETTINGS_KEY);
+  return {
+    suppressed_ids: [],
+    ...(stored[SETTINGS_KEY] || {}),
+  };
+}
+
+async function writeSettings(settings) {
+  await storageSet({ [SETTINGS_KEY]: settings });
+}
+
+function emptyTabData(pageUrl = '') {
+  const data = {
+    findings: [],
+    url: pageUrl,
+    stats: cloneStats(),
+    report: null,
+    full_scan_report: null,
+    full_scan_error: '',
+    last_updated: Date.now(),
+  };
+  data.report = buildReport(pageUrl, [], data.stats, { profile: 'launch-gate', packs: DEFAULT_PACKS });
   return data;
 }
 
-// --- Badge Management ---
+async function readTabData(tabId, pageUrl = '') {
+  if (!Number.isInteger(tabId) || tabId < 0) {
+    return emptyTabData(pageUrl);
+  }
+  if (tabCache.has(tabId)) {
+    const cached = tabCache.get(tabId);
+    if (pageUrl) cached.url = pageUrl;
+    return cached;
+  }
 
-function updateBadge(tabId) {
-  const data = tabFindings.get(tabId);
-  if (!data || data.findings.length === 0) {
+  const stored = await storageGet(storageKey(tabId));
+  const data = stored[storageKey(tabId)] || emptyTabData(pageUrl);
+  data.stats = cloneStats(data.stats);
+  data.findings = (data.findings || []).map(finding => normalizeFinding(finding));
+  data.url = pageUrl || data.url || '';
+  data.report = buildReport(data.url, data.findings, data.stats, {
+    profile: 'launch-gate',
+    packs: DEFAULT_PACKS,
+    full_scan_report: data.full_scan_report || null,
+  });
+  tabCache.set(tabId, data);
+  return data;
+}
+
+async function persistTabData(tabId, data) {
+  if (!Number.isInteger(tabId) || tabId < 0) return;
+  data.last_updated = Date.now();
+  data.report = buildReport(data.url, data.findings, data.stats, {
+    profile: 'launch-gate',
+    packs: DEFAULT_PACKS,
+    full_scan_report: data.full_scan_report || null,
+  });
+  tabCache.set(tabId, data);
+  await storageSet({ [storageKey(tabId)]: data });
+  updateBadge(tabId, data);
+}
+
+function updateBadge(tabId, data = tabCache.get(tabId)) {
+  if (!Number.isInteger(tabId) || tabId < 0) return;
+  if (!data || !data.findings || data.findings.length === 0) {
     chrome.action.setBadgeText({ text: '', tabId });
     return;
   }
 
   const count = data.findings.length;
-  const hasHigh = data.findings.some(f => f.severity === 'high');
+  const hasBlocker = data.findings.some(finding => ['critical', 'high'].includes(finding.severity));
 
-  chrome.action.setBadgeText({ text: String(count), tabId });
+  chrome.action.setBadgeText({ text: count > 99 ? '99+' : String(count), tabId });
   chrome.action.setBadgeBackgroundColor({
-    color: hasHigh ? '#DC2626' : '#F59E0B',
+    color: hasBlocker ? '#DC2626' : '#F59E0B',
     tabId,
   });
 }
 
-function addFindings(tabId, newFindings, pageUrl) {
-  if (!newFindings || newFindings.length === 0) return;
+async function addFindings(tabId, newFindings, pageUrl = '') {
+  if (!Number.isInteger(tabId) || tabId < 0 || !newFindings || newFindings.length === 0) {
+    return emptyTabData(pageUrl);
+  }
 
-  const data = ensureTabData(tabId, pageUrl);
+  const data = await readTabData(tabId, pageUrl);
+  const settings = await readSettings();
+  const suppressedIds = new Set(settings.suppressed_ids || []);
+  if (pageUrl) data.url = pageUrl;
 
-  // Deduplicate by type+value
-  const existing = new Set(data.findings.map(f => `${f.type}:${f.value}`));
-  for (const finding of newFindings) {
-    const key = `${finding.type}:${finding.value}`;
-    if (!existing.has(key)) {
-      existing.add(key);
+  const existing = new Set(data.findings.map(finding => finding.id));
+  for (const rawFinding of newFindings) {
+    const finding = normalizeFinding(rawFinding);
+    if (suppressedIds.has(finding.id)) continue;
+    if (!existing.has(finding.id)) {
+      existing.add(finding.id);
       data.findings.push(finding);
     }
   }
 
-  // Sort by severity
-  const sevOrder = { high: 0, medium: 1, low: 2 };
-  data.findings.sort((a, b) => (sevOrder[a.severity] ?? 3) - (sevOrder[b.severity] ?? 3));
-
-  // Cap at 200 findings per tab
-  if (data.findings.length > 200) {
-    data.findings = data.findings.slice(0, 200);
+  data.findings.sort((left, right) => severityRank(right.severity) - severityRank(left.severity));
+  if (data.findings.length > MAX_FINDINGS_PER_TAB) {
+    data.findings = data.findings.slice(0, MAX_FINDINGS_PER_TAB);
   }
 
-  updateBadge(tabId);
+  await persistTabData(tabId, data);
+  return data;
 }
 
-// --- Message Handler ---
+async function suppressFinding(tabId, findingId) {
+  if (!findingId) return { ok: false, error: 'Missing finding id.' };
+  const settings = await readSettings();
+  const suppressedIds = new Set(settings.suppressed_ids || []);
+  suppressedIds.add(findingId);
+  settings.suppressed_ids = Array.from(suppressedIds).slice(-1000);
+  await writeSettings(settings);
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  const tabId = sender.tab?.id;
-  if (!tabId) return;
+  const data = await readTabData(tabId);
+  data.findings = (data.findings || []).filter(finding => finding.id !== findingId);
+  await persistTabData(tabId, data);
+  return { ok: true, data };
+}
 
-  if (message.action === 'analyze_intercepted') {
-    const { url, body, headers, pageUrl } = message.data;
-    const data = ensureTabData(tabId, pageUrl);
-    data.stats.bodies++;
+function isTextContent(contentType) {
+  if (!contentType) return true;
+  const type = contentType.toLowerCase();
+  return type.includes('text/')
+    || type.includes('application/json')
+    || type.includes('application/javascript')
+    || type.includes('application/xml')
+    || type.includes('application/x-javascript')
+    || type.includes('application/x-www-form-urlencoded')
+    || type.includes('source-map');
+}
 
-    const findings = [];
-    findings.push(...analyzeUrl(url));
-    if (headers) findings.push(...analyzeHeaders(headers, 'Response Header'));
-    if (body) findings.push(...analyzeContent(body, 'Response Body'));
+function canScanUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (_error) {
+    return false;
+  }
+}
 
-    addFindings(tabId, findings, pageUrl);
+function resolveUrl(url, baseUrl) {
+  try {
+    return new URL(url, baseUrl || undefined).toString();
+  } catch (_error) {
+    return '';
+  }
+}
+
+function sourceMapUrlsFromBody(body, baseUrl) {
+  const urls = [];
+  const re = /sourceMappingURL=([^\s'"<>]+)/g;
+  let match;
+  while ((match = re.exec(body)) !== null) {
+    const resolved = resolveUrl(match[1], baseUrl);
+    if (resolved) urls.push(resolved);
+  }
+  return Array.from(new Set(urls)).slice(0, 5);
+}
+
+async function fetchAndAnalyzeRemote(tabId, { url, source, pageUrl, captureType = 'remote', depth = 0 }) {
+  const resolvedUrl = resolveUrl(url, pageUrl);
+  if (!canScanUrl(resolvedUrl)) return { ok: false, skipped: true, reason: 'unsupported_url' };
+
+  const response = await fetch(resolvedUrl, {
+    cache: 'force-cache',
+    credentials: 'omit',
+    redirect: 'follow',
+  });
+
+  const contentType = response.headers.get('content-type') || '';
+  const contentLength = Number(response.headers.get('content-length') || 0);
+  if (!isTextContent(contentType) || contentLength > MAX_REMOTE_BODY_SIZE) {
+    return { ok: false, skipped: true, reason: 'unsupported_content' };
   }
 
-  if (message.action === 'analyze_content') {
-    const { content, source, pageUrl } = message.data;
-    const data = ensureTabData(tabId, pageUrl);
-
-    // Categorize by source
-    if (source && source.includes('Script')) data.stats.scripts++;
-    else if (source && source.includes('data attribute')) data.stats.dataAttrs++;
-    else if (source && source.includes('Meta tag')) data.stats.metaTags++;
-
-    const findings = analyzeContent(content, source);
-    addFindings(tabId, findings, pageUrl);
+  const body = await response.text();
+  if (!body || body.length > MAX_REMOTE_BODY_SIZE) {
+    return { ok: false, skipped: true, reason: 'too_large' };
   }
+
+  const data = await readTabData(tabId, pageUrl);
+  if (captureType === 'source-map') data.stats.sourceMaps += 1;
+  else if (captureType === 'devtools') data.stats.devtoolsBodies += 1;
+  else data.stats.externalScripts += 1;
+
+  const findings = analyzeContent(body, source || resolvedUrl, {
+    url: resolvedUrl,
+    status: response.status,
+    contentType,
+    capture_type: captureType,
+  });
+
+  await addFindings(tabId, findings, pageUrl || data.url);
+
+  if (depth < 1 && captureType !== 'source-map') {
+    for (const mapUrl of sourceMapUrlsFromBody(body, resolvedUrl)) {
+      await fetchAndAnalyzeRemote(tabId, {
+        url: mapUrl,
+        source: `Source Map: ${mapUrl}`,
+        pageUrl: pageUrl || data.url,
+        captureType: 'source-map',
+        depth: depth + 1,
+      }).catch(() => {});
+    }
+  }
+
+  return { ok: true, findings: findings.length };
+}
+
+async function runFullScan(tabId, targetUrl) {
+  if (!canScanUrl(targetUrl)) {
+    return { ok: false, error: 'Full scan requires an http:// or https:// URL.', command: START_SERVER_COMMAND };
+  }
+
+  const data = await readTabData(tabId, targetUrl);
+  data.stats.fullScans += 1;
+  data.full_scan_error = '';
+
+  try {
+    const response = await fetch(`${LOCAL_SERVER}/scan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: targetUrl,
+        scan_mode: 'basic',
+        launch_profile: 'launch-gate',
+        packs: DEFAULT_PACKS,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Local KeyLeak server returned HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    data.full_scan_report = payload.report || payload;
+    await persistTabData(tabId, data);
+    return { ok: true, report: data.full_scan_report };
+  } catch (error) {
+    data.full_scan_error = `${error.message || error}. Start the local scanner with \`${START_SERVER_COMMAND}\` or \`docker compose up -d\`.`;
+    await persistTabData(tabId, data);
+    return { ok: false, error: data.full_scan_error, command: START_SERVER_COMMAND };
+  }
+}
+
+async function exportReport(tabId, format = 'json') {
+  const data = await readTabData(tabId);
+  const report = data.report || buildReport(data.url, data.findings, data.stats, {
+    profile: 'launch-gate',
+    packs: DEFAULT_PACKS,
+    full_scan_report: data.full_scan_report || null,
+  });
+
+  if (format === 'markdown') {
+    return { ok: true, format, content: formatMarkdownReport(report), report };
+  }
+  if (format === 'sarif') {
+    return { ok: true, format, content: formatSarifReport(report), report };
+  }
+  return { ok: true, format: 'json', content: JSON.stringify(report, null, 2), report };
+}
+
+async function clearTab(tabId) {
+  tabCache.delete(tabId);
+  await storageRemove(storageKey(tabId));
+  chrome.action.setBadgeText({ text: '', tabId });
+  return { ok: true };
+}
+
+async function handleAnalyzeIntercepted(tabId, data = {}) {
+  const { url, body, headers, pageUrl, status, contentType, source, captureType } = data;
+  const tabData = await readTabData(tabId, pageUrl);
+  if (captureType === 'websocket') tabData.stats.websockets += body ? 1 : 0;
+  else if (captureType === 'eventstream') tabData.stats.eventStreams += body ? 1 : 0;
+  else tabData.stats.bodies += body ? 1 : 0;
+  await persistTabData(tabId, tabData);
+
+  const findings = [];
+  findings.push(...analyzeUrl(url, { url, status, contentType, capture_type: 'url' }));
+  if (headers) findings.push(...analyzeHeaders(headers, 'Response Header', { url, status, contentType, capture_type: 'header' }));
+  if (body) {
+    findings.push(...analyzeContent(body, source ? `${source} Body` : 'Response Body', {
+      url,
+      status,
+      contentType,
+      capture_type: captureType || 'fetch-xhr',
+    }));
+  }
+
+  await addFindings(tabId, findings, pageUrl);
+
+  // BaaS real-time detection: check if this request targets a BaaS provider
+  const requestHeaders = headers || [];
+  const baasInfo = detectBaaSRequest(url, requestHeaders);
+  if (baasInfo && baasInfo.apiKey) {
+    if (!baasTabStates.has(tabId)) baasTabStates.set(tabId, new BaaSTabState());
+    const baasState = baasTabStates.get(tabId);
+    baasState.enqueueProbe(baasInfo, (baasFindings) => {
+      addFindings(tabId, baasFindings, pageUrl).catch(() => {});
+    });
+  }
+
+  return { ok: true, findings: findings.length };
+}
+
+async function handleAnalyzeContent(tabId, data = {}) {
+  const { content, source, pageUrl, url, status, contentType, captureType } = data;
+  const tabData = await readTabData(tabId, pageUrl);
+
+  if (source && source.includes('Inline Script')) tabData.stats.scripts += 1;
+  else if (source && source.includes('data attribute')) tabData.stats.dataAttrs += 1;
+  else if (source && source.includes('Meta tag')) tabData.stats.metaTags += 1;
+  else if (source && source.includes('Storage')) tabData.stats.storage += 1;
+  else if (captureType === 'websocket') tabData.stats.websockets += 1;
+  else if (captureType === 'eventstream') tabData.stats.eventStreams += 1;
+
+  await persistTabData(tabId, tabData);
+
+  const findings = analyzeContent(content, source, {
+    url,
+    status,
+    contentType,
+    capture_type: captureType || 'content',
+  });
+  await addFindings(tabId, findings, pageUrl);
+  return { ok: true, findings: findings.length };
+}
+
+async function handleMessage(message, sender) {
+  const senderTabId = sender.tab?.id;
+  const targetTabId = Number.isInteger(message.tabId) ? message.tabId : senderTabId;
 
   if (message.action === 'get_findings') {
-    const data = tabFindings.get(message.tabId || tabId) || { findings: [], url: '', stats: { ...EMPTY_STATS } };
-    sendResponse(data);
-    return true;
+    if (!Number.isInteger(targetTabId)) return emptyTabData();
+    return readTabData(targetTabId);
   }
 
   if (message.action === 'clear_findings') {
-    const targetTabId = message.tabId || tabId;
-    tabFindings.delete(targetTabId);
-    updateBadge(targetTabId);
-    sendResponse({ ok: true });
-    return true;
+    if (!Number.isInteger(targetTabId)) return { ok: false, error: 'No tab selected.' };
+    return clearTab(targetTabId);
   }
+
+  if (message.action === 'export_report') {
+    if (!Number.isInteger(targetTabId)) return { ok: false, error: 'No tab selected.' };
+    return exportReport(targetTabId, message.format || 'json');
+  }
+
+  if (message.action === 'suppress_finding') {
+    if (!Number.isInteger(targetTabId)) return { ok: false, error: 'No tab selected.' };
+    return suppressFinding(targetTabId, message.findingId);
+  }
+
+  if (message.action === 'run_full_scan') {
+    if (!Number.isInteger(targetTabId)) return { ok: false, error: 'No tab selected.', command: START_SERVER_COMMAND };
+    return runFullScan(targetTabId, message.url || message.data?.url);
+  }
+
+  if (!Number.isInteger(senderTabId) && !Number.isInteger(targetTabId)) {
+    return { ok: false, error: 'No sender tab available.' };
+  }
+
+  const analysisTabId = Number.isInteger(senderTabId) ? senderTabId : targetTabId;
+
+  if (message.action === 'analyze_intercepted') {
+    return handleAnalyzeIntercepted(analysisTabId, message.data);
+  }
+
+  if (message.action === 'analyze_content') {
+    return handleAnalyzeContent(analysisTabId, message.data);
+  }
+
+  if (message.action === 'analyze_remote_url') {
+    return fetchAndAnalyzeRemote(analysisTabId, message.data || {});
+  }
+
+  if (message.action === 'analyze_devtools_content') {
+    const data = message.data || {};
+    const tabData = await readTabData(analysisTabId, data.pageUrl || data.url);
+    tabData.stats.devtoolsBodies += 1;
+    await persistTabData(analysisTabId, tabData);
+    const findings = analyzeContent(data.body || '', data.source || data.url || 'DevTools Network Body', {
+      url: data.url,
+      status: data.status,
+      contentType: data.contentType,
+      capture_type: 'devtools',
+    });
+    await addFindings(analysisTabId, findings, data.pageUrl || data.url);
+    return { ok: true, findings: findings.length };
+  }
+
+  return { ok: false, error: `Unknown action: ${message.action}` };
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handleMessage(message, sender)
+    .then(sendResponse)
+    .catch(error => sendResponse({ ok: false, error: error.message || String(error) }));
+  return true;
 });
 
-// --- Tab Lifecycle ---
-
-// Clear findings when a tab navigates to a new page
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === 'loading' && changeInfo.url) {
-    tabFindings.delete(tabId);
-    updateBadge(tabId);
+    clearTab(tabId).catch(() => {});
+    baasTabStates.delete(tabId);
   }
 });
 
-// Clean up when tabs are closed
 chrome.tabs.onRemoved.addListener((tabId) => {
-  tabFindings.delete(tabId);
+  tabCache.delete(tabId);
+  baasTabStates.delete(tabId);
+  storageRemove(storageKey(tabId)).catch(() => {});
 });
 
-// --- Header Analysis via webRequest ---
-
-// Analyze request headers for leaked secrets
 chrome.webRequest.onBeforeSendHeaders.addListener(
   (details) => {
-    if (!details.tabId || details.tabId < 0) return;
-    if (!details.requestHeaders) return;
+    if (!details.tabId || details.tabId < 0 || !details.requestHeaders) return;
+    const tabId = details.tabId;
+    readTabData(tabId, details.url)
+      .then((data) => {
+        data.stats.requests += 1;
+        return persistTabData(tabId, data);
+      })
+      .then(() => {
+        const headers = details.requestHeaders.map(h => ({ name: h.name, value: h.value || '' }));
+        const findings = [
+          ...analyzeHeaders(headers, 'Request Header', { url: details.url, capture_type: 'header' }),
+          ...analyzeUrl(details.url, { url: details.url, capture_type: 'url' }),
+        ];
 
-    const data = ensureTabData(details.tabId, details.url);
-    data.stats.requests++;
+        // BaaS detection from outgoing request headers
+        const baasInfo = detectBaaSRequest(details.url, headers);
+        if (baasInfo && baasInfo.apiKey) {
+          if (!baasTabStates.has(tabId)) baasTabStates.set(tabId, new BaaSTabState());
+          const baasState = baasTabStates.get(tabId);
+          baasState.enqueueProbe(baasInfo, (baasFindings) => {
+            addFindings(tabId, baasFindings, details.url).catch(() => {});
+          });
+        }
 
-    const headers = details.requestHeaders.map(h => ({ name: h.name, value: h.value || '' }));
-    const findings = analyzeHeaders(headers, 'Request Header');
-    const urlFindings = analyzeUrl(details.url);
-
-    addFindings(details.tabId, [...findings, ...urlFindings], details.url);
+        return addFindings(tabId, findings, details.url);
+      })
+      .catch(() => {});
   },
   { urls: ['<all_urls>'] },
-  ['requestHeaders']
+  ['requestHeaders'],
 );
 
-// Analyze response headers
 chrome.webRequest.onHeadersReceived.addListener(
   (details) => {
-    if (!details.tabId || details.tabId < 0) return;
-    if (!details.responseHeaders) return;
-
-    ensureTabData(details.tabId, details.url);
-
+    if (!details.tabId || details.tabId < 0 || !details.responseHeaders) return;
     const headers = details.responseHeaders.map(h => ({ name: h.name, value: h.value || '' }));
-    const findings = analyzeHeaders(headers, 'Response Header');
-
-    addFindings(details.tabId, findings, details.url);
+    const findings = analyzeHeaders(headers, 'Response Header', {
+      url: details.url,
+      status: details.statusCode,
+      capture_type: 'header',
+    });
+    addFindings(details.tabId, findings, details.url).catch(() => {});
   },
   { urls: ['<all_urls>'] },
-  ['responseHeaders']
+  ['responseHeaders'],
 );
 
-console.log('[KeyLeak] Service worker started — passive monitoring active');
+console.log('[KeyLeak] Service worker started - launch-gate monitoring active');

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -328,6 +328,7 @@ async function exportReport(tabId, format = 'json') {
 
 async function clearTab(tabId) {
   tabCache.delete(tabId);
+  baasTabStates.delete(tabId);
   await storageRemove(storageKey(tabId));
   chrome.action.setBadgeText({ text: '', tabId });
   return { ok: true };
@@ -358,7 +359,7 @@ async function handleAnalyzeIntercepted(tabId, data = {}) {
   // BaaS real-time detection: check if this request targets a BaaS provider
   const requestHeaders = headers || [];
   const baasInfo = detectBaaSRequest(url, requestHeaders);
-  if (baasInfo && baasInfo.apiKey) {
+  if (baasInfo && (baasInfo.apiKey || baasInfo.provider === 'firebase')) {
     if (!baasTabStates.has(tabId)) baasTabStates.set(tabId, new BaaSTabState());
     const baasState = baasTabStates.get(tabId);
     baasState.enqueueProbe(baasInfo, (baasFindings) => {
@@ -495,7 +496,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 
         // BaaS detection from outgoing request headers
         const baasInfo = detectBaaSRequest(details.url, headers);
-        if (baasInfo && baasInfo.apiKey) {
+        if (baasInfo && (baasInfo.apiKey || baasInfo.provider === 'firebase')) {
           if (!baasTabStates.has(tabId)) baasTabStates.set(tabId, new BaaSTabState());
           const baasState = baasTabStates.get(tabId);
           baasState.enqueueProbe(baasInfo, (baasFindings) => {

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -12,6 +12,7 @@ import {
   severityRank,
 } from './lib/reporting.js';
 import { detectBaaSRequest, BaaSTabState } from './lib/baas-detector.js';
+import { testKey } from './lib/key-tester.js';
 
 const STORAGE_PREFIX = 'keyleak_tab_';
 const SETTINGS_KEY = 'keyleak_settings';
@@ -415,6 +416,17 @@ async function handleMessage(message, sender) {
   if (message.action === 'suppress_finding') {
     if (!Number.isInteger(targetTabId)) return { ok: false, error: 'No tab selected.' };
     return suppressFinding(targetTabId, message.findingId);
+  }
+
+  if (message.action === 'test_key') {
+    const { type, raw_value } = message;
+    if (!type || !raw_value) return { ok: false, error: 'Missing type or raw_value.' };
+    try {
+      const result = await testKey(type, raw_value);
+      return { ok: true, ...result };
+    } catch (err) {
+      return { ok: false, status: 'error', detail: err.message || 'Test failed.' };
+    }
   }
 
   if (message.action === 'run_full_scan') {

--- a/extension/tests/analyzer.test.js
+++ b/extension/tests/analyzer.test.js
@@ -6,12 +6,13 @@ import { buildReport, formatMarkdownReport, formatSarifReport, redactValue } fro
 
 const detectorIds = new Set(PATTERN_DEFINITIONS.map(definition => definition.id));
 
-assert(detectorIds.has('mcp_config_secret'));
+// mcp_config_secret is extension=false (too noisy on minified JS)
+assert(!detectorIds.has('mcp_config_secret'));
 assert(detectorIds.has('graphql_introspection_hint'));
 assert(detectorIds.has('hidden_prompt_injection'));
 assert(detectorIds.has('source_map_reference'));
 assert(detectorIds.has('openrouter_api_key'));
-assert(detectorIds.has('sql_injection_lead'));
+assert(!detectorIds.has('sql_injection_lead'));
 assert(detectorIds.has('xss_sink_lead'));
 assert(detectorIds.has('idor_direct_object_lead'));
 assert(!detectorIds.has('n_plus_one_query_lead'));
@@ -36,10 +37,9 @@ assert.notEqual(openAiFinding.evidence.redacted_value, openAiKey);
 assert.match(openAiFinding.evidence.redacted_value, /\.\.\./);
 assert.equal(openAiFinding.raw_value, openAiKey);
 
+// sql_injection_lead is extension=false (too noisy on minified JS)
 const sqlFinding = findings.find(finding => finding.type === 'sql_injection');
-assert(sqlFinding);
-assert.equal(sqlFinding.category, 'appsec');
-assert.equal(sqlFinding.validation_status, 'lead');
+assert(!sqlFinding, 'sql_injection should not be in extension bundle');
 
 const xssFinding = findings.find(finding => finding.type === 'xss');
 assert(xssFinding);

--- a/extension/tests/analyzer.test.js
+++ b/extension/tests/analyzer.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+
+import { analyzeContent } from '../lib/analyzer.js';
+import { PATTERN_DEFINITIONS } from '../lib/patterns.js';
+import { buildReport, formatMarkdownReport, formatSarifReport, redactValue } from '../lib/reporting.js';
+
+const detectorIds = new Set(PATTERN_DEFINITIONS.map(definition => definition.id));
+
+assert(detectorIds.has('mcp_config_secret'));
+assert(detectorIds.has('graphql_introspection_hint'));
+assert(detectorIds.has('hidden_prompt_injection'));
+assert(detectorIds.has('source_map_reference'));
+assert(detectorIds.has('openrouter_api_key'));
+assert(detectorIds.has('sql_injection_lead'));
+assert(detectorIds.has('xss_sink_lead'));
+assert(detectorIds.has('idor_direct_object_lead'));
+assert(!detectorIds.has('n_plus_one_query_lead'));
+
+const openAiKey = `sk-proj-${'a'.repeat(24)}`;
+const findings = analyzeContent(
+  `window.__CONFIG__ = { openai: "${openAiKey}", map: "sourceMappingURL=app.js.map" };
+   const query = \`SELECT * FROM users WHERE id=\${userId}\`;
+   element.innerHTML = location.hash;
+   fetch('/users/123456');`,
+  'External Script: https://preview.example.com/app.js',
+  { url: 'https://preview.example.com/app.js', capture_type: 'external-script' },
+);
+
+const openAiFinding = findings.find(finding => finding.type === 'openai_api_key');
+assert(openAiFinding);
+assert.equal(openAiFinding.severity, 'critical');
+assert.equal(openAiFinding.detector_id, 'leak.openai_api_key');
+assert.equal(openAiFinding.category, 'leak');
+assert.equal(openAiFinding.validation_status, 'validated');
+assert.notEqual(openAiFinding.evidence.redacted_value, openAiKey);
+assert.match(openAiFinding.evidence.redacted_value, /\.\.\./);
+assert.equal(openAiFinding.raw_value, openAiKey);
+
+const sqlFinding = findings.find(finding => finding.type === 'sql_injection');
+assert(sqlFinding);
+assert.equal(sqlFinding.category, 'appsec');
+assert.equal(sqlFinding.validation_status, 'lead');
+
+const xssFinding = findings.find(finding => finding.type === 'xss');
+assert(xssFinding);
+assert.equal(xssFinding.detector_id, 'appsec.xss_sink_lead');
+
+const idorFinding = findings.find(finding => finding.type === 'idor');
+assert(idorFinding);
+assert.equal(idorFinding.category, 'access-control');
+
+const report = buildReport('https://preview.example.com/?token=very-secret-token-value', findings, { externalScripts: 1 });
+assert.equal(report.verdict.status, 'BLOCK_SHIP');
+assert.equal(report.profile, 'launch-gate');
+assert.deepEqual(report.packs, ['leak', 'appsec', 'access-control']);
+assert.equal(report.pack_summary.leak.total_findings > 0, true);
+assert.equal(report.pack_summary.appsec.total_findings > 0, true);
+assert.ok(!report.target.includes('very-secret-token-value') || report.target.includes('...') || report.target.length > 0, 'target URL should be present');
+assert.equal(report.findings.some(finding => Object.hasOwn(finding, 'raw_value')), false);
+assert.match(formatMarkdownReport(report), /BLOCK SHIP/);
+assert.match(formatSarifReport(report), /leak.openai_api_key/);
+
+assert.equal(redactValue('abcd'), 'abcd');

--- a/extension/tests/baas-detector.test.js
+++ b/extension/tests/baas-detector.test.js
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for BaaS real-time detector.
+ * Run: node extension/tests/baas-detector.test.js
+ */
+
+import { detectBaaSRequest, classifyTable, buildBaaSFinding, BaaSTabState } from '../lib/baas-detector.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${message}`);
+  }
+}
+
+function test(name, fn) {
+  console.log(`  ${name}`);
+  fn();
+}
+
+console.log('BaaS Detector Tests');
+console.log('===================');
+
+// --- detectBaaSRequest ---
+
+test('detects Supabase table request', () => {
+  const result = detectBaaSRequest(
+    'https://abcdefghijklmnopqrst.supabase.co/rest/v1/profiles?select=*&limit=1',
+    [{ name: 'apikey', value: 'test-key-123' }]
+  );
+  assert(result !== null, 'should detect');
+  assert(result.provider === 'supabase', 'provider should be supabase');
+  assert(result.type === 'table', 'type should be table');
+  assert(result.endpoint === 'profiles', 'endpoint should be profiles');
+  assert(result.apiKey === 'test-key-123', 'should extract apikey header');
+  assert(result.baseUrl === 'https://abcdefghijklmnopqrst.supabase.co', 'should extract base URL');
+});
+
+test('detects Supabase RPC request', () => {
+  const result = detectBaaSRequest(
+    'https://abcdefghijklmnopqrst.supabase.co/rest/v1/rpc/increment_plays',
+    [{ name: 'apikey', value: 'key' }]
+  );
+  assert(result !== null, 'should detect');
+  assert(result.type === 'rpc', 'type should be rpc');
+  assert(result.endpoint === 'increment_plays', 'endpoint should be increment_plays');
+});
+
+test('detects Supabase storage request', () => {
+  const result = detectBaaSRequest(
+    'https://abcdefghijklmnopqrst.supabase.co/storage/v1/object/public/images/photo.jpg',
+    [{ name: 'apikey', value: 'key' }]
+  );
+  assert(result !== null, 'should detect');
+  assert(result.type === 'storage', 'type should be storage');
+});
+
+test('detects Firebase Realtime Database request', () => {
+  const result = detectBaaSRequest(
+    'https://my-app-default-rtdb.firebaseio.com/users.json',
+    []
+  );
+  assert(result !== null, 'should detect');
+  assert(result.provider === 'firebase', 'provider should be firebase');
+  assert(result.type === 'database', 'type should be database');
+});
+
+test('returns null for non-BaaS URL', () => {
+  const result = detectBaaSRequest('https://api.example.com/v1/users', []);
+  assert(result === null, 'should return null for non-BaaS URL');
+});
+
+test('extracts apikey from object-style headers', () => {
+  const result = detectBaaSRequest(
+    'https://abcdefghijklmnopqrst.supabase.co/rest/v1/users',
+    { apikey: 'my-key', Authorization: 'Bearer jwt-token' }
+  );
+  assert(result !== null, 'should detect');
+  assert(result.apiKey === 'my-key', 'should extract from object headers');
+});
+
+// --- classifyTable ---
+
+test('classifies payout table as critical', () => {
+  assert(classifyTable('artist_payout_details') === 'critical', 'payout should be critical');
+});
+
+test('classifies admin table as critical', () => {
+  assert(classifyTable('admin_settings') === 'critical', 'admin should be critical');
+});
+
+test('classifies regular table as high', () => {
+  assert(classifyTable('posts') === 'high', 'posts should be high');
+});
+
+test('classifies tracks as high', () => {
+  assert(classifyTable('tracks') === 'high', 'tracks should be high');
+});
+
+// --- buildBaaSFinding ---
+
+test('builds finding for open Supabase table', () => {
+  const finding = buildBaaSFinding(
+    { provider: 'supabase', type: 'table', baseUrl: 'https://x.supabase.co', endpoint: 'users', apiKey: 'k' },
+    { open: true, status: 200, columns: ['id', 'email', 'name'] }
+  );
+  assert(finding.type === 'baas_open_table', 'type should be baas_open_table');
+  assert(finding.severity === 'high', 'users table should be high');
+  assert(finding.validation_status === 'confirmed', 'should be confirmed');
+  assert(finding.category === 'baas', 'category should be baas');
+  assert(finding.evidence.snippet.includes('users'), 'snippet should mention table name');
+  assert(finding.evidence.snippet.includes('id'), 'snippet should include column names');
+});
+
+test('builds critical finding for payment table', () => {
+  const finding = buildBaaSFinding(
+    { provider: 'supabase', type: 'table', baseUrl: 'https://x.supabase.co', endpoint: 'payment_details', apiKey: 'k' },
+    { open: true, status: 200, columns: ['id', 'amount'] }
+  );
+  assert(finding.severity === 'critical', 'payment table should be critical');
+});
+
+test('builds finding for open Firebase DB', () => {
+  const finding = buildBaaSFinding(
+    { provider: 'firebase', type: 'database', baseUrl: 'https://app.firebaseio.com', endpoint: '/', apiKey: '' },
+    { open: true, status: 200, keys: ['users', 'posts'] }
+  );
+  assert(finding.type === 'baas_open_table', 'type should be baas_open_table');
+  assert(finding.severity === 'critical', 'open Firebase DB should be critical');
+  assert(finding.evidence.snippet.includes('Firebase'), 'should mention Firebase');
+});
+
+// --- BaaSTabState ---
+
+test('BaaSTabState deduplicates endpoints', () => {
+  const state = new BaaSTabState();
+  assert(state.shouldProbe('users') === true, 'first probe should be allowed');
+  state.markTested('users');
+  assert(state.shouldProbe('users') === false, 'duplicate probe should be blocked');
+  assert(state.shouldProbe('posts') === true, 'different endpoint should be allowed');
+});
+
+test('BaaSTabState respects probe cap', () => {
+  const state = new BaaSTabState();
+  for (let i = 0; i < 30; i++) {
+    state.markTested(`table_${i}`);
+  }
+  assert(state.shouldProbe('table_30') === false, 'should block after cap reached');
+});
+
+// --- Summary ---
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/extension/tests/baas-detector.test.js
+++ b/extension/tests/baas-detector.test.js
@@ -3,7 +3,7 @@
  * Run: node extension/tests/baas-detector.test.js
  */
 
-import { detectBaaSRequest, classifyTable, buildBaaSFinding, BaaSTabState } from '../lib/baas-detector.js';
+import { detectBaaSRequest, classifyTable, buildBaaSFinding, BaaSTabState, MAX_PROBES_PER_TAB } from '../lib/baas-detector.js';
 
 let passed = 0;
 let failed = 0;
@@ -67,6 +67,17 @@ test('detects Firebase Realtime Database request', () => {
   assert(result !== null, 'should detect');
   assert(result.provider === 'firebase', 'provider should be firebase');
   assert(result.type === 'database', 'type should be database');
+});
+
+test('detects Firebase Storage request', () => {
+  const result = detectBaaSRequest(
+    'https://firebasestorage.googleapis.com/v0/b/my-app.appspot.com/o/photo.jpg',
+    []
+  );
+  assert(result !== null, 'should detect');
+  assert(result.provider === 'firebase', 'provider should be firebase');
+  assert(result.type === 'storage', 'type should be storage');
+  assert(result.endpoint === 'my-app.appspot.com', 'endpoint should be bucket name');
 });
 
 test('returns null for non-BaaS URL', () => {
@@ -134,22 +145,51 @@ test('builds finding for open Firebase DB', () => {
   assert(finding.evidence.snippet.includes('Firebase'), 'should mention Firebase');
 });
 
+test('builds finding for open RPC function', () => {
+  const finding = buildBaaSFinding(
+    { provider: 'supabase', type: 'rpc', baseUrl: 'https://x.supabase.co', endpoint: 'get_stats', apiKey: 'k' },
+    { open: true, status: 200 }
+  );
+  assert(finding.type === 'baas_open_rpc', 'type should be baas_open_rpc');
+  assert(finding.severity === 'medium', 'RPC should be medium');
+  assert(finding.evidence.snippet.includes('get_stats'), 'snippet should mention function name');
+});
+
+test('builds finding for open storage bucket', () => {
+  const finding = buildBaaSFinding(
+    { provider: 'supabase', type: 'storage', baseUrl: 'https://x.supabase.co', endpoint: 'storage', apiKey: 'k' },
+    { open: true, status: 200, buckets: [{ name: 'avatars', public: true }] }
+  );
+  assert(finding.type === 'baas_open_storage', 'type should be baas_open_storage');
+  assert(finding.severity === 'high', 'storage should be high');
+  assert(finding.evidence.snippet.includes('avatars'), 'snippet should include bucket name');
+});
+
 // --- BaaSTabState ---
 
 test('BaaSTabState deduplicates endpoints', () => {
   const state = new BaaSTabState();
-  assert(state.shouldProbe('users') === true, 'first probe should be allowed');
-  state.markTested('users');
-  assert(state.shouldProbe('users') === false, 'duplicate probe should be blocked');
-  assert(state.shouldProbe('posts') === true, 'different endpoint should be allowed');
+  const info = { provider: 'supabase', type: 'table', endpoint: 'users' };
+  assert(state.shouldProbe(info) === true, 'first probe should be allowed');
+  state.markTested(info);
+  assert(state.shouldProbe(info) === false, 'duplicate probe should be blocked');
+  assert(state.shouldProbe({ provider: 'supabase', type: 'table', endpoint: 'posts' }) === true, 'different endpoint should be allowed');
+});
+
+test('BaaSTabState uses composite dedupe key', () => {
+  const state = new BaaSTabState();
+  const tableInfo = { provider: 'supabase', type: 'table', endpoint: 'users' };
+  const rpcInfo = { provider: 'supabase', type: 'rpc', endpoint: 'users' };
+  state.markTested(tableInfo);
+  assert(state.shouldProbe(rpcInfo) === true, 'same endpoint but different type should be allowed');
 });
 
 test('BaaSTabState respects probe cap', () => {
   const state = new BaaSTabState();
-  for (let i = 0; i < 30; i++) {
-    state.markTested(`table_${i}`);
+  for (let i = 0; i < MAX_PROBES_PER_TAB; i++) {
+    state.markTested({ provider: 'supabase', type: 'table', endpoint: `table_${i}` });
   }
-  assert(state.shouldProbe('table_30') === false, 'should block after cap reached');
+  assert(state.shouldProbe({ provider: 'supabase', type: 'table', endpoint: `table_${MAX_PROBES_PER_TAB}` }) === false, 'should block after cap reached');
 });
 
 // --- Summary ---

--- a/keyleak/baas_validator.py
+++ b/keyleak/baas_validator.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from .models import Evidence, Finding
 from .redaction import redact_url, redact_value
 
-BaaSProber = Callable[[str, str, Dict[str, str]], Dict[str, Any]]
+BaaSProber = Callable[..., Dict[str, Any]]
 
 TABLE_PROBE_CAP = 50
 BUCKET_PROBE_CAP = 10
@@ -99,10 +99,13 @@ class BaaSValidation:
 # Default HTTP prober — overridden by tests.
 # ---------------------------------------------------------------------------
 
-def _default_prober(method: str, url: str, headers: Dict[str, str]) -> Dict[str, Any]:  # pragma: no cover
+def _default_prober(method: str, url: str, headers: Dict[str, str], body: Optional[str] = None) -> Dict[str, Any]:  # pragma: no cover
     import requests as _requests
 
-    resp = _requests.request(method, url, headers=headers, timeout=10)
+    kwargs: Dict[str, Any] = {"headers": headers, "timeout": 10}
+    if body is not None and method.upper() in ("POST", "PUT", "PATCH"):
+        kwargs["data"] = body
+    resp = _requests.request(method, url, **kwargs)
     body: Any = None
     try:
         body = resp.json()
@@ -556,13 +559,22 @@ def _probe_write_access(
     prober: BaaSProber,
     validation: BaaSValidation,
 ) -> None:
-    """Test if open tables accept writes. Uses invalid schema body to avoid creating data."""
+    """Test if open tables accept writes.
+
+    Sends a POST with an intentionally invalid JSON body that cannot match
+    any real table schema.  PostgREST returns 400 (schema error) when
+    inserts are enabled but the body is invalid, vs 403 when RLS blocks
+    the write entirely.  A 400 therefore proves writes are structurally
+    open without ever creating a row.
+    """
     write_headers = {**headers, "Content-Type": "application/json", "Prefer": "return=minimal"}
+    # Body with a key that cannot match any real column — guarantees 400, never 201.
+    probe_body = '{"__keyleak_write_probe__": true}'
     open_table_names = [t.target for t in validation.open_tables]
 
     for table in open_table_names[:WRITE_PROBE_CAP]:
         try:
-            resp = prober("POST", f"{config.project_url}/rest/v1/{table}", write_headers)
+            resp = prober("POST", f"{config.project_url}/rest/v1/{table}", write_headers, probe_body)
         except Exception:
             continue
 
@@ -608,7 +620,7 @@ def _decode_jwt_claims(token: str) -> Optional[Dict[str, Any]]:
     try:
         payload = parts[1]
         # Add padding
-        payload += "=" * (4 - len(payload) % 4)
+        payload += "=" * ((4 - len(payload) % 4) % 4)
         decoded = base64.urlsafe_b64decode(payload)
         return _json.loads(decoded)
     except Exception:

--- a/keyleak/baas_validator.py
+++ b/keyleak/baas_validator.py
@@ -514,39 +514,35 @@ def _probe_rpcs(
     prober: BaaSProber,
     validation: BaaSValidation,
 ) -> None:
-    rpc_headers = {**headers, "Content-Type": "application/json"}
-    for fn in config.rpc_functions[:RPC_PROBE_CAP]:
-        try:
-            resp = prober("POST", f"{config.project_url}/rest/v1/rpc/{fn}", rpc_headers)
-        except Exception:
-            continue
+    """Surface RPC functions as leads without executing them.
 
-        status = resp.get("status_code", 0)
-        if status in (200, 204):
-            result = BaaSProbeResult(
-                probe_type="rpc_call", target=fn, status="confirmed", http_status=status,
-            )
-            validation.callable_rpcs.append(result)
-            validation.findings.append(Finding(
-                type="baas_open_rpc",
-                severity="medium",
-                confidence=0.85,
-                detector_id="baas.open_rpc",
+    POSTing to an RPC endpoint executes the function, which may have
+    side effects.  Instead we emit each client-referenced RPC as a
+    ``lead`` so operators can review permissions manually.
+    """
+    for fn in config.rpc_functions[:RPC_PROBE_CAP]:
+        validation.callable_rpcs.append(BaaSProbeResult(
+            probe_type="rpc_call", target=fn, status="lead",
+        ))
+        validation.findings.append(Finding(
+            type="baas_open_rpc",
+            severity="medium",
+            confidence=0.6,
+            detector_id="baas.open_rpc",
+            source=config.project_url,
+            evidence=Evidence(
                 source=config.project_url,
-                evidence=Evidence(
-                    source=config.project_url,
-                    snippet=f"RPC function '{fn}' callable without authentication (HTTP {status}).",
-                    redacted_value=f"rpc:{fn}",
-                    response_status=status,
-                    request_url=f"{redact_url(config.project_url)}/rest/v1/rpc/{fn}",
-                ),
-                risk_reason=f"Supabase RPC function '{fn}' is callable with just the anon key. "
-                            "If it mutates data or returns sensitive information, this is exploitable.",
-                remediation=f"Add a security definer or check auth.uid() inside the '{fn}' function. "
-                            "Consider revoking EXECUTE from the anon role.",
-                validation_status="confirmed",
-                category="baas",
-            ))
+                snippet=f"RPC function '{fn}' referenced in client code and callable via the REST API.",
+                redacted_value=f"rpc:{fn}",
+                request_url=f"{redact_url(config.project_url)}/rest/v1/rpc/{fn}",
+            ),
+            risk_reason=f"Supabase RPC function '{fn}' is exposed to the anon role via the client bundle. "
+                        "If it mutates data or returns sensitive information, it may be exploitable.",
+            remediation=f"Verify that '{fn}' checks auth.uid() internally. "
+                        "Consider revoking EXECUTE from the anon role for sensitive functions.",
+            validation_status="lead",
+            category="baas",
+        ))
 
 
 # ---------------------------------------------------------------------------

--- a/keyleak/baas_validator.py
+++ b/keyleak/baas_validator.py
@@ -106,14 +106,14 @@ def _default_prober(method: str, url: str, headers: Dict[str, str], body: Option
     if body is not None and method.upper() in ("POST", "PUT", "PATCH"):
         kwargs["data"] = body
     resp = _requests.request(method, url, **kwargs)
-    body: Any = None
+    response_body: Any = None
     try:
-        body = resp.json()
+        response_body = resp.json()
     except Exception:
-        body = resp.text[:500] if resp.text else None
+        response_body = resp.text[:500] if resp.text else None
     return {
         "status_code": resp.status_code,
-        "body": body,
+        "body": response_body,
         "headers": {k.lower(): v for k, v in resp.headers.items()},
     }
 

--- a/keyleak/baas_validator.py
+++ b/keyleak/baas_validator.py
@@ -1,0 +1,920 @@
+"""BaaS active validation engine (Wave 4.1).
+
+Detects Supabase, Firebase, and Appwrite configuration extracted from client
+bundles, then probes their REST APIs with read-only requests to confirm
+whether Row-Level Security (or equivalent) is properly enforced.
+
+Architecture mirrors ``blast_radius.py``: every HTTP call goes through an
+injectable ``BaaSProber`` callable so tests never touch the network.
+"""
+
+from __future__ import annotations
+
+import base64
+import json as _json
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .models import Evidence, Finding
+from .redaction import redact_url, redact_value
+
+BaaSProber = Callable[[str, str, Dict[str, str]], Dict[str, Any]]
+
+TABLE_PROBE_CAP = 50
+BUCKET_PROBE_CAP = 10
+RPC_PROBE_CAP = 20
+WRITE_PROBE_CAP = 20
+
+
+@dataclass
+class BaaSConfig:
+    provider: str
+    project_url: str
+    api_key: str
+    tables: List[str] = field(default_factory=list)
+    rpc_functions: List[str] = field(default_factory=list)
+    storage_buckets: List[str] = field(default_factory=list)
+
+
+@dataclass
+class BaaSProbeResult:
+    probe_type: str
+    target: str
+    status: str  # "confirmed", "denied", "error"
+    http_status: Optional[int] = None
+    row_count: Optional[int] = None
+    columns: Optional[List[str]] = None
+    note: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "probe_type": self.probe_type,
+            "target": self.target,
+            "status": self.status,
+        }
+        if self.http_status is not None:
+            d["http_status"] = self.http_status
+        if self.row_count is not None:
+            d["row_count"] = self.row_count
+        if self.columns:
+            d["columns"] = self.columns
+        if self.note:
+            d["note"] = self.note
+        return d
+
+
+@dataclass
+class BaaSValidation:
+    provider: str
+    project_url_redacted: str
+    key_valid: bool = False
+    open_tables: List[BaaSProbeResult] = field(default_factory=list)
+    protected_tables: List[BaaSProbeResult] = field(default_factory=list)
+    accessible_buckets: List[BaaSProbeResult] = field(default_factory=list)
+    callable_rpcs: List[BaaSProbeResult] = field(default_factory=list)
+    writable_tables: List[BaaSProbeResult] = field(default_factory=list)
+    realtime_channels: List[BaaSProbeResult] = field(default_factory=list)
+    cors_open: bool = False
+    findings: List[Finding] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "project_url_redacted": self.project_url_redacted,
+            "key_valid": self.key_valid,
+            "open_tables": [t.to_dict() for t in self.open_tables],
+            "protected_tables": [t.to_dict() for t in self.protected_tables],
+            "accessible_buckets": [b.to_dict() for b in self.accessible_buckets],
+            "callable_rpcs": [r.to_dict() for r in self.callable_rpcs],
+            "writable_tables": [w.to_dict() for w in self.writable_tables],
+            "realtime_channels": [c.to_dict() for c in self.realtime_channels],
+            "cors_open": self.cors_open,
+            "findings_count": len(self.findings),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default HTTP prober — overridden by tests.
+# ---------------------------------------------------------------------------
+
+def _default_prober(method: str, url: str, headers: Dict[str, str]) -> Dict[str, Any]:  # pragma: no cover
+    import requests as _requests
+
+    resp = _requests.request(method, url, headers=headers, timeout=10)
+    body: Any = None
+    try:
+        body = resp.json()
+    except Exception:
+        body = resp.text[:500] if resp.text else None
+    return {
+        "status_code": resp.status_code,
+        "body": body,
+        "headers": {k.lower(): v for k, v in resp.headers.items()},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Config extraction
+# ---------------------------------------------------------------------------
+
+_SUPABASE_URL_RE = re.compile(r"https://[a-z0-9]{20,}\.supabase\.co")
+_SUPABASE_JWT_RE = re.compile(
+    r"eyJ[A-Za-z0-9_-]{30,}\.eyJ[A-Za-z0-9_-]{30,}\.[A-Za-z0-9_-]{20,}"
+)
+_SUPABASE_PUB_RE = re.compile(r"sb_publishable_[A-Za-z0-9_-]{20,}")
+
+# Firebase
+_FIREBASE_DB_RE = re.compile(r"https://[a-z0-9-]+\.firebaseio\.com")
+_FIREBASE_KEY_RE = re.compile(r"AIza[0-9A-Za-z_-]{35}")
+_FIREBASE_BUCKET_RE = re.compile(r"[a-z0-9-]+\.appspot\.com")
+
+# Appwrite / PocketBase
+_APPWRITE_ENDPOINT_RE = re.compile(r"https?://[a-zA-Z0-9.-]+/v1")
+_POCKETBASE_URL_RE = re.compile(r"https?://[a-zA-Z0-9.-]+(?::[0-9]+)?")
+
+
+def extract_baas_config(
+    raw_findings: Optional[List[Dict[str, Any]]] = None,
+    js_extraction: Optional[Dict[str, Any]] = None,
+) -> Optional[BaaSConfig]:
+    """Build a BaaSConfig from browser-scan findings and the JS extraction payload."""
+
+    project_url: Optional[str] = None
+    api_key: Optional[str] = None
+    tables: List[str] = []
+    rpcs: List[str] = []
+    buckets: List[str] = []
+
+    if js_extraction:
+        project_url = js_extraction.get("supabase_url")
+        api_key = js_extraction.get("supabase_key")
+        tables = list(js_extraction.get("tables") or [])
+        rpcs = list(js_extraction.get("rpcs") or [])
+        buckets = list(js_extraction.get("buckets") or [])
+
+    for f in raw_findings or []:
+        det = f.get("detector_id") or f.get("type") or ""
+        val = f.get("value") or ""
+        if not project_url and ("supabase_url" in det or _SUPABASE_URL_RE.search(val)):
+            m = _SUPABASE_URL_RE.search(val)
+            if m:
+                project_url = m.group(0)
+        if not api_key and ("supabase_anon_key" in det or "supabase_publishable_key" in det):
+            api_key = val
+        if not api_key and _SUPABASE_JWT_RE.search(val):
+            api_key = _SUPABASE_JWT_RE.search(val).group(0)  # type: ignore[union-attr]
+        if not api_key and _SUPABASE_PUB_RE.search(val):
+            api_key = _SUPABASE_PUB_RE.search(val).group(0)  # type: ignore[union-attr]
+
+    if project_url and api_key:
+        tables = list(dict.fromkeys(tables))
+        rpcs = list(dict.fromkeys(rpcs))
+        buckets = list(dict.fromkeys(buckets))
+
+        return BaaSConfig(
+            provider="supabase",
+            project_url=project_url.rstrip("/"),
+            api_key=api_key,
+            tables=tables,
+            rpc_functions=rpcs,
+            storage_buckets=buckets,
+        )
+
+    # Firebase detection
+    firebase_url: Optional[str] = None
+    firebase_key: Optional[str] = None
+    firebase_bucket: Optional[str] = None
+
+    if js_extraction:
+        firebase_url = js_extraction.get("firebase_db_url")
+        firebase_key = js_extraction.get("firebase_api_key")
+        firebase_bucket = js_extraction.get("firebase_storage_bucket")
+
+    for f in raw_findings or []:
+        det = f.get("detector_id") or f.get("type") or ""
+        val = f.get("value") or ""
+        if not firebase_url and ("firebase_db_url" in det or _FIREBASE_DB_RE.search(val)):
+            m = _FIREBASE_DB_RE.search(val)
+            if m:
+                firebase_url = m.group(0)
+        if not firebase_key and _FIREBASE_KEY_RE.search(val):
+            firebase_key = _FIREBASE_KEY_RE.search(val).group(0)
+        if not firebase_bucket and _FIREBASE_BUCKET_RE.search(val):
+            firebase_bucket = _FIREBASE_BUCKET_RE.search(val).group(0)
+
+    if firebase_url:
+        return BaaSConfig(
+            provider="firebase",
+            project_url=firebase_url.rstrip("/"),
+            api_key=firebase_key or "",
+            storage_buckets=[firebase_bucket] if firebase_bucket else [],
+        )
+
+    # Appwrite detection
+    appwrite_endpoint: Optional[str] = None
+    appwrite_project: Optional[str] = None
+    if js_extraction:
+        appwrite_endpoint = js_extraction.get("appwrite_endpoint")
+        appwrite_project = js_extraction.get("appwrite_project")
+
+    for f in raw_findings or []:
+        det = f.get("detector_id") or f.get("type") or ""
+        val = f.get("value") or ""
+        if not appwrite_endpoint and "appwrite_endpoint" in det:
+            m = _APPWRITE_ENDPOINT_RE.search(val)
+            if m:
+                appwrite_endpoint = m.group(0)
+
+    if appwrite_endpoint:
+        return BaaSConfig(
+            provider="appwrite",
+            project_url=appwrite_endpoint.rstrip("/"),
+            api_key=appwrite_project or "",
+        )
+
+    # PocketBase detection
+    pocketbase_url: Optional[str] = None
+    if js_extraction:
+        pocketbase_url = js_extraction.get("pocketbase_url")
+    for f in raw_findings or []:
+        det = f.get("detector_id") or f.get("type") or ""
+        val = f.get("value") or ""
+        if not pocketbase_url and "pocketbase_url" in det:
+            m = _POCKETBASE_URL_RE.search(val)
+            if m:
+                pocketbase_url = m.group(0)
+
+    if pocketbase_url:
+        return BaaSConfig(
+            provider="pocketbase",
+            project_url=pocketbase_url.rstrip("/"),
+            api_key="",
+        )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Active validation
+# ---------------------------------------------------------------------------
+
+def validate_baas_config(
+    config: BaaSConfig,
+    *,
+    prober: Optional[BaaSProber] = None,
+    js_extraction: Optional[Dict[str, Any]] = None,
+) -> BaaSValidation:
+    """Run read-only probes against a BaaS configuration.
+
+    Returns a ``BaaSValidation`` with enriched findings. All HTTP calls go
+    through ``prober`` (defaults to ``requests`` in production).
+    """
+    if config.provider == "supabase":
+        return _validate_supabase(config, prober or _default_prober, js_extraction=js_extraction)
+    if config.provider == "firebase":
+        return _validate_firebase(config, prober or _default_prober)
+    if config.provider == "appwrite":
+        return _validate_appwrite(config, prober or _default_prober)
+    if config.provider == "pocketbase":
+        return _validate_pocketbase(config, prober or _default_prober)
+    return BaaSValidation(
+        provider=config.provider,
+        project_url_redacted=redact_url(config.project_url),
+    )
+
+
+def _validate_supabase(config: BaaSConfig, prober: BaaSProber, *, js_extraction: Optional[Dict[str, Any]] = None) -> BaaSValidation:
+    url = config.project_url
+    headers = {
+        "apikey": config.api_key,
+        "Authorization": f"Bearer {config.api_key}",
+    }
+    validation = BaaSValidation(
+        provider="supabase",
+        project_url_redacted=redact_url(url),
+    )
+
+    try:
+        resp = prober("GET", f"{url}/rest/v1/", headers)
+    except Exception as exc:
+        validation.key_valid = False
+        validation.findings.append(_finding(
+            "baas_key_validation_error", "medium", config,
+            f"Supabase key validation probe failed: {exc}",
+            "Check network connectivity and Supabase project status.",
+        ))
+        return validation
+
+    status = resp.get("status_code", 0)
+    validation.key_valid = status == 200
+    if not validation.key_valid:
+        validation.findings.append(_finding(
+            "baas_key_invalid", "info", config,
+            f"Supabase anon key returned HTTP {status}. Key may be invalid or project may be paused.",
+            "No action needed if the key is intentionally disabled.",
+        ))
+        return validation
+
+    resp_headers = resp.get("headers") or {}
+    cors = resp_headers.get("access-control-allow-origin", "")
+    validation.cors_open = cors == "*"
+    if validation.cors_open:
+        validation.findings.append(_finding(
+            "baas_cors_wildcard", "low", config,
+            "Supabase REST API returns Access-Control-Allow-Origin: *. Any origin can make authenticated requests.",
+            f"Restrict CORS to your application's origin in the Supabase dashboard.",
+            validation_status="confirmed",
+        ))
+
+    _probe_tables(config, headers, prober, validation)
+    _probe_storage(config, headers, prober, validation)
+    _probe_rpcs(config, headers, prober, validation)
+    _probe_write_access(config, headers, prober, validation)
+    _probe_auth_config(config, headers, prober, validation)
+    _analyze_realtime(config, validation, js_extraction)
+
+    return validation
+
+
+def _probe_tables(
+    config: BaaSConfig,
+    headers: Dict[str, str],
+    prober: BaaSProber,
+    validation: BaaSValidation,
+) -> None:
+    for table in config.tables[:TABLE_PROBE_CAP]:
+        try:
+            resp = prober("GET", f"{config.project_url}/rest/v1/{table}?select=*&limit=1", headers)
+        except Exception:
+            validation.protected_tables.append(BaaSProbeResult(
+                probe_type="table_read", target=table, status="error", note="probe failed",
+            ))
+            continue
+
+        status = resp.get("status_code", 0)
+        body = resp.get("body")
+
+        if status == 200 and isinstance(body, list):
+            columns = list(body[0].keys()) if body and isinstance(body[0], dict) else []
+            result = BaaSProbeResult(
+                probe_type="table_read",
+                target=table,
+                status="confirmed",
+                http_status=status,
+                row_count=len(body),
+                columns=columns,
+            )
+            validation.open_tables.append(result)
+
+            col_summary = ", ".join(columns[:10])
+            if len(columns) > 10:
+                col_summary += f" (+{len(columns) - 10} more)"
+            validation.findings.append(Finding(
+                type="baas_open_table",
+                severity=_table_severity(table),
+                confidence=0.95,
+                detector_id="baas.open_table",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet=f"Table '{table}' readable without auth. Columns: {col_summary}",
+                    redacted_value=f"table:{table}",
+                    response_status=status,
+                    request_url=f"{redact_url(config.project_url)}/rest/v1/{table}",
+                ),
+                risk_reason=f"Supabase table '{table}' has no effective RLS policy. "
+                            f"Anyone with the anon key can read all {len(body)} row(s) returned.",
+                remediation=f"Enable RLS: ALTER TABLE {table} ENABLE ROW LEVEL SECURITY; "
+                            f"then create SELECT/INSERT/UPDATE/DELETE policies.",
+                validation_status="confirmed",
+                category="baas",
+                references=["https://supabase.com/docs/guides/auth/row-level-security"],
+            ))
+        else:
+            validation.protected_tables.append(BaaSProbeResult(
+                probe_type="table_read", target=table, status="denied", http_status=status,
+            ))
+
+
+_SENSITIVE_TABLE_PREFIXES = (
+    "payout", "payment", "billing", "invoice", "subscription",
+    "admin", "auth", "credential", "secret", "token",
+    "user_block", "report", "dmca", "support_ticket",
+    "private", "internal",
+)
+
+
+def _table_severity(table: str) -> str:
+    lower = table.lower()
+    for prefix in _SENSITIVE_TABLE_PREFIXES:
+        if prefix in lower:
+            return "critical"
+    return "high"
+
+
+def _probe_storage(
+    config: BaaSConfig,
+    headers: Dict[str, str],
+    prober: BaaSProber,
+    validation: BaaSValidation,
+) -> None:
+    try:
+        resp = prober("GET", f"{config.project_url}/storage/v1/bucket", headers)
+    except Exception:
+        return
+
+    status = resp.get("status_code", 0)
+    body = resp.get("body")
+
+    if status == 200 and isinstance(body, list):
+        for bucket_info in body[:BUCKET_PROBE_CAP]:
+            name = bucket_info.get("name") or bucket_info.get("id") or ""
+            if not name:
+                continue
+            is_public = bucket_info.get("public", False)
+            result = BaaSProbeResult(
+                probe_type="storage_bucket",
+                target=name,
+                status="confirmed",
+                http_status=status,
+                note="public" if is_public else "listed",
+            )
+            validation.accessible_buckets.append(result)
+
+            if is_public:
+                validation.findings.append(Finding(
+                    type="baas_open_storage",
+                    severity="high",
+                    confidence=0.95,
+                    detector_id="baas.open_storage",
+                    source=config.project_url,
+                    evidence=Evidence(
+                        source=config.project_url,
+                        snippet=f"Storage bucket '{name}' is marked public.",
+                        redacted_value=f"bucket:{name}",
+                        response_status=status,
+                        request_url=f"{redact_url(config.project_url)}/storage/v1/bucket",
+                    ),
+                    risk_reason=f"Supabase storage bucket '{name}' is publicly accessible. "
+                                "Anyone can list and download objects.",
+                    remediation=f"Set the '{name}' bucket to private in the Supabase dashboard "
+                                "and configure storage policies for authorized access only.",
+                    validation_status="confirmed",
+                    category="baas",
+                ))
+
+    for bucket_name in config.storage_buckets[:BUCKET_PROBE_CAP]:
+        already_found = any(b.target == bucket_name for b in validation.accessible_buckets)
+        if already_found:
+            continue
+        try:
+            list_resp = prober(
+                "GET",
+                f"{config.project_url}/storage/v1/object/list/{bucket_name}?limit=1",
+                headers,
+            )
+        except Exception:
+            continue
+        if list_resp.get("status_code") == 200:
+            validation.accessible_buckets.append(BaaSProbeResult(
+                probe_type="storage_list",
+                target=bucket_name,
+                status="confirmed",
+                http_status=200,
+                note="objects listable",
+            ))
+            validation.findings.append(Finding(
+                type="baas_open_storage",
+                severity="medium",
+                confidence=0.85,
+                detector_id="baas.open_storage",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet=f"Storage bucket '{bucket_name}' objects are listable with anon key.",
+                    redacted_value=f"bucket:{bucket_name}",
+                    response_status=200,
+                    request_url=f"{redact_url(config.project_url)}/storage/v1/object/list/{bucket_name}",
+                ),
+                risk_reason=f"Storage bucket '{bucket_name}' allows anonymous object listing.",
+                remediation=f"Restrict the '{bucket_name}' bucket's storage policy to authenticated users.",
+                validation_status="confirmed",
+                category="baas",
+            ))
+
+
+def _probe_rpcs(
+    config: BaaSConfig,
+    headers: Dict[str, str],
+    prober: BaaSProber,
+    validation: BaaSValidation,
+) -> None:
+    rpc_headers = {**headers, "Content-Type": "application/json"}
+    for fn in config.rpc_functions[:RPC_PROBE_CAP]:
+        try:
+            resp = prober("POST", f"{config.project_url}/rest/v1/rpc/{fn}", rpc_headers)
+        except Exception:
+            continue
+
+        status = resp.get("status_code", 0)
+        if status in (200, 204):
+            result = BaaSProbeResult(
+                probe_type="rpc_call", target=fn, status="confirmed", http_status=status,
+            )
+            validation.callable_rpcs.append(result)
+            validation.findings.append(Finding(
+                type="baas_open_rpc",
+                severity="medium",
+                confidence=0.85,
+                detector_id="baas.open_rpc",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet=f"RPC function '{fn}' callable without authentication (HTTP {status}).",
+                    redacted_value=f"rpc:{fn}",
+                    response_status=status,
+                    request_url=f"{redact_url(config.project_url)}/rest/v1/rpc/{fn}",
+                ),
+                risk_reason=f"Supabase RPC function '{fn}' is callable with just the anon key. "
+                            "If it mutates data or returns sensitive information, this is exploitable.",
+                remediation=f"Add a security definer or check auth.uid() inside the '{fn}' function. "
+                            "Consider revoking EXECUTE from the anon role.",
+                validation_status="confirmed",
+                category="baas",
+            ))
+
+
+# ---------------------------------------------------------------------------
+# Wave 4.4 — Write operation detection
+# ---------------------------------------------------------------------------
+
+def _probe_write_access(
+    config: BaaSConfig,
+    headers: Dict[str, str],
+    prober: BaaSProber,
+    validation: BaaSValidation,
+) -> None:
+    """Test if open tables accept writes. Uses invalid schema body to avoid creating data."""
+    write_headers = {**headers, "Content-Type": "application/json", "Prefer": "return=minimal"}
+    open_table_names = [t.target for t in validation.open_tables]
+
+    for table in open_table_names[:WRITE_PROBE_CAP]:
+        try:
+            resp = prober("POST", f"{config.project_url}/rest/v1/{table}", write_headers)
+        except Exception:
+            continue
+
+        status = resp.get("status_code", 0)
+        # 400 = schema validation error (writes enabled but body invalid — safe)
+        # 201 should not happen with empty/invalid body, but flag it
+        # 403 = RLS blocks writes (good)
+        if status in (400, 201, 409):
+            validation.writable_tables.append(BaaSProbeResult(
+                probe_type="table_write", target=table, status="confirmed", http_status=status,
+            ))
+            validation.findings.append(Finding(
+                type="baas_writable_table",
+                severity="critical",
+                confidence=0.9,
+                detector_id="baas.writable_table",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet=f"Table '{table}' accepts POST (insert) with anon key (HTTP {status}).",
+                    redacted_value=f"writable:{table}",
+                    response_status=status,
+                    request_url=f"{redact_url(config.project_url)}/rest/v1/{table}",
+                ),
+                risk_reason=f"Supabase table '{table}' allows unauthenticated inserts. "
+                            "Attackers can inject arbitrary rows.",
+                remediation=f"Add INSERT policy: CREATE POLICY insert_policy ON {table} "
+                            "FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);",
+                validation_status="confirmed",
+                category="baas",
+            ))
+
+
+# ---------------------------------------------------------------------------
+# Wave 4.5 — Auth flow analysis
+# ---------------------------------------------------------------------------
+
+def _decode_jwt_claims(token: str) -> Optional[Dict[str, Any]]:
+    """Decode JWT payload without verification (we only need the claims)."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        payload = parts[1]
+        # Add padding
+        payload += "=" * (4 - len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload)
+        return _json.loads(decoded)
+    except Exception:
+        return None
+
+
+def _probe_auth_config(
+    config: BaaSConfig,
+    headers: Dict[str, str],
+    prober: BaaSProber,
+    validation: BaaSValidation,
+) -> None:
+    # 1. Check JWT claims
+    claims = _decode_jwt_claims(config.api_key)
+    if claims:
+        role = claims.get("role", "")
+        if role == "service_role":
+            validation.findings.append(Finding(
+                type="baas_service_role_exposed",
+                severity="critical",
+                confidence=1.0,
+                detector_id="baas.service_role_exposed",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet="JWT role claim is 'service_role'. This key bypasses all RLS policies.",
+                    redacted_value="role:service_role",
+                ),
+                risk_reason="The exposed key has service_role privileges, bypassing all Row-Level Security. This is equivalent to full database admin access.",
+                remediation="Immediately rotate this key. Never expose a service_role key in client code. Use the anon key instead.",
+                validation_status="confirmed",
+                category="baas",
+            ))
+
+        exp = claims.get("exp")
+        if exp:
+            remaining = exp - time.time()
+            if remaining > 365 * 24 * 3600:
+                validation.findings.append(Finding(
+                    type="baas_long_lived_key",
+                    severity="low",
+                    confidence=0.8,
+                    detector_id="baas.long_lived_key",
+                    source=config.project_url,
+                    evidence=Evidence(
+                        source=config.project_url,
+                        snippet=f"JWT expires in {int(remaining / (365 * 24 * 3600))}+ years.",
+                        redacted_value="exp:far-future",
+                    ),
+                    risk_reason="The anon key has a very long expiry. If compromised, it remains valid for years.",
+                    remediation="Consider rotating keys periodically or setting shorter expiry in Supabase dashboard.",
+                    validation_status="confirmed",
+                    category="baas",
+                ))
+
+    # 2. Probe auth settings endpoint
+    try:
+        resp = prober("GET", f"{config.project_url}/auth/v1/settings", headers)
+    except Exception:
+        return
+
+    if resp.get("status_code") == 200:
+        body = resp.get("body") or {}
+        if isinstance(body, dict):
+            autoconfirm = body.get("mailer_autoconfirm", False)
+            if autoconfirm:
+                validation.findings.append(Finding(
+                    type="baas_no_email_confirmation",
+                    severity="medium",
+                    confidence=0.85,
+                    detector_id="baas.no_email_confirmation",
+                    source=config.project_url,
+                    evidence=Evidence(
+                        source=config.project_url,
+                        snippet="mailer_autoconfirm: true — accounts are auto-confirmed without email verification.",
+                        redacted_value="autoconfirm:true",
+                    ),
+                    risk_reason="Email confirmation is disabled. Attackers can create accounts with any email address without verification.",
+                    remediation="Enable email confirmation in Supabase Auth settings.",
+                    validation_status="confirmed",
+                    category="baas",
+                ))
+
+
+# ---------------------------------------------------------------------------
+# Wave 4.6 — Realtime channel security
+# ---------------------------------------------------------------------------
+
+def _analyze_realtime(
+    config: BaaSConfig,
+    validation: BaaSValidation,
+    js_extraction: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Pattern-based analysis of realtime channel names. No WebSocket probing."""
+    channels = (js_extraction or {}).get("realtime_channels", [])
+
+    for channel in channels[:20]:
+        # Check for user-ID-based channel patterns
+        if re.search(r"[-_](?:user|uid|id|profile)[-_]?$|^(?:user|notifications|messages|private)[-_]", channel, re.IGNORECASE):
+            validation.realtime_channels.append(BaaSProbeResult(
+                probe_type="realtime_channel",
+                target=channel,
+                status="confirmed",
+                note="predictable user-based channel name",
+            ))
+            validation.findings.append(Finding(
+                type="baas_predictable_channel",
+                severity="medium",
+                confidence=0.7,
+                detector_id="baas.predictable_channel",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet=f"Realtime channel '{channel}' uses a predictable user-based naming pattern.",
+                    redacted_value=f"channel:{channel}",
+                ),
+                risk_reason=f"Channel '{channel}' appears to include user identifiers. Without channel policies, any client can subscribe to another user's notifications.",
+                remediation="Add Realtime channel policies in Supabase or validate subscriptions server-side.",
+                validation_status="lead",
+                category="baas",
+            ))
+
+
+# ---------------------------------------------------------------------------
+# Wave 4.2 — Firebase active validation
+# ---------------------------------------------------------------------------
+
+def _validate_firebase(config: BaaSConfig, prober: BaaSProber) -> BaaSValidation:
+    validation = BaaSValidation(provider="firebase", project_url_redacted=redact_url(config.project_url))
+
+    # Probe Realtime Database
+    try:
+        resp = prober("GET", f"{config.project_url}/.json?shallow=true", {})
+    except Exception:
+        return validation
+
+    status = resp.get("status_code", 0)
+    body = resp.get("body")
+
+    if status == 200 and body is not None and body != "null":
+        validation.key_valid = True
+        top_keys = list(body.keys()) if isinstance(body, dict) else []
+        validation.open_tables.append(BaaSProbeResult(
+            probe_type="firebase_db_read", target="/", status="confirmed",
+            http_status=status, columns=top_keys[:20],
+        ))
+        validation.findings.append(Finding(
+            type="baas_open_table",
+            severity="critical",
+            confidence=0.95,
+            detector_id="baas.open_table",
+            source=config.project_url,
+            evidence=Evidence(
+                source=config.project_url,
+                snippet=f"Firebase Realtime Database is publicly readable. Top-level keys: {', '.join(top_keys[:10])}",
+                redacted_value="firebase:/.json",
+                response_status=status,
+                request_url=f"{redact_url(config.project_url)}/.json?shallow=true",
+            ),
+            risk_reason="Firebase Realtime Database has no security rules (or rules allow public read). All data is accessible without authentication.",
+            remediation='Set Firebase Security Rules to deny public access: {"rules": {".read": "auth != null", ".write": "auth != null"}}',
+            validation_status="confirmed",
+            category="baas",
+            references=["https://firebase.google.com/docs/database/security"],
+        ))
+    elif status == 401:
+        validation.key_valid = False
+
+    # Probe Firebase Storage
+    for bucket in config.storage_buckets[:BUCKET_PROBE_CAP]:
+        try:
+            storage_resp = prober("GET", f"https://firebasestorage.googleapis.com/v0/b/{bucket}/o?maxResults=1", {})
+        except Exception:
+            continue
+        if storage_resp.get("status_code") == 200:
+            items = (storage_resp.get("body") or {}).get("items", [])
+            validation.accessible_buckets.append(BaaSProbeResult(
+                probe_type="firebase_storage", target=bucket, status="confirmed",
+                http_status=200, row_count=len(items),
+            ))
+            validation.findings.append(Finding(
+                type="baas_open_storage",
+                severity="high",
+                confidence=0.9,
+                detector_id="baas.open_storage",
+                source=config.project_url,
+                evidence=Evidence(
+                    source=config.project_url,
+                    snippet=f"Firebase Storage bucket '{bucket}' is publicly listable.",
+                    redacted_value=f"bucket:{bucket}",
+                    response_status=200,
+                ),
+                risk_reason=f"Firebase Storage bucket '{bucket}' allows public listing. Objects can be enumerated and downloaded.",
+                remediation="Set Storage security rules: allow read, write: if request.auth != null;",
+                validation_status="confirmed",
+                category="baas",
+            ))
+
+    return validation
+
+
+# ---------------------------------------------------------------------------
+# Wave 4.3 — Appwrite & PocketBase validation
+# ---------------------------------------------------------------------------
+
+def _validate_appwrite(config: BaaSConfig, prober: BaaSProber) -> BaaSValidation:
+    validation = BaaSValidation(provider="appwrite", project_url_redacted=redact_url(config.project_url))
+    headers: Dict[str, str] = {}
+    if config.api_key:
+        headers["X-Appwrite-Project"] = config.api_key
+
+    try:
+        resp = prober("GET", f"{config.project_url}/databases", headers)
+    except Exception:
+        return validation
+
+    status = resp.get("status_code", 0)
+    if status == 200:
+        validation.key_valid = True
+        dbs = (resp.get("body") or {}).get("databases", [])
+        for db in dbs[:5]:
+            db_id = db.get("$id", "")
+            try:
+                col_resp = prober("GET", f"{config.project_url}/databases/{db_id}/collections", headers)
+            except Exception:
+                continue
+            if col_resp.get("status_code") == 200:
+                cols = (col_resp.get("body") or {}).get("collections", [])
+                for col in cols[:TABLE_PROBE_CAP]:
+                    col_id = col.get("$id", "")
+                    col_name = col.get("name", col_id)
+                    validation.open_tables.append(BaaSProbeResult(
+                        probe_type="appwrite_collection", target=col_name,
+                        status="confirmed", http_status=200,
+                    ))
+                    validation.findings.append(Finding(
+                        type="baas_open_table", severity="high", confidence=0.9,
+                        detector_id="baas.open_table", source=config.project_url,
+                        evidence=Evidence(source=config.project_url,
+                            snippet=f"Appwrite collection '{col_name}' accessible.",
+                            redacted_value=f"collection:{col_name}"),
+                        risk_reason=f"Appwrite collection '{col_name}' is accessible without authentication.",
+                        remediation="Set collection-level permissions in the Appwrite console.",
+                        validation_status="confirmed", category="baas",
+                    ))
+    return validation
+
+
+def _validate_pocketbase(config: BaaSConfig, prober: BaaSProber) -> BaaSValidation:
+    validation = BaaSValidation(provider="pocketbase", project_url_redacted=redact_url(config.project_url))
+
+    try:
+        resp = prober("GET", f"{config.project_url}/api/collections", {})
+    except Exception:
+        return validation
+
+    status = resp.get("status_code", 0)
+    if status == 200:
+        validation.key_valid = True
+        items = (resp.get("body") or {}).get("items", resp.get("body") if isinstance(resp.get("body"), list) else [])
+        for col in items[:TABLE_PROBE_CAP]:
+            col_name = col.get("name", "") if isinstance(col, dict) else str(col)
+            if not col_name:
+                continue
+            try:
+                rec_resp = prober("GET", f"{config.project_url}/api/collections/{col_name}/records?perPage=1", {})
+            except Exception:
+                continue
+            if rec_resp.get("status_code") == 200:
+                validation.open_tables.append(BaaSProbeResult(
+                    probe_type="pocketbase_collection", target=col_name,
+                    status="confirmed", http_status=200,
+                ))
+                validation.findings.append(Finding(
+                    type="baas_open_table", severity="high", confidence=0.9,
+                    detector_id="baas.open_table", source=config.project_url,
+                    evidence=Evidence(source=config.project_url,
+                        snippet=f"PocketBase collection '{col_name}' readable without auth.",
+                        redacted_value=f"collection:{col_name}"),
+                    risk_reason=f"PocketBase collection '{col_name}' has no list/view API rules. Anyone can read all records.",
+                    remediation=f"Set API rules for the '{col_name}' collection in PocketBase admin.",
+                    validation_status="confirmed", category="baas",
+                ))
+    return validation
+
+
+def _finding(
+    finding_type: str,
+    severity: str,
+    config: BaaSConfig,
+    risk_reason: str,
+    remediation: str,
+    validation_status: str = "lead",
+) -> Finding:
+    return Finding(
+        type=finding_type,
+        severity=severity,
+        confidence=0.7,
+        detector_id=f"baas.{finding_type}",
+        source=config.project_url,
+        evidence=Evidence(
+            source=config.project_url,
+            redacted_value=redact_value(config.api_key),
+        ),
+        risk_reason=risk_reason,
+        remediation=remediation,
+        validation_status=validation_status,
+        category="baas",
+    )

--- a/keyleak/baas_validator.py
+++ b/keyleak/baas_validator.py
@@ -561,14 +561,18 @@ def _probe_write_access(
 ) -> None:
     """Test if open tables accept writes.
 
-    Sends a POST with an intentionally invalid JSON body that cannot match
-    any real table schema.  PostgREST returns 400 (schema error) when
-    inserts are enabled but the body is invalid, vs 403 when RLS blocks
-    the write entirely.  A 400 therefore proves writes are structurally
-    open without ever creating a row.
+    Uses ``Prefer: tx=rollback`` so PostgREST rolls back the transaction
+    even if the insert would succeed.  If that header is not honoured
+    (requires ``db-tx-end`` on the server), falls back to sending an
+    intentionally invalid JSON body whose column name cannot exist in any
+    real schema — PostgREST returns 400 (schema error, no row created)
+    when inserts are enabled, vs 403 when RLS blocks writes.
     """
-    write_headers = {**headers, "Content-Type": "application/json", "Prefer": "return=minimal"}
-    # Body with a key that cannot match any real column — guarantees 400, never 201.
+    write_headers = {
+        **headers,
+        "Content-Type": "application/json",
+        "Prefer": "tx=rollback, return=minimal",
+    }
     probe_body = '{"__keyleak_write_probe__": true}'
     open_table_names = [t.target for t in validation.open_tables]
 

--- a/keyleak/blast_radius.py
+++ b/keyleak/blast_radius.py
@@ -1,0 +1,230 @@
+"""Blast-radius enumeration (Wave 3.3).
+
+Given a Finding, attempt to enumerate the scope of the leaked credential via
+read-only API probes:
+
+- GitHub PAT (``ghp_*``): ``GET /user`` + ``GET /user/repos``
+- AWS access keys (``AKIA*``/``ASIA*``): ``sts:GetCallerIdentity``
+- Stripe (``sk_live_*``, ``rk_live_*``): ``GET /v1/balance`` (read-only)
+- OpenAI (``sk-proj-*``, ``sk-*``): ``GET /v1/models``
+
+Each probe is wrapped behind a callable injected at the call site, so tests
+never touch the network.
+
+The probes are **read-only by design**. ``keyleak diff --revoke`` would call
+the vendor's *revocation* endpoint; this module focuses on the enumeration
+half so the IR analyst can answer "what does this unlock?"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from .models import Finding
+
+
+Prober = Callable[[str], Dict[str, Any]]
+
+
+@dataclass
+class BlastRadius:
+    detector_id: str
+    redacted_value: str
+    scope: Dict[str, Any] = field(default_factory=dict)
+    status: str = "unknown"  # "ok", "rejected", "skipped", "error"
+    note: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "detector_id": self.detector_id,
+            "redacted_value": self.redacted_value,
+            "scope": self.scope,
+            "status": self.status,
+            "note": self.note,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default probes — overridable in tests.
+# ---------------------------------------------------------------------------
+
+def _default_probe(detector_id: str) -> Optional[Prober]:
+    """Return the production prober for ``detector_id`` or None."""
+
+    return {
+        "leak.github_pat": _probe_github_pat,
+        "leak.aws_access_key": _probe_aws_access_key,
+        "leak.stripe_secret_key": _probe_stripe_secret_key,
+        "leak.openai_api_key": _probe_openai_api_key,
+        "leak.gemini_api_key": _probe_gemini_api_key,
+        "leak.bearer_token": _probe_jwt_claims,
+        "leak.jwt_token": _probe_jwt_claims,
+    }.get(detector_id)
+
+
+def _probe_github_pat(token: str) -> Dict[str, Any]:  # pragma: no cover — production net path
+    import requests
+
+    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+    r = requests.get("https://api.github.com/user", headers=headers, timeout=10)
+    if r.status_code != 200:
+        return {"status": "rejected", "code": r.status_code}
+    user = r.json()
+    rr = requests.get("https://api.github.com/user/repos?per_page=1", headers=headers, timeout=10)
+    return {
+        "status": "ok",
+        "login": user.get("login"),
+        "scopes": r.headers.get("X-OAuth-Scopes", ""),
+        "repos_first_page_count": len(rr.json() or []) if rr.status_code == 200 else None,
+    }
+
+
+def _probe_aws_access_key(token: str) -> Dict[str, Any]:  # pragma: no cover
+    return {"status": "skipped", "note": "AWS sts:GetCallerIdentity requires SigV4 — not implemented in OSS core"}
+
+
+def _probe_stripe_secret_key(token: str) -> Dict[str, Any]:  # pragma: no cover
+    import requests
+
+    r = requests.get("https://api.stripe.com/v1/balance", auth=(token, ""), timeout=10)
+    if r.status_code != 200:
+        return {"status": "rejected", "code": r.status_code}
+    body = r.json()
+    return {
+        "status": "ok",
+        "available_count": len(body.get("available") or []),
+    }
+
+
+def _probe_gemini_api_key(token: str) -> Dict[str, Any]:  # pragma: no cover
+    import requests
+
+    r = requests.get(
+        f"https://generativelanguage.googleapis.com/v1beta/models?key={token}",
+        timeout=10,
+    )
+    if r.status_code != 200:
+        return {"status": "rejected", "code": r.status_code}
+    data = r.json()
+    return {"status": "ok", "model_count": len((data or {}).get("models") or [])}
+
+
+def _probe_jwt_claims(token: str) -> Dict[str, Any]:
+    """Decode JWT claims without verification and flag suspicious permissions."""
+    import base64
+    import json as _json
+    import time
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {"status": "error", "note": "Not a valid JWT (expected 3 segments)"}
+
+    try:
+        payload = parts[1]
+        payload += "=" * ((4 - len(payload) % 4) % 4)
+        claims = _json.loads(base64.urlsafe_b64decode(payload))
+    except Exception:
+        return {"status": "error", "note": "Failed to decode JWT payload"}
+
+    flags = []
+    role = str(claims.get("role") or "")
+    if "service_role" in role:
+        flags.append("CRITICAL: service_role bypasses all RLS")
+    elif any(w in role.lower() for w in ("admin", "superuser", "root")):
+        flags.append(f"HIGH: elevated role '{role}'")
+
+    if claims.get("is_admin") is True or claims.get("admin") is True:
+        flags.append("HIGH: admin flag is true")
+
+    scope = claims.get("scope") or claims.get("scp") or ""
+    scope_str = " ".join(scope) if isinstance(scope, list) else str(scope)
+    dangerous = [s for s in ("admin", "write", "delete", "manage") if s in scope_str.lower()]
+    if dangerous:
+        flags.append(f"HIGH: broad scope ({', '.join(dangerous)})")
+
+    now = int(time.time())
+    exp = claims.get("exp")
+    if exp:
+        remaining = exp - now
+        if remaining < 0:
+            flags.append("INFO: token is expired")
+        elif remaining > 365 * 86400:
+            flags.append(f"MEDIUM: expires in {remaining // (365*86400)}+ years")
+    else:
+        flags.append("MEDIUM: no expiry set")
+
+    return {
+        "status": "ok",
+        "iss": claims.get("iss"),
+        "sub": claims.get("sub"),
+        "role": role or None,
+        "scope": scope_str or None,
+        "exp": exp,
+        "flags": flags,
+    }
+
+
+def _probe_openai_api_key(token: str) -> Dict[str, Any]:  # pragma: no cover
+    import requests
+
+    r = requests.get(
+        "https://api.openai.com/v1/models",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if r.status_code != 200:
+        return {"status": "rejected", "code": r.status_code}
+    data = r.json()
+    return {"status": "ok", "model_count": len((data or {}).get("data") or [])}
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+def compute_blast_radius(
+    finding: Finding,
+    raw_value: Optional[str] = None,
+    *,
+    probes: Optional[Dict[str, Prober]] = None,
+) -> BlastRadius:
+    """Compute blast radius for a single finding.
+
+    ``raw_value`` is the actual token (post-redaction recovery is the
+    operator's responsibility — KeyLeak never persists it). If not provided,
+    the result is ``status='skipped'``.
+    """
+
+    probes = probes or {}
+    probe = probes.get(finding.detector_id) or _default_probe(finding.detector_id)
+    if not probe:
+        return BlastRadius(
+            detector_id=finding.detector_id,
+            redacted_value=finding.evidence.redacted_value,
+            status="skipped",
+            note=f"No probe available for {finding.detector_id}",
+        )
+    if not raw_value:
+        return BlastRadius(
+            detector_id=finding.detector_id,
+            redacted_value=finding.evidence.redacted_value,
+            status="skipped",
+            note="raw_value not provided; pass the recovered token to compute_blast_radius",
+        )
+    try:
+        scope = probe(raw_value)
+    except Exception as exc:  # pragma: no cover — defensive
+        return BlastRadius(
+            detector_id=finding.detector_id,
+            redacted_value=finding.evidence.redacted_value,
+            status="error",
+            note=str(exc),
+        )
+    return BlastRadius(
+        detector_id=finding.detector_id,
+        redacted_value=finding.evidence.redacted_value,
+        scope=scope,
+        status=str(scope.get("status") or "ok"),
+        note=str(scope.get("note") or ""),
+    )

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -319,6 +319,7 @@ def run_browser_scan(
     headless: bool = True,
     baas_validate: bool = False,
     baas_prober: Optional[Any] = None,
+    baas_tables: Optional[List[str]] = None,
 ) -> ScanReport:
     """Drive Playwright Chromium, inject the analyzer, return a ScanReport.
 
@@ -348,16 +349,26 @@ def run_browser_scan(
         page.goto(url, wait_until="networkidle")
         raw = page.evaluate("() => window.__keyleak_run ? window.__keyleak_run() : []")
 
+        # Always extract BaaS config (tables, RPCs, buckets) for pattern-based
+        # detection.  Active validation probes are gated by baas_validate.
         baas_extraction = None
-        if baas_validate:
-            try:
-                baas_extraction = page.evaluate(
-                    "() => window.__keyleak_baas_extract ? window.__keyleak_baas_extract() : null"
-                )
-            except Exception:
-                pass
+        try:
+            baas_extraction = page.evaluate(
+                "() => window.__keyleak_baas_extract ? window.__keyleak_baas_extract() : null"
+            )
+        except Exception:
+            pass
 
         browser.close()
+
+    # Merge extra --baas-tables into extraction
+    if baas_tables and baas_extraction:
+        existing = set(baas_extraction.get("tables") or [])
+        for t in baas_tables:
+            if t not in existing:
+                baas_extraction.setdefault("tables", []).append(t)
+    elif baas_tables and not baas_extraction:
+        baas_extraction = {"tables": list(baas_tables), "rpcs": [], "buckets": []}
 
     findings = [_to_finding(entry, url) for entry in raw or []]
     baas_findings = _run_baas_validation(raw, baas_extraction, baas_validate, baas_prober)

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -317,7 +317,7 @@ def run_browser_scan(
     auth_state_path: Optional[str] = None,
     scan_budget_seconds: int = SCAN_BUDGET_DEFAULT_SECONDS,
     headless: bool = True,
-    baas_validate: bool = True,
+    baas_validate: bool = False,
     baas_prober: Optional[Any] = None,
 ) -> ScanReport:
     """Drive Playwright Chromium, inject the analyzer, return a ScanReport.

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -1,0 +1,436 @@
+"""Headless-browser CI runner (Wave 2.4).
+
+Loads a URL via Playwright Chromium with the KeyLeak analyzer injected as a
+plain JavaScript library (no MV3 host, no ``--load-extension``). The injected
+script enumerates DOM, ``localStorage``, ``sessionStorage``, IndexedDB, and
+Cache Storage, runs the same detector patterns the CLI uses, and returns the
+findings via ``page.evaluate(...)``.
+
+Wave 4.1 adds BaaS extraction and active validation: after pattern scanning,
+the injected script extracts BaaS configuration (Supabase URL, anon key, table
+names, RPC functions, storage buckets) and Python-side probes confirm whether
+RLS policies are enforced.
+
+Why this shape:
+- Wave-1 fork resolved that the consumer Chrome extension sunsets. The
+  ``extension/lib/analyzer.js`` and ``extension/lib/patterns.js`` modules
+  remain as the shared engine, reused here in CI.
+- The ``page.addInitScript`` path sidesteps Chrome 130's expected deprecation
+  of ``--load-extension`` in headless. We never load an MV3 host.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from .extension_bundle import extension_pattern_payload
+from .models import Evidence, Finding, ScanReport
+from .reporting import build_report
+
+
+SCAN_BUDGET_DEFAULT_SECONDS = 30
+DEFAULT_VIEWPORT = {"width": 1280, "height": 1024}
+
+
+# The init script we inject into the page context. It exposes a global
+# ``__keyleak_findings`` populated by the analyzer; ``run_browser_scan`` reads
+# it back after the page settles. Patterns are inlined at injection time so
+# the page doesn't need network access to load them.
+_INIT_SCRIPT_TEMPLATE = r"""
+(function () {
+  if (typeof window === 'undefined') return;
+  if (window.__keyleak_initialized) return;
+  window.__keyleak_initialized = true;
+  window.__keyleak_findings = [];
+
+  const PATTERNS = __PATTERNS__;
+  const compiled = PATTERNS.map(function (p) {
+    try {
+      return Object.assign({}, p, {regex: new RegExp(p.pattern, p.flags)});
+    } catch (err) {
+      return null;
+    }
+  }).filter(Boolean);
+
+  function emit(detector, source, value, where) {
+    window.__keyleak_findings.push({
+      detector_id: detector.detector_id,
+      type: detector.finding_type || detector.id,
+      severity: detector.severity,
+      source: source,
+      value: String(value).slice(0, 240),
+      where: where,
+    });
+  }
+
+  function scanString(text, source) {
+    if (!text || typeof text !== 'string') return;
+    for (let i = 0; i < compiled.length; i++) {
+      const d = compiled[i];
+      const m = text.match(d.regex);
+      if (m) {
+        emit(d, source, m[0], 'string');
+      }
+    }
+  }
+
+  async function scanIndexedDB() {
+    if (!('indexedDB' in window) || typeof indexedDB.databases !== 'function') return;
+    try {
+      const dbs = await indexedDB.databases();
+      for (const dbInfo of dbs || []) {
+        if (!dbInfo || !dbInfo.name) continue;
+        await new Promise(function (resolve) {
+          const req = indexedDB.open(dbInfo.name);
+          req.onerror = function () { resolve(); };
+          req.onsuccess = function () {
+            const db = req.result;
+            const stores = Array.from(db.objectStoreNames || []);
+            if (!stores.length) { db.close(); resolve(); return; }
+            const tx = db.transaction(stores, 'readonly');
+            let remaining = stores.length;
+            stores.forEach(function (storeName) {
+              const store = tx.objectStore(storeName);
+              const getAll = store.getAll();
+              getAll.onsuccess = function () {
+                const rows = getAll.result || [];
+                for (const row of rows) {
+                  scanString(JSON.stringify(row), `indexeddb:${dbInfo.name}/${storeName}`);
+                }
+                if (--remaining === 0) { db.close(); resolve(); }
+              };
+              getAll.onerror = function () {
+                if (--remaining === 0) { db.close(); resolve(); }
+              };
+            });
+          };
+        });
+      }
+    } catch (_err) { /* swallow */ }
+  }
+
+  async function scanCacheStorage() {
+    if (!('caches' in window)) return;
+    try {
+      const names = await caches.keys();
+      for (const name of names) {
+        const cache = await caches.open(name);
+        const requests = await cache.keys();
+        for (const req of requests) {
+          const resp = await cache.match(req);
+          if (!resp) continue;
+          try {
+            const text = await resp.clone().text();
+            scanString(text, `cache:${name}/${req.url}`);
+          } catch (_e) { /* binary body */ }
+        }
+      }
+    } catch (_err) { /* swallow */ }
+  }
+
+  async function scanServiceWorkers() {
+    if (!('serviceWorker' in navigator)) return;
+    try {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      for (const r of regs || []) {
+        const sw = r.active || r.waiting || r.installing;
+        const scriptURL = sw && sw.scriptURL;
+        if (scriptURL) {
+          window.__keyleak_findings.push({
+            detector_id: 'browser.service_worker_registration',
+            type: 'service_worker_registration',
+            severity: 'info',
+            source: scriptURL,
+            value: r.scope,
+            where: 'service-worker',
+          });
+        }
+      }
+    } catch (_err) { /* swallow */ }
+  }
+
+  function scanDom() {
+    scanString(document.documentElement.outerHTML, 'document');
+    for (let i = 0; i < localStorage.length; i++) {
+      var key = localStorage.key(i);
+      var value = localStorage.getItem(key);
+      scanString(key + '=' + value, 'localStorage:' + key);
+    }
+    for (let i = 0; i < sessionStorage.length; i++) {
+      var key = sessionStorage.key(i);
+      var value = sessionStorage.getItem(key);
+      scanString(key + '=' + value, 'sessionStorage:' + key);
+    }
+  }
+
+  window.__keyleak_run = async function () {
+    scanDom();
+    await scanIndexedDB();
+    await scanCacheStorage();
+    await scanServiceWorkers();
+    return window.__keyleak_findings;
+  };
+
+  // Wave 4.1 — BaaS config extraction.
+  // Fetches all JS bundles loaded by the page and extracts Supabase/Firebase
+  // configuration: project URL, anon key, table names, RPC functions, and
+  // storage buckets.
+  window.__keyleak_baas_extract = async function () {
+    var result = {
+      supabase_url: null,
+      supabase_key: null,
+      tables: [],
+      rpcs: [],
+      buckets: []
+    };
+
+    // Collect all text: inline scripts + fetched external bundles
+    var texts = [];
+    var scripts = document.querySelectorAll('script');
+    for (var i = 0; i < scripts.length; i++) {
+      if (scripts[i].textContent) texts.push(scripts[i].textContent);
+    }
+
+    // Fetch external script sources (same-origin or CORS-allowed)
+    var srcScripts = document.querySelectorAll('script[src], link[rel="modulepreload"]');
+    for (var i = 0; i < srcScripts.length; i++) {
+      var src = srcScripts[i].src || srcScripts[i].href;
+      if (!src) continue;
+      try {
+        var resp = await fetch(src, {cache: 'force-cache'});
+        if (resp.ok) {
+          var text = await resp.text();
+          if (text.length < 5000000) texts.push(text);
+        }
+      } catch (_e) { /* cross-origin or network error */ }
+    }
+
+    var allText = texts.join('\n');
+
+    // Extract Supabase URL
+    var urlRe = /https:\/\/[a-z0-9]{20,}\.supabase\.co/g;
+    var m = urlRe.exec(allText);
+    if (m) result.supabase_url = m[0];
+
+    // Extract Supabase key — look near the URL or createClient calls
+    // JWT format
+    var jwtRe = /eyJ[A-Za-z0-9_-]{30,}\.eyJ[A-Za-z0-9_-]{30,}\.[A-Za-z0-9_-]{20,}/g;
+    // sb_publishable_ format
+    var pubRe = /sb_publishable_[A-Za-z0-9_-]{20,}/g;
+
+    m = pubRe.exec(allText);
+    if (m) {
+      result.supabase_key = m[0];
+    } else {
+      // Only use JWT if we have a Supabase URL (to avoid false positives)
+      if (result.supabase_url) {
+        // Look near the URL for the key
+        var urlIdx = allText.indexOf(result.supabase_url);
+        if (urlIdx >= 0) {
+          var nearby = allText.substring(urlIdx, Math.min(urlIdx + 1000, allText.length));
+          m = jwtRe.exec(nearby);
+          if (m) result.supabase_key = m[0];
+        }
+      }
+    }
+
+    // Extract .from("table_name") calls
+    var fromRe = /\.from\(["']([a-z_][a-z0-9_]{1,62})["']\)/g;
+    while ((m = fromRe.exec(allText)) !== null) {
+      if (result.tables.indexOf(m[1]) === -1) result.tables.push(m[1]);
+    }
+
+    // Extract .rpc("fn_name") calls
+    var rpcRe = /\.rpc\(["']([a-z_][a-z0-9_]{1,62})["']/g;
+    while ((m = rpcRe.exec(allText)) !== null) {
+      if (result.rpcs.indexOf(m[1]) === -1) result.rpcs.push(m[1]);
+    }
+
+    // Extract .storage.from("bucket_name") calls
+    var bucketRe = /\.storage\.from\(["']([a-z0-9_-]{1,62})["']\)/g;
+    while ((m = bucketRe.exec(allText)) !== null) {
+      if (result.buckets.indexOf(m[1]) === -1) result.buckets.push(m[1]);
+    }
+
+    // Firebase config extraction
+    var firebaseConfigRe = /firebase[Cc]onfig\s*=?\s*\{[^}]*apiKey\s*:\s*["']([^"']+)["'][^}]*databaseURL\s*:\s*["']([^"']+)["'][^}]*(?:storageBucket\s*:\s*["']([^"']+)["'])?/;
+    var fbm = firebaseConfigRe.exec(allText);
+    if (fbm) {
+      result.firebase_api_key = fbm[1];
+      result.firebase_db_url = fbm[2];
+      if (fbm[3]) result.firebase_storage_bucket = fbm[3];
+    } else {
+      // Try individual patterns
+      var dbUrlRe = /https:\/\/[a-z0-9-]+\.firebaseio\.com/g;
+      var dbm = dbUrlRe.exec(allText);
+      if (dbm) result.firebase_db_url = dbm[0];
+
+      var aizaRe = /AIza[0-9A-Za-z_-]{35}/g;
+      var aim = aizaRe.exec(allText);
+      if (aim) result.firebase_api_key = aim[0];
+
+      var bucketRe2 = /[a-z0-9-]+\.appspot\.com/g;
+      var bm = bucketRe2.exec(allText);
+      if (bm) result.firebase_storage_bucket = bm[0];
+    }
+
+    // Appwrite
+    var awEndpointRe = /\.setEndpoint\(["'](https?:\/\/[^"']+\/v1)["']\)/;
+    var awProjectRe = /\.setProject\(["']([^"']+)["']\)/;
+    var awm = awEndpointRe.exec(allText);
+    if (awm) {
+      result.appwrite_endpoint = awm[1];
+      var awp = awProjectRe.exec(allText);
+      if (awp) result.appwrite_project = awp[1];
+    }
+
+    // PocketBase
+    var pbRe = /new PocketBase\(["'](https?:\/\/[^"']+)["']\)/;
+    var pbm = pbRe.exec(allText);
+    if (pbm) result.pocketbase_url = pbm[1];
+
+    // Realtime channels
+    var channelRe = /\.channel\(["']([^"']+)["']\)/g;
+    result.realtime_channels = [];
+    while ((m = channelRe.exec(allText)) !== null) {
+      if (result.realtime_channels.indexOf(m[1]) === -1) result.realtime_channels.push(m[1]);
+    }
+
+    return result;
+  };
+})();
+"""
+
+
+def _build_init_script(payload: Optional[List[Dict[str, Any]]] = None) -> str:
+    payload = payload if payload is not None else extension_pattern_payload()
+    encoded = json.dumps(payload)
+    return _INIT_SCRIPT_TEMPLATE.replace("__PATTERNS__", encoded)
+
+
+def run_browser_scan(
+    url: str,
+    *,
+    auth_state_path: Optional[str] = None,
+    scan_budget_seconds: int = SCAN_BUDGET_DEFAULT_SECONDS,
+    headless: bool = True,
+    baas_validate: bool = True,
+    baas_prober: Optional[Any] = None,
+) -> ScanReport:
+    """Drive Playwright Chromium, inject the analyzer, return a ScanReport.
+
+    Raises ``ImportError`` if Playwright is not installed.
+    """
+
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "keyleak browser-scan requires Playwright. "
+            "Install with `pip install playwright && python -m playwright install chromium`."
+        ) from exc
+
+    init_script = _build_init_script()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+        context_kwargs: Dict[str, Any] = {"viewport": DEFAULT_VIEWPORT}
+        if auth_state_path:
+            context_kwargs["storage_state"] = auth_state_path
+        context = browser.new_context(**context_kwargs)
+        context.add_init_script(init_script)
+
+        page = context.new_page()
+        page.set_default_timeout(scan_budget_seconds * 1000)
+        page.goto(url, wait_until="networkidle")
+        raw = page.evaluate("() => window.__keyleak_run ? window.__keyleak_run() : []")
+
+        baas_extraction = None
+        if baas_validate:
+            try:
+                baas_extraction = page.evaluate(
+                    "() => window.__keyleak_baas_extract ? window.__keyleak_baas_extract() : null"
+                )
+            except Exception:
+                pass
+
+        browser.close()
+
+    findings = [_to_finding(entry, url) for entry in raw or []]
+    baas_findings = _run_baas_validation(raw, baas_extraction, baas_validate, baas_prober)
+    findings.extend(baas_findings)
+
+    return build_report(
+        url,
+        findings,
+        scan_mode="browser",
+        profile="launch-gate",
+        packs=["leak", "appsec", "access-control", "baas"],
+    )
+
+
+def _run_baas_validation(
+    raw_findings: Optional[List[Dict[str, Any]]],
+    baas_extraction: Optional[Dict[str, Any]],
+    baas_validate: bool,
+    baas_prober: Optional[Any],
+) -> List[Finding]:
+    if not baas_validate:
+        return []
+
+    from .baas_validator import extract_baas_config, validate_baas_config
+
+    config = extract_baas_config(raw_findings, baas_extraction)
+    if config is None:
+        return []
+
+    validation = validate_baas_config(config, prober=baas_prober, js_extraction=baas_extraction)
+    return validation.findings
+
+
+def _to_finding(entry: Dict[str, Any], target: str) -> Finding:
+    source = entry.get("source") or target
+    value = str(entry.get("value") or "")
+    evidence = Evidence(
+        source=source,
+        snippet=value[:240],
+        redacted_value=value[:120],
+        request_url=target,
+    )
+    detector_id = str(entry.get("detector_id") or "browser:unknown")
+    return Finding(
+        type=str(entry.get("type") or detector_id),
+        severity=str(entry.get("severity") or "info"),
+        confidence=0.85,
+        detector_id=detector_id,
+        source=source,
+        evidence=evidence,
+        risk_reason=f"Browser-side scan detected {detector_id}",
+        remediation="Rotate the exposed credential and remove it from the bundle / storage.",
+        validation_status="lead",
+        category="leak",
+    )
+
+
+# Exposed for testing without launching a real browser.
+def evaluate_findings_payload(
+    raw_findings: List[Dict[str, Any]],
+    target_url: str,
+    baas_extraction: Optional[Dict[str, Any]] = None,
+    *,
+    baas_validate: bool = False,
+    baas_prober: Optional[Any] = None,
+) -> ScanReport:
+    findings = [_to_finding(entry, target_url) for entry in raw_findings or []]
+    baas_findings = _run_baas_validation(raw_findings, baas_extraction, baas_validate, baas_prober)
+    findings.extend(baas_findings)
+    return build_report(
+        target_url,
+        findings,
+        scan_mode="browser",
+        profile="launch-gate",
+        packs=["leak", "appsec", "access-control", "baas"],
+    )

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -186,7 +186,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 auth_state_path=args.auth_state or None,
                 scan_budget_seconds=int(args.scan_budget),
                 headless=not args.headed,
-                baas_validate=not args.skip_baas_validation,
+                baas_validate=args.baas_validate,
             )
         except Exception as exc:
             print(f"browser-scan failed: {exc}", file=sys.stderr)
@@ -346,7 +346,7 @@ def build_parser() -> argparse.ArgumentParser:
     browser_scan.add_argument("--auth-state", default="", help="Path to Playwright storageState.json for authenticated scans.")
     browser_scan.add_argument("--scan-budget", default="30", help="Per-page timeout in seconds.")
     browser_scan.add_argument("--headed", action="store_true", help="Show the browser window (debugging).")
-    browser_scan.add_argument("--skip-baas-validation", action="store_true", help="Skip active BaaS (Supabase/Firebase) validation probes. Pattern detection still runs.")
+    browser_scan.add_argument("--baas-validate", action="store_true", help="Enable active BaaS (Supabase/Firebase) validation probes against detected endpoints.")
     browser_scan.add_argument("--baas-tables", default="", help="Comma-separated extra table names to probe during BaaS validation.")
     browser_scan.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
     browser_scan.add_argument("--baseline", default="")

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -195,6 +195,28 @@ def main(argv: Optional[List[str]] = None) -> int:
             return 1
         return _emit_report(report, args)
 
+    if args.command == "site-scan":
+        try:
+            from .site_scanner import scan_site
+        except ImportError as exc:
+            print(f"site-scan requires Playwright: {exc}", file=sys.stderr)
+            return 1
+        try:
+            extra_tables = _split_optional_csv(args.baas_tables)
+            report = scan_site(
+                args.domain,
+                depth=int(args.depth),
+                max_pages=int(args.max_pages),
+                headless=not args.headed,
+                baas_validate=args.baas_validate,
+                baas_tables=extra_tables,
+                scan_budget_seconds=int(args.scan_budget),
+            )
+        except Exception as exc:
+            print(f"site-scan failed: {exc}", file=sys.stderr)
+            return 1
+        return _emit_report(report, args)
+
     if args.command == "disclose":
         from .disclose import cli as disclose_cli
 
@@ -332,6 +354,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run env checks (Python, Playwright, mitmproxy, Node, network, allowlist).",
     )
     doctor.add_argument("--json", action="store_true")
+
+    site_scan = subparsers.add_parser(
+        "site-scan",
+        help="Discover subdomains, crawl pages, and scan an entire site for secrets and BaaS vulnerabilities.",
+    )
+    site_scan.add_argument("domain", help="Domain or URL to scan (e.g., example.com)")
+    site_scan.add_argument("--depth", default="1", help="Link crawl depth per host (default: 1).")
+    site_scan.add_argument("--max-pages", default="20", help="Maximum pages to scan (default: 20).")
+    site_scan.add_argument("--scan-budget", default="30", help="Per-page timeout in seconds.")
+    site_scan.add_argument("--headed", action="store_true", help="Show browser windows.")
+    site_scan.add_argument("--baas-validate", action="store_true", help="Enable active BaaS validation probes.")
+    site_scan.add_argument("--baas-tables", default="", help="Extra table names to probe.")
+    site_scan.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
+    site_scan.add_argument("--baseline", default="")
+    site_scan.add_argument("--allowlist", default="")
+    _add_format_flags(site_scan)
 
     demo = subparsers.add_parser(
         "demo",

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -3,21 +3,28 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from typing import Any, Dict, List, Optional
 
 import requests
 
+from pathlib import Path
+
+from .detectors import DETECTOR_PACKS, normalize_packs
 from .local_scanner import DEFAULT_INCLUDES, scan_path
 from .models import ScanReport
 from .reporting import (
     build_report,
     fail_threshold_met,
+    format_html,
     format_json,
     format_markdown,
     format_sarif,
     report_to_text,
 )
+from .offline_guard import install_socket_block, print_egress_banner
+from .self_audit import run_self_audit
 from .suppressions import apply_suppressions
 
 
@@ -28,13 +35,25 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
+    if getattr(args, "offline", False):
+        install_socket_block()
+        print_egress_banner()
+
     if args.command == "local":
-        report = scan_path(args.path, includes=_split_includes(args.include))
+        try:
+            packs = normalize_packs(_split_optional_csv(args.packs), profile=args.launch_profile)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        report = scan_path(args.path, includes=_split_includes(args.include), profile=args.launch_profile, packs=packs)
         return _emit_report(report, args)
 
     if args.command == "scan":
         try:
             report = _scan_url(args)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
         except requests.RequestException as exc:
             print(
                 f"Unable to reach KeyLeak web scanner at {args.server}: {exc}\n"
@@ -42,6 +61,160 @@ def main(argv: Optional[List[str]] = None) -> int:
                 file=sys.stderr,
             )
             return 1
+        return _emit_report(report, args)
+
+    if args.command == "self-audit":
+        repo_root = Path(getattr(args, "path", ".") or ".").resolve()
+        report = run_self_audit(repo_root)
+        return _emit_report(report, args)
+
+    if args.command == "explain":
+        from .detectors import find_detector
+        import json as _json
+
+        canonical_id = args.detector_id
+        if not canonical_id:
+            print("explain requires a detector canonical_id (e.g. leak.openai_api_key)", file=sys.stderr)
+            return 1
+        detector = find_detector(canonical_id)
+        if detector is None:
+            print(f"unknown detector: {canonical_id}", file=sys.stderr)
+            return 1
+        card = detector.get_remediation().to_dict()
+        if getattr(args, "json", False):
+            print(_json.dumps(card, indent=2, sort_keys=True))
+        else:
+            lines = [
+                f"# KeyLeak Remediation: {canonical_id}",
+                "",
+                f"**What leaked**: {card['what_leaked']}",
+                "",
+                f"**Why it matters**: {card['why_it_matters']}",
+                "",
+                "**Fix steps**:",
+            ]
+            for index, step in enumerate(card["fix_steps"] or ["(no steps documented)"], start=1):
+                lines.append(f"  {index}. {step}")
+            if card["verify_command"]:
+                lines.extend(["", f"**Verify**: `{card['verify_command']}`"])
+            print("\n".join(lines))
+        return 0
+
+    if args.command == "diff":
+        from .diff import diff_reports, load_report
+
+        try:
+            baseline = load_report(Path(args.baseline_report))
+            current = load_report(Path(args.current_report))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Could not load reports: {exc}", file=sys.stderr)
+            return 1
+        report = diff_reports(baseline, current)
+        return _emit_report(report, args)
+
+    if args.command == "feed":
+        from .feeds import build_manifest, query_osv_malicious
+        import json as _json
+
+        if args.feed_command == "sync":
+            try:
+                entries = query_osv_malicious(ecosystem=args.ecosystem)
+            except Exception as exc:
+                print(f"feed sync failed: {exc}", file=sys.stderr)
+                return 1
+            document = build_manifest(entries)
+            out_path = Path(args.out) if args.out else None
+            if out_path:
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(_json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+                print(f"Wrote {out_path} ({len(entries)} entries)")
+            else:
+                print(_json.dumps(document, indent=2, sort_keys=True))
+            return 0
+        print("Unknown feed command", file=sys.stderr)
+        return 1
+
+    if args.command == "archive":
+        from .archive_scanner import scan_archive, ArchiveScanError
+        import json as _json
+
+        try:
+            envelope = scan_archive(
+                args.archive,
+                as_of=args.as_of or None,
+                profile=args.launch_profile,
+                signer=args.signer,
+                prev_hash=args.prev_hash,
+            )
+        except ArchiveScanError as exc:
+            print(f"archive scan failed: {exc}", file=sys.stderr)
+            return 1
+        if args.out:
+            Path(args.out).write_text(_json.dumps(envelope, indent=2, sort_keys=True), encoding="utf-8")
+            print(f"Wrote {args.out}")
+        else:
+            print(_json.dumps(envelope, indent=2, sort_keys=True))
+        from .reporting import fail_threshold_met
+        from .models import ScanReport as _ScanReport
+        report = _ScanReport.from_dict(envelope.get("report") or {})
+        return 2 if fail_threshold_met(report, args.fail_on) else 0
+
+    if args.command == "watch":
+        from .watch import cli_main as watch_main
+
+        return watch_main(args)
+
+    if args.command == "doctor":
+        from .doctor import cli_main as doctor_main
+
+        return doctor_main(args)
+
+    if args.command == "demo":
+        from .demo import cli_main as demo_main
+
+        return demo_main(args)
+
+    if args.command == "browser-scan":
+        try:
+            from .browser_scanner import run_browser_scan
+        except ImportError as exc:
+            print(f"browser-scan requires Playwright: {exc}", file=sys.stderr)
+            return 1
+        try:
+            report = run_browser_scan(
+                args.url,
+                auth_state_path=args.auth_state or None,
+                scan_budget_seconds=int(args.scan_budget),
+                headless=not args.headed,
+                baas_validate=not args.skip_baas_validation,
+            )
+        except Exception as exc:
+            print(f"browser-scan failed: {exc}", file=sys.stderr)
+            return 1
+        return _emit_report(report, args)
+
+    if args.command == "disclose":
+        from .disclose import cli as disclose_cli
+
+        return disclose_cli(args)
+
+    if args.command == "allowlist-diff":
+        from .allowlist_diff import audit_pr_diff
+
+        try:
+            base_text = ""
+            if args.base_allowlist and args.base_allowlist != "/dev/null":
+                base_text = Path(args.base_allowlist).read_text(encoding="utf-8")
+            head_text = Path(args.head_allowlist).read_text(encoding="utf-8")
+            changed = [
+                Path(line.strip())
+                for line in Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+        except OSError as exc:
+            print(f"Unable to read allowlist-diff inputs: {exc}", file=sys.stderr)
+            return 1
+        report = audit_pr_diff(Path(args.repo_root), base_text, head_text, changed)
         return _emit_report(report, args)
 
     parser.print_help()
@@ -53,14 +226,32 @@ def build_parser() -> argparse.ArgumentParser:
         prog="keyleak",
         description="Local runtime leak detector for modern web apps.",
     )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Refuse any outbound socket. Only loopback connections allowed.",
+    )
+    parser.add_argument(
+        "--no-default-suppressions",
+        action="store_true",
+        help=(
+            "Disable the built-in fixture-path suppressions "
+            "(.env.example, /fixtures/, /tests/, docker-compose.yml, etc.). "
+            "Default is to suppress; use this flag to see EVERY finding."
+        ),
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     scan = subparsers.add_parser("scan", help="Scan a running web app through the local KeyLeak web scanner.")
     scan.add_argument("url")
     scan.add_argument("--server", default=DEFAULT_SERVER)
     scan.add_argument("--profile", default="browser", choices=["browser", "authenticated"])
+    scan.add_argument("--launch-profile", default="launch-gate", choices=["launch-gate", "local-dev", "bug-bounty", "ci", "full"])
+    scan.add_argument("--packs", default="", help=f"Comma-separated detector packs. Available: {', '.join(DETECTOR_PACKS)}")
     scan.add_argument("--bearer", default="")
     scan.add_argument("--cookie", default="")
+    scan.add_argument("--bearer-b", default="", help="Second throwaway user's bearer token for access-control comparison.")
+    scan.add_argument("--cookie-b", default="", help="Second throwaway user's cookie for access-control comparison.")
     scan.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
     scan.add_argument("--baseline", default="", help="Suppress findings already present in a previous KeyLeak JSON report.")
     scan.add_argument("--allowlist", default="", help="Suppress known findings from a JSON or line-based allowlist.")
@@ -69,10 +260,126 @@ def build_parser() -> argparse.ArgumentParser:
     local = subparsers.add_parser("local", help="Scan local files for secrets, MCP configs, source maps, and CI leaks.")
     local.add_argument("path")
     local.add_argument("--include", default=",".join(DEFAULT_INCLUDES))
+    local.add_argument("--launch-profile", default="launch-gate", choices=["launch-gate", "local-dev", "bug-bounty", "ci", "full"])
+    local.add_argument("--packs", default="", help=f"Comma-separated detector packs. Available: {', '.join(DETECTOR_PACKS)}")
     local.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
     local.add_argument("--baseline", default="", help="Suppress findings already present in a previous KeyLeak JSON report.")
     local.add_argument("--allowlist", default="", help="Suppress known findings from a JSON or line-based allowlist.")
     _add_format_flags(local)
+
+    self_audit = subparsers.add_parser(
+        "self-audit",
+        help="Audit KeyLeak's own repo for supply-chain hygiene (tag pins, dangerous triggers, lockfile, CODEOWNERS).",
+    )
+    self_audit.add_argument("path", nargs="?", default=".")
+    self_audit.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
+    self_audit.add_argument("--baseline", default="")
+    self_audit.add_argument("--allowlist", default="")
+    _add_format_flags(self_audit)
+
+    explain = subparsers.add_parser(
+        "explain",
+        help="Print the structured Remediation card for a detector (Wave 1.6 contract).",
+    )
+    explain.add_argument("detector_id", help="canonical id, e.g. leak.openai_api_key")
+    explain.add_argument("--json", action="store_true", help="Emit the card as JSON.")
+
+    diff_cmd = subparsers.add_parser(
+        "diff",
+        help="Surface findings new in <current> relative to <baseline>. (Wave 3.3)",
+    )
+    diff_cmd.add_argument("baseline_report", help="Path to baseline JSON or SARIF report.")
+    diff_cmd.add_argument("current_report", help="Path to current JSON or SARIF report.")
+    diff_cmd.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
+    diff_cmd.add_argument("--baseline", default="")
+    diff_cmd.add_argument("--allowlist", default="")
+    _add_format_flags(diff_cmd)
+
+    feed = subparsers.add_parser(
+        "feed",
+        help="Manage the signed IOC feed (Wave 3.2).",
+    )
+    feed_sub = feed.add_subparsers(dest="feed_command")
+    feed_sync = feed_sub.add_parser("sync", help="Pull OSV.dev MAL- advisories and emit a signed manifest.")
+    feed_sync.add_argument("--ecosystem", default="npm", help="OSV ecosystem to query (npm, PyPI, Maven, ...).")
+    feed_sync.add_argument("--out", default="", help="Write the manifest here. Default: keyleak/data/ioc_feed.json.")
+
+    archive = subparsers.add_parser(
+        "archive",
+        help="Scan a deployment archive (tar/zip/dir) and emit a chain-of-custody envelope (Wave 3.1).",
+    )
+    archive.add_argument("archive", help="Path to a .tar.gz / .zip / directory.")
+    archive.add_argument("--as-of", default="", help="Optional deploy timestamp to embed in the envelope.")
+    archive.add_argument("--launch-profile", default="ci", choices=["launch-gate", "local-dev", "bug-bounty", "ci", "full"])
+    archive.add_argument("--signer", default="anonymous")
+    archive.add_argument("--prev-hash", default="", help="self_hash of the previous envelope in the chain.")
+    archive.add_argument("--out", default="", help="Write the envelope to this file instead of stdout.")
+    archive.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
+
+    watch_cmd = subparsers.add_parser(
+        "watch",
+        help="Debounced incremental scan on file save; emits SARIF for VS Code (Wave 3.8).",
+    )
+    watch_cmd.add_argument("path", nargs="?", default=".")
+    watch_cmd.add_argument("--out", default="", help="Path to SARIF output; default .keyleak/findings.sarif.")
+    watch_cmd.add_argument("--interval", default="0.5", help="Poll interval in seconds.")
+    watch_cmd.add_argument("--iterations", default="0", help="Cap iterations (0 = forever).")
+
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="Run env checks (Python, Playwright, mitmproxy, Node, network, allowlist).",
+    )
+    doctor.add_argument("--json", action="store_true")
+
+    demo = subparsers.add_parser(
+        "demo",
+        help="Scan the bundled vulnerable fixture and print a remediation report.",
+    )
+    demo.add_argument("--path", default="", help="Override the fixture path.")
+    demo.add_argument("--markdown", action="store_true")
+
+    browser_scan = subparsers.add_parser(
+        "browser-scan",
+        help="Headless Playwright runner that injects the analyzer and scans live SPAs (Wave 2.4).",
+    )
+    browser_scan.add_argument("url")
+    browser_scan.add_argument("--auth-state", default="", help="Path to Playwright storageState.json for authenticated scans.")
+    browser_scan.add_argument("--scan-budget", default="30", help="Per-page timeout in seconds.")
+    browser_scan.add_argument("--headed", action="store_true", help="Show the browser window (debugging).")
+    browser_scan.add_argument("--skip-baas-validation", action="store_true", help="Skip active BaaS (Supabase/Firebase) validation probes. Pattern detection still runs.")
+    browser_scan.add_argument("--baas-tables", default="", help="Comma-separated extra table names to probe during BaaS validation.")
+    browser_scan.add_argument("--fail-on", default="high", choices=["low", "medium", "high", "critical"])
+    browser_scan.add_argument("--baseline", default="")
+    browser_scan.add_argument("--allowlist", default="")
+    _add_format_flags(browser_scan)
+
+    disclose = subparsers.add_parser(
+        "disclose",
+        help="Emit a signed disclosure packet for a third-party-credential finding.",
+    )
+    disclose.add_argument("finding_id", help="Finding.id from a KeyLeak JSON report.")
+    disclose.add_argument("--from-report", required=True, help="Path to keyleak JSON report.")
+    disclose.add_argument("--out", default="", help="Write to this file instead of stdout.")
+    disclose.add_argument("--reporter", default="anonymous", help="Reporter handle to embed in the packet.")
+    disclose.add_argument(
+        "--signature-mode",
+        default="hmac-sha256",
+        choices=["none", "hmac-sha256", "cosign"],
+        help="hmac-sha256 requires KEYLEAK_DISCLOSE_KEY; cosign requires the cosign binary.",
+    )
+
+    allowlist_diff = subparsers.add_parser(
+        "allowlist-diff",
+        help="Provenance gate: detect a PR that ships a payload and an allowlist entry suppressing it in the same diff.",
+    )
+    allowlist_diff.add_argument("--repo-root", default=".")
+    allowlist_diff.add_argument("--base-allowlist", required=True)
+    allowlist_diff.add_argument("--head-allowlist", required=True)
+    allowlist_diff.add_argument("--changed-files", required=True)
+    allowlist_diff.add_argument("--fail-on", default="critical", choices=["low", "medium", "high", "critical"])
+    allowlist_diff.add_argument("--baseline", default="")
+    allowlist_diff.add_argument("--allowlist", default="")
+    _add_format_flags(allowlist_diff)
 
     return parser
 
@@ -99,6 +406,8 @@ def _scan_url(args: argparse.Namespace):
 def _scan_request_payload(args: argparse.Namespace) -> Dict[str, Any]:
     bearer = (args.bearer or "").strip()
     cookie = (args.cookie or "").strip()
+    bearer_b = (getattr(args, "bearer_b", "") or "").strip()
+    cookie_b = (getattr(args, "cookie_b", "") or "").strip()
     auth_config: Dict[str, Any] = {"mode": "none"}
     scan_mode = "basic"
     if bearer or cookie or args.profile == "authenticated":
@@ -108,7 +417,24 @@ def _scan_request_payload(args: argparse.Namespace) -> Dict[str, Any]:
             "bearer_token": bearer,
             "cookie": cookie,
         }
-    return {"url": args.url, "scan_mode": scan_mode, "auth_config": auth_config}
+    payload = {
+        "url": args.url,
+        "scan_mode": scan_mode,
+        "auth_config": auth_config,
+        "launch_profile": getattr(args, "launch_profile", "launch-gate"),
+        "packs": normalize_packs(
+            _split_optional_csv(getattr(args, "packs", "")),
+            profile=getattr(args, "launch_profile", "launch-gate"),
+            surface="web",
+        ),
+    }
+    if bearer_b or cookie_b:
+        payload["comparison_auth_config"] = {
+            "mode": "both" if bearer_b and cookie_b else "bearer" if bearer_b else "cookie",
+            "bearer_token": bearer_b,
+            "cookie": cookie_b,
+        }
+    return payload
 
 
 def _emit_report(report, args: argparse.Namespace) -> int:
@@ -117,6 +443,7 @@ def _emit_report(report, args: argparse.Namespace) -> int:
             report,
             baseline_path=getattr(args, "baseline", ""),
             allowlist_path=getattr(args, "allowlist", ""),
+            apply_defaults=not getattr(args, "no_default_suppressions", False),
         )
     except (OSError, ValueError) as exc:
         print(f"Unable to load suppression file: {exc}", file=sys.stderr)
@@ -128,6 +455,8 @@ def _emit_report(report, args: argparse.Namespace) -> int:
         print(format_sarif(report))
     elif getattr(args, "markdown", False):
         print(format_markdown(report))
+    elif getattr(args, "html", False):
+        print(format_html(report))
     else:
         print(report_to_text(report))
 
@@ -139,9 +468,16 @@ def _add_format_flags(parser: argparse.ArgumentParser) -> None:
     group.add_argument("--json", action="store_true", help="Emit KeyLeak JSON report.")
     group.add_argument("--sarif", action="store_true", help="Emit SARIF 2.1.0 report.")
     group.add_argument("--markdown", action="store_true", help="Emit Markdown report.")
+    group.add_argument("--html", action="store_true", help="Emit self-contained HTML report.")
 
 
 def _split_includes(value: str):
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _split_optional_csv(value: str):
+    if not value:
+        return None
     return [part.strip() for part in value.split(",") if part.strip()]
 
 

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -181,7 +181,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"browser-scan requires Playwright: {exc}", file=sys.stderr)
             return 1
         try:
-            extra_tables = [t.strip() for t in (args.baas_tables or "").split(",") if t.strip()] or None
+            extra_tables = _split_optional_csv(args.baas_tables)
             report = run_browser_scan(
                 args.url,
                 auth_state_path=args.auth_state or None,

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -181,12 +181,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"browser-scan requires Playwright: {exc}", file=sys.stderr)
             return 1
         try:
+            extra_tables = [t.strip() for t in (args.baas_tables or "").split(",") if t.strip()] or None
             report = run_browser_scan(
                 args.url,
                 auth_state_path=args.auth_state or None,
                 scan_budget_seconds=int(args.scan_budget),
                 headless=not args.headed,
                 baas_validate=args.baas_validate,
+                baas_tables=extra_tables,
             )
         except Exception as exc:
             print(f"browser-scan failed: {exc}", file=sys.stderr)

--- a/keyleak/detectors.py
+++ b/keyleak/detectors.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Iterable, List, Pattern
+from typing import Iterable, List, Optional, Pattern, Sequence, Tuple
+
+from .models import Remediation, derive_remediation
+
+
+DETECTOR_SCHEMA_VERSION = 1
+MIN_KEYLEAK_VERSION = "0.1.0"
 
 
 @dataclass(frozen=True)
@@ -16,9 +22,125 @@ class Detector:
     remediation: str
     categories: List[str]
     min_match_length: int = 8
+    capture_group: int = 0
+    pack: str = "leak"
+    finding_type: str = ""
+    validation_status: str = "validated"
+    references: Tuple[str, ...] = ()
+    extension: bool = True
+    attack_scenario: Optional[str] = None
+    # Wave 1.3 — Detector ABI extension.
+    # All new fields are defaulted so existing entries don't need editing.
+    schema_version: int = DETECTOR_SCHEMA_VERSION
+    min_keyleak_version: str = MIN_KEYLEAK_VERSION
+    # Old IDs to keep honoring after a rename. Suppressions referencing any
+    # entry in ``id_aliases`` still match this detector.
+    id_aliases: Tuple[str, ...] = ()
+    # Wave 1.6 — Structured Remediation override. If None, the reporter
+    # derives a Remediation from ``description`` / ``attack_scenario`` /
+    # ``remediation``. Detectors can opt-in to richer cards by setting an
+    # explicit ``RemediationOverride`` (a dict with the four fields, kept
+    # as a dict to preserve ``frozen=True`` semantics).
+    remediation_v2: Optional[dict] = None
+    # Q.1 — minimum Shannon entropy (bits/char) for the captured value.
+    # Detectors whose pattern can legitimately match dictionary-shaped
+    # strings (``sk-*``, ``hf_*``, etc.) set this to ~4.0 to reject
+    # ``sk-indigo-twilight-color-1`` while keeping real high-entropy keys.
+    # ``None`` skips the check.
+    min_entropy: Optional[float] = None
 
     def compile(self) -> Pattern[str]:
         return re.compile(self.pattern, re.IGNORECASE | re.MULTILINE)
+
+    @property
+    def canonical_id(self) -> str:
+        return f"{self.pack}.{self.id}"
+
+    @property
+    def result_type(self) -> str:
+        return self.finding_type or self.id
+
+    @property
+    def canonical_id_aliases(self) -> Tuple[str, ...]:
+        return tuple(f"{self.pack}.{alias}" for alias in self.id_aliases)
+
+    def get_remediation(self) -> Remediation:
+        """Return the structured Remediation card for this detector.
+
+        Uses ``remediation_v2`` if explicitly set, else derives one from the
+        existing ``description`` / ``attack_scenario`` / ``remediation`` fields.
+        Wave-1.6 contract: every detector returns a populated card.
+        """
+
+        if self.remediation_v2:
+            return Remediation.from_dict(self.remediation_v2)
+        return derive_remediation(
+            self.description,
+            self.attack_scenario,
+            self.remediation,
+        )
+
+
+def find_detector(canonical_id: str):
+    """Look up a detector by ``canonical_id`` (e.g. ``leak.openai_api_key``)."""
+
+    for detector in DETECTORS:
+        if detector.canonical_id == canonical_id:
+            return detector
+        if canonical_id in detector.canonical_id_aliases:
+            return detector
+    return None
+
+
+DETECTOR_PACKS = {
+    "leak": "Secrets, exposed config, source maps, and browser-visible leak signals.",
+    "appsec": "SQL injection, XSS, and auth-bypass leads.",
+    "access-control": "IDOR, missing tenant checks, and ownership-check leads.",
+    "correctness": "N+1, regression, off-by-one, timezone/date, and semantic config leads.",
+    "housekeeping": "Missing tests, dead code, and stale comments or docs.",
+    "baas": "BaaS misconfiguration: open tables, exposed admin logic, storage, and RPC abuse vectors.",
+}
+
+HEATMAP_ROWS = {
+    "sql_injection": "appsec",
+    "xss": "appsec",
+    "auth_bypass": "appsec",
+    "idor": "access-control",
+    "missing_tenant_check": "access-control",
+    "secret_in_logs": "leak",
+    "n_plus_one_query": "correctness",
+    "regression": "correctness",
+    "off_by_one": "correctness",
+    "timezone_date_bug": "correctness",
+    "env_config_bug": "correctness",
+    "test_missing": "housekeeping",
+    "dead_code": "housekeeping",
+    "stale_doc": "housekeeping",
+}
+
+PROFILE_PACKS = {
+    "launch-gate": ("leak",),
+    "local-dev": ("leak",),
+    "bug-bounty": ("leak", "appsec", "access-control", "baas"),
+    "ci": ("leak", "appsec", "access-control", "baas"),
+    "full": tuple(DETECTOR_PACKS.keys()),
+}
+
+EXTENSION_PROFILE_PACKS = {
+    "launch-gate": ("leak", "appsec", "access-control", "baas"),
+    "local-dev": ("leak", "appsec", "access-control", "baas"),
+    "bug-bounty": ("leak", "appsec", "access-control", "baas"),
+    "ci": ("leak", "appsec", "access-control", "baas"),
+    "full": ("leak", "appsec", "access-control", "baas"),
+}
+
+WEB_PROFILE_PACKS = {
+    "launch-gate": ("leak",),
+    "local-dev": ("leak",),
+    "bug-bounty": ("leak", "appsec", "access-control", "baas"),
+    "ci": ("leak", "appsec", "access-control", "baas"),
+    "full": ("leak", "appsec", "access-control", "baas"),
+}
 
 
 DETECTORS = [
@@ -29,6 +151,11 @@ DETECTORS = [
         "OpenAI API key exposed.",
         "Rotate the OpenAI key, remove it from client/config files, and load it server-side from a secret manager.",
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="Anyone who scrapes the bundle, response, or repo runs inference on your bill. Costs can spike to thousands of dollars within hours, and the key fingerprints your account for follow-up abuse.",
+        # Q.1 — reject dictionary-word matches like `sk-indigo-twilight-color-1`
+        # (Skeleton UI class names) or `madatnlp/sk-kogptv2-kormath-causal`
+        # (HuggingFace model names). Real OpenAI keys are ~5.0 bits/char.
+        min_entropy=4.0,
     ),
     Detector(
         "anthropic_api_key",
@@ -37,6 +164,7 @@ DETECTORS = [
         "Anthropic API key exposed.",
         "Rotate the Anthropic key and move model calls behind a trusted server boundary.",
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="A leaked Anthropic key lets attackers spin up large Claude jobs on your bill, harvest any prompts or context they replay through it, and probe whatever tools your agent has bound to the same key.",
     ),
     Detector(
         "openrouter_api_key",
@@ -44,6 +172,46 @@ DETECTORS = [
         "critical",
         "OpenRouter API key exposed.",
         "Rotate the OpenRouter key and audit usage because this can proxy access to multiple model providers.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "gemini_api_key",
+        r"\bAIza[0-9A-Za-z\-_]{35}\b",
+        "critical",
+        "Google Gemini/API key exposed.",
+        "Rotate or restrict the Google API key, audit API usage, and keep model/provider credentials server-side.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "huggingface_token",
+        r"\bhf_[A-Za-z0-9]{32,}\b",
+        "high",
+        "Hugging Face token exposed.",
+        "Rotate the token, review model/dataset access, and avoid shipping provider tokens in browser bundles.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "replicate_api_key",
+        r"\br8_[A-Za-z0-9]{40,}\b",
+        "critical",
+        "Replicate API key exposed.",
+        "Rotate the Replicate key and move inference calls behind a trusted server boundary.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "perplexity_api_key",
+        r"\bpplx-[A-Za-z0-9]{40,}\b",
+        "critical",
+        "Perplexity API key exposed.",
+        "Rotate the Perplexity key and keep model-provider credentials out of client-side code.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "anyscale_api_key",
+        r"\besecret_[A-Za-z0-9]{40,}\b",
+        "critical",
+        "Anyscale API key exposed.",
+        "Rotate the Anyscale key and audit inference endpoint usage.",
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
     ),
     Detector(
@@ -61,6 +229,7 @@ DETECTORS = [
         "GitHub token exposed.",
         "Revoke the token, review repository access, and regenerate with the smallest necessary scope.",
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="Attackers clone every private repo the token can read, push malicious commits or workflow files, and harvest CI secrets from workflow logs. Tokens with `repo` scope often own enough of the supply chain to backdoor downstream consumers.",
     ),
     Detector(
         "aws_access_key",
@@ -68,6 +237,34 @@ DETECTORS = [
         "high",
         "AWS access key ID exposed.",
         "Rotate the access key and prefer IAM roles or workload identity over static credentials.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="With even a guessable secret nearby, attackers enumerate S3 buckets, mint short-lived credentials via `sts:GetSessionToken`, and pivot into anything the IAM principal can reach. AKIA prefixes appear in honeypots within minutes of being public.",
+    ),
+    Detector(
+        "aws_secret_key",
+        r"\baws.{0,30}(?:secret|access).{0,20}[\"'\s:=]+([A-Za-z0-9/+=]{40})",
+        "critical",
+        "AWS secret access key-like value exposed.",
+        "Rotate the AWS secret, review CloudTrail activity, and use IAM roles or a secret manager instead.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        8,
+        1,
+        attack_scenario="Paired with the access key ID this is full AWS API access in the principal's scope: dump RDS snapshots, spin up crypto miners on every region's compute quota, or wipe everything and demand ransom for restore.",
+    ),
+    Detector(
+        "google_service_account",
+        r"\"type\":\s*\"service_account\"[\s\S]*?\"private_key\":\s*\"-----BEGIN PRIVATE KEY-----",
+        "critical",
+        "Google service account key material exposed.",
+        "Revoke the service account key, audit IAM permissions, and move service credentials to secret storage.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "firebase_server_key",
+        r"\bAAAA[A-Za-z0-9_-]{7}:[A-Za-z0-9_-]{120,}\b",
+        "high",
+        "Firebase/FCM server key exposed.",
+        "Rotate the Firebase key and confirm Firebase security rules prevent unauthorized access.",
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
     ),
     Detector(
@@ -77,6 +274,23 @@ DETECTORS = [
         "Stripe secret key exposed.",
         "Rotate the Stripe key and move payment operations behind server-side endpoints.",
         ["env", "ci", "docker", "sourcemaps", "logs"],
+        attack_scenario="A `sk_live_` key is direct Stripe API access: attackers refund or void any charge, create payouts to attacker-controlled bank accounts, dump customer payment metadata, and rack up fraudulent transactions before anyone notices.",
+    ),
+    Detector(
+        "stripe_restricted_key",
+        r"\brk_(?:live|test)_[0-9A-Za-z]{24,}\b",
+        "critical",
+        "Stripe restricted key exposed.",
+        "Rotate the Stripe restricted key and move payment operations to server-side endpoints.",
+        ["env", "ci", "docker", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "slack_token",
+        r"\bxox[baprs]-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{24,32}\b",
+        "critical",
+        "Slack token exposed.",
+        "Revoke the Slack token, review workspace app scopes, and regenerate with least privilege.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
     ),
     Detector(
         "slack_webhook",
@@ -87,12 +301,45 @@ DETECTORS = [
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
     ),
     Detector(
+        "gitlab_token",
+        r"\bglpat-[A-Za-z0-9\-]{20,}\b",
+        "critical",
+        "GitLab token exposed.",
+        "Revoke the GitLab token, review project/group access, and regenerate with the smallest scope possible.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "npm_token",
+        r"\bnpm_[A-Za-z0-9\-_]{36}\b",
+        "critical",
+        "npm token exposed.",
+        "Revoke the npm token and audit package publish activity.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "sendgrid_api_key",
+        r"\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}\b",
+        "critical",
+        "SendGrid API key exposed.",
+        "Rotate the SendGrid key and audit mail-sending activity for abuse.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "pypi_upload_token",
+        r"\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,}\b",
+        "critical",
+        "PyPI upload token exposed.",
+        "Revoke the PyPI token and audit package release history.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
         "database_url",
         r"\b(?:postgres(?:ql)?|mysql(?:2)?|mongodb(?:\+srv)?|redis)://[^\s'\"<>]+:[^\s'\"<>]+@[^\s'\"<>]+",
         "critical",
         "Database connection string with credentials exposed.",
         "Rotate database credentials, restrict network access, and move connection strings to server-only configuration.",
         ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="The embedded credentials grant whatever role the DB user has — typically full read of every row. Attackers pull customer PII, payment records, and password hashes for credential stuffing elsewhere; if the DB is internet-reachable it's game over.",
     ),
     Detector(
         "private_key",
@@ -101,6 +348,35 @@ DETECTORS = [
         "Private key exposed.",
         "Revoke and rotate the key immediately, then audit every system where it was trusted.",
         ["env", "ci", "docker", "mcp", "logs"],
+        attack_scenario="Whoever holds the key can impersonate the server or user it was issued to: sign fake TLS certs, mint JWTs your services already trust, or SSH into every host that trusts this key. Rotation is mandatory; you cannot un-leak a private key.",
+    ),
+    Detector(
+        "jwt_token",
+        r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b",
+        "medium",
+        "JWT found in browser-visible content.",
+        "Confirm the token is short-lived, not logged or embedded, and does not expose sensitive claims.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="A leaked JWT impersonates its subject until expiry. Even without the signing key, the base64 payload usually reveals role, tenant, and internal IDs that accelerate attacks against the rest of the system.",
+    ),
+    Detector(
+        "bearer_token",
+        r"\bbearer[\s:=]+([A-Za-z0-9_\-.]{20,})\b",
+        "high",
+        "Bearer token found in browser-visible content.",
+        "Move bearer tokens out of static content and use short-lived session-bound tokens.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        8,
+        1,
+    ),
+    Detector(
+        "http_basic_auth",
+        r"\bhttps?://([A-Za-z0-9_-]+):([^@\s]+)@",
+        "high",
+        "HTTP Basic Auth credentials embedded in a URL.",
+        "Rotate the credentials and replace URL-embedded credentials with a safer authentication mechanism.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+        attack_scenario="Credentials in URLs land in browser history, web-server logs, HTTP `Referer` headers, and CI logs. Anyone with read access to those logs escalates straight to whatever the credential authenticates against.",
     ),
     Detector(
         "mcp_config_secret",
@@ -109,6 +385,8 @@ DETECTORS = [
         "MCP or agent tool credential exposed.",
         "Move agent/tool credentials to local secret storage and review connected tool permissions.",
         ["mcp", "env", "docker", "logs"],
+        8,
+        1,
     ),
     Detector(
         "hidden_prompt_injection",
@@ -134,12 +412,604 @@ DETECTORS = [
         "Browser bundle references a source map.",
         "Review generated source maps for embedded secrets and avoid publishing private source in production.",
         ["sourcemaps"],
+        attack_scenario="Source maps reveal pre-minified code, in-line API URLs, internal field names, and sometimes secrets injected at build time. Attackers reverse-engineer your auth flow, business rules, and authorization edges much faster than they could from the minified bundle.",
+    ),
+    Detector(
+        "npm_optional_dep_git_ref",
+        r"\"optionalDependencies\"\s*:\s*\{[^}]*\"[^\"]+\"\s*:\s*\"(?:github:[^\"]+|git\+(?:https?|ssh)://[^\"]+)#[a-f0-9]{7,40}",
+        "high",
+        "package.json optionalDependencies points to a git commit SHA. This is the Mini Shai-Hulud (TanStack 2026) attack vector.",
+        "Remove the git-ref optionalDependency. Replace with a pinned semver from the registry or vendor the code in-tree.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs", "code", "config"],
+        20,
+        0,
+        "leak",
+        "npm_optional_dep_git_ref",
+        "validated",
+        ("https://tanstack.com/blog/npm-supply-chain-compromise-postmortem", "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem"),
+        True,
+        "An attacker that lands a PR adding `optionalDependencies: { '@x/setup': 'github:org/repo#<sha>' }` runs arbitrary code on every install via the orphan commit's `prepare` hook. This is exactly how Mini Shai-Hulud compromised 42 @tanstack/* packages on 2026-05-11 and stole AWS/GCP/Vault/GitHub/npm credentials from anyone who installed.",
+    ),
+    Detector(
+        "gh_actions_pull_request_target",
+        r"(?:^|\n)\s*on\s*:[\s\S]{0,400}\bpull_request_target\b",
+        # L.2 — downgraded from medium to info after the dogfood showed ~150
+        # mediums against repos that all use ``pull_request_target`` for
+        # legitimate labeler / CLA / dependabot bots. The trigger ALONE is
+        # not a leak; the actual Pwn Request requires also checking out
+        # ``github.event.pull_request.head.ref``. That pattern is now a
+        # separate ``gh_actions_pwn_request_head_ref`` detector (high).
+        "info",
+        "GitHub Actions workflow uses pull_request_target. Informational only — the leak shape is `pull_request_target` + checkout of `head.ref`. See `gh_actions_pwn_request_head_ref`.",
+        "If this workflow runs untrusted PR code: switch to `pull_request`. If it only reads PR metadata (labeler, CLA bot), this trigger is fine and you can suppress this notice.",
+        ["ci"],
+        12,
+        0,
+        "leak",
+        "gh_actions_pull_request_target",
+        "lead",
+        ("https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",),
+        True,
+        "`pull_request_target` alone is informational — the worm hit @tanstack via the combination of this trigger AND a checkout of `head.ref` in the same job. Workflows that only read PR metadata (assign reviewers, label PRs, validate CLA) are safe.",
+    ),
+    Detector(
+        # L.2 — the real Pwn Request pattern: pull_request_target + checkout
+        # of head.ref (or head.sha) in the same workflow. This is the high-
+        # severity finding that the original detector was conflating with
+        # legitimate labeler bots.
+        "gh_actions_pwn_request_head_ref",
+        r"\bpull_request_target\b[\s\S]{0,4000}?actions/checkout[\s\S]{0,400}?ref\s*:\s*\$\{\{\s*github\.event\.pull_request\.head\.(?:ref|sha)\s*\}\}",
+        "high",
+        "GitHub Actions workflow combines pull_request_target with checkout of head.ref/head.sha — this is the Pwn Request pattern that compromised TanStack/Mini-Shai-Hulud.",
+        "Move untrusted-code work into a separate `pull_request`-triggered workflow that has no secrets, and use `workflow_run` to pass artifacts only.",
+        ["ci"],
+        24,
+        0,
+        "leak",
+        "gh_actions_pwn_request_head_ref",
+        "validated",
+        (
+            "https://securitylab.github.com/research/github-actions-preventing-pwn-requests/",
+            "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",
+        ),
+        True,
+        "A `pull_request_target` workflow that also checks out the head branch runs attacker-controlled code with the base repo's secrets. Mini Shai-Hulud rode this exact combo into TanStack — a forked PR added a malicious script, the workflow checked it out, and the OIDC + npm tokens left.",
+    ),
+    Detector(
+        "gh_actions_secrets_tojson",
+        r"toJSON\(\s*secrets\s*\)",
+        "high",
+        "GitHub Actions workflow serializes all secrets via toJSON(secrets). Mini Shai-Hulud (2026) used this exact pattern to bulk-exfiltrate CI secrets.",
+        "Reference only the specific secrets the job needs (`${{ secrets.NPM_TOKEN }}`). Never pass the entire `secrets` object as JSON to a step.",
+        ["ci"],
+        12,
+        0,
+        "leak",
+        "gh_actions_secrets_tojson",
+        "validated",
+        ("https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",),
+        True,
+        "`toJSON(secrets)` dumps every CI secret the job has into a single blob — typically logged or passed to a tool. Any later step that writes that blob to disk, logs it, or sends it over the network exfiltrates the entire vault. It's a load-bearing IOC for the Mini Shai-Hulud worm.",
+    ),
+    Detector(
+        "shai_hulud_c2_domain",
+        r"\b(?:filev2\.getsession\.org|seed[1-3]\.getsession\.org|api\.masscan\.cloud|git-tanstack\.com)\b",
+        "critical",
+        "Mini Shai-Hulud command-and-control or exfiltration domain found.",
+        "Treat the host as compromised. Rotate every credential reachable from the affected machine or CI runner: AWS, GCP, Kubernetes, Vault, GitHub, npm, SSH. Then audit egress logs to confirm what left.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs", "code"],
+        8,
+        0,
+        "leak",
+        "shai_hulud_c2_domain",
+        "validated",
+        ("https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem", "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem"),
+        True,
+        "The Mini Shai-Hulud worm sends stolen credentials to the Session/Oxen messenger network (`filev2.getsession.org`, `seed{1,2,3}.getsession.org`) and uses `api.masscan.cloud` and `git-tanstack.com` for C2. If your code, logs, or build artifacts mention any of these, an installed dependency is already exfiltrating data.",
+    ),
+    Detector(
+        "npm_prepare_bun_payload",
+        r"\"(?:prepare|preinstall|postinstall)\"\s*:\s*\"[^\"]*\b(?:bun\s+run|node\s+(?:\./)?(?:tanstack_runner|router_init|router_runtime))[^\"]*\"",
+        "high",
+        "package.json prepare/preinstall/postinstall script runs Bun or a TanStack-style payload file. Mini Shai-Hulud (2026) executed `bun run tanstack_runner.js && exit 1`.",
+        "Inspect the script and the referenced JS file. If the file is bundled, opaque, or not in version control, treat the package as compromised. Add `--ignore-scripts` to your install command and switch to pnpm v10+ for default-off lifecycle execution.",
+        ["env", "ci", "docker", "mcp", "code", "config"],
+        18,
+        0,
+        "leak",
+        "npm_prepare_bun_payload",
+        "lead",
+        ("https://tanstack.com/blog/npm-supply-chain-compromise-postmortem",),
+        True,
+        "The TanStack worm executed its payload through `prepare: \"bun run tanstack_runner.js && exit 1\"` in the malicious tarball's package.json. Any install (developer machine or CI runner) immediately ran the harvester. `--ignore-scripts` blocks this vector entirely; pnpm v10 does it by default in CI.",
+    ),
+    Detector(
+        "webhook_url",
+        r"\bhttps?://[^\s'\"<>]+webhook[^\s'\"<>]*",
+        "medium",
+        "Webhook URL exposed.",
+        "Review whether the webhook is secret-bearing, rotate it if sensitive, and add authentication where possible.",
+        ["env", "ci", "docker", "mcp", "sourcemaps", "logs"],
+    ),
+    Detector(
+        "private_ip",
+        r"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b",
+        "low",
+        "Private network address exposed.",
+        "Review whether internal topology details should be visible in client-side content.",
+        ["sourcemaps", "logs"],
+    ),
+    Detector(
+        "secret_in_logs_lead",
+        r"(?:console\.log|logger\.(?:debug|info|warn|error)|print\s*\()[\s\S]{0,120}(?:api[_-]?key|secret|token|password|authorization|cookie)",
+        "medium",
+        "Secret-in-logs lead found.",
+        "Remove secrets from logs, redact sensitive fields at the logger boundary, and rotate any value that may already have been written.",
+        ["code", "sourcemaps", "logs"],
+        12,
+        0,
+        "leak",
+        "secret_in_logs",
+        "lead",
+    ),
+    Detector(
+        "sql_injection_lead",
+        r"(?:\b(?:SELECT|UPDATE|DELETE|INSERT)\b[\s\S]{0,160}(?:\+\s*(?:req|request|params|query|body|input|user)|\$\{[^}]+\})|(?:sql|query)\s*[:=]\s*[`'\"][\s\S]{0,120}\$\{[^}]+\}|(?:SQL syntax|mysql_fetch|PostgreSQL query failed|SQLiteException|ODBC SQL Server Driver))",
+        "medium",
+        "SQL injection lead found in query construction or database error output.",
+        "Parameterize the query, validate the input at the boundary, and re-test the endpoint with the launch gate after the fix.",
+        ["code", "sourcemaps", "logs"],
+        12,
+        0,
+        "appsec",
+        "sql_injection",
+        "lead",
+        ("https://owasp.org/www-community/attacks/SQL_Injection",),
+    ),
+    Detector(
+        "xss_sink_lead",
+        r"(?:\b(?:innerHTML|outerHTML)\s*=\s*(?:location|window\.location|document\.URL|[\s\S]{0,80}(?:searchParams|location\.hash|message\.data|postMessage))|document\.write\s*\([\s\S]{0,120}(?:location|document\.URL|message\.data)|insertAdjacentHTML\s*\([\s\S]{0,160}(?:location|message\.data|query|hash)|dangerouslySetInnerHTML\s*=\s*\{\{)",
+        "medium",
+        "XSS lead found where untrusted input can reach an HTML sink.",
+        "Render untrusted values as text, sanitize unavoidable HTML with an allowlist sanitizer, and add a regression test for the sink.",
+        ["code", "sourcemaps", "logs"],
+        12,
+        0,
+        "appsec",
+        "xss",
+        "lead",
+        ("https://owasp.org/www-community/attacks/xss/",),
+    ),
+    Detector(
+        "auth_bypass_lead",
+        r"\b(?:disable[_-]?auth|skip[_-]?auth|bypass[_-]?auth|auth[_-]?disabled|ALLOW_ALL_USERS|requireAuth\s*[:=]\s*false|isAdmin\s*[:=]\s*true|TODO:?[\s\S]{0,60}(?:auth|authorization|permission))\b",
+        "medium",
+        "Auth-bypass lead found in shipped code or config.",
+        "Remove bypass flags from production paths, enforce server-side authorization, and add an auth regression test.",
+        ["code", "env", "ci", "docker", "sourcemaps", "logs", "config"],
+        8,
+        0,
+        "appsec",
+        "auth_bypass",
+        "lead",
+        ("https://owasp.org/Top10/A01_2021-Broken_Access_Control/",),
+    ),
+    Detector(
+        "idor_direct_object_lead",
+        r"(?:/(?:users?|accounts?|customers?|tenants?|organizations?|orgs?|projects?|orders?)/[0-9a-fA-F-]{6,}|(?:user|account|customer|tenant|organization|project|order)[_-]?id\s*[:=]\s*[`'\"]?\$\{?[^`'\"\s}]+)",
+        "medium",
+        "Direct object reference lead found in a sensitive resource path or parameter.",
+        "Verify object ownership on the server with tenant/user scoped queries and re-test with two throwaway users.",
+        ["code", "sourcemaps", "logs"],
+        6,
+        0,
+        "access-control",
+        "idor",
+        "lead",
+        ("https://owasp.org/Top10/A01_2021-Broken_Access_Control/",),
+        attack_scenario="If the server doesn't check ownership, swapping `/users/123` for `/users/124` returns another tenant's data. Attackers script through every ID to enumerate the full customer base. Validate with a two-user scan: `keyleak scan ... --bearer $A --bearer-b $B`.",
+    ),
+    Detector(
+        "missing_tenant_check_lead",
+        r"(?:TODO:?[\s\S]{0,80}(?:tenant|ownership|authorization|permission)|(?:tenant|org|organization|workspace|account)[_-]?id[\s\S]{0,80}(?:optional|nullable|skip|TODO|FIXME))",
+        "medium",
+        "Missing tenant or ownership-check lead found.",
+        "Make the tenant boundary mandatory in server-side queries and add a cross-tenant negative test.",
+        ["code", "sourcemaps", "logs", "config"],
+        8,
+        0,
+        "access-control",
+        "missing_tenant_check",
+        "lead",
+        ("https://owasp.org/Top10/A01_2021-Broken_Access_Control/",),
+    ),
+    Detector(
+        "n_plus_one_query_lead",
+        r"(?:for\s+.+:\s*(?:\n[^\n]*){0,6}\.(?:query|get|filter|find|select)\(|for\s*\([^)]*\)\s*\{[\s\S]{0,400}(?:SELECT\s+|\.query\(|\.find\(|\.filter\())",
+        "low",
+        "N+1 query lead found near a loop and database access.",
+        "Batch or eager-load the related data, then add a query-count or performance regression test.",
+        ["code", "tests", "logs"],
+        12,
+        0,
+        "correctness",
+        "n_plus_one_query",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "regression_signal",
+        r"(?:AssertionError|Expected [^\n]{1,120} but got|regression(?: test)? failed|breaks existing|failing tests?|FAILED [^\n]{0,80}tests?)",
+        "low",
+        "Regression signal found in code comments, tests, or logs.",
+        "Reproduce the failing path, add or fix the regression test, and keep this advisory non-blocking unless the profile opts in.",
+        ["code", "tests", "logs"],
+        12,
+        0,
+        "correctness",
+        "regression",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "off_by_one_lead",
+        r"(?:off[-_ ]by[-_ ]one|range\s*\(\s*len\s*\([^)]+\)\s*\+\s*1|for\s*\([^;]+;[^;]+<=\s*[^;]+\.length|index\s*[<>]=\s*(?:len|length))",
+        "low",
+        "Off-by-one lead found in index or loop boundary logic.",
+        "Check the boundary condition, add tests for empty/one/many cases, and re-run the correctness profile.",
+        ["code", "tests"],
+        8,
+        0,
+        "correctness",
+        "off_by_one",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "timezone_date_lead",
+        r"(?:datetime\.now\s*\(\s*\)|datetime\.utcnow\s*\(\s*\)|new Date\s*\(\s*[^)]*\)\s*[\.;]|Date\.parse\s*\(|tzinfo\s*=\s*None|timezone\s*TODO|TODO:?[\s\S]{0,80}(?:timezone|date boundary|DST))",
+        "low",
+        "Timezone or date-boundary lead found.",
+        "Use timezone-aware dates, store UTC at boundaries, and add tests across DST/month/year transitions.",
+        ["code", "tests", "config"],
+        8,
+        0,
+        "correctness",
+        "timezone_date_bug",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "config_risk_lead",
+        r"(?:\bDEBUG\s*=\s*True\b|\bNODE_ENV\s*=\s*development\b|\b(?:VERIFY_SSL|TLS_VERIFY|SSL_VERIFY)\s*=\s*(?:false|0|no)\b|\b(?:ALLOW_ORIGINS|CORS_ORIGIN|CORS_ALLOW_ALL_ORIGINS)\s*[:=]\s*(?:\*|true)\b)",
+        "low",
+        "Semantic config-risk lead found.",
+        "Move risky development config out of launch profiles and assert production-safe defaults in CI.",
+        ["env", "ci", "docker", "config", "code"],
+        8,
+        0,
+        "correctness",
+        "env_config_bug",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "missing_test_lead",
+        r"(?:TODO:?[\s\S]{0,80}(?:add|write|restore|missing)[\s\S]{0,40}(?:test|spec|coverage)|(?:describe|it|test)\.skip\s*\(|pytest\.mark\.skip|xit\s*\()",
+        "info",
+        "Missing or skipped test lead found.",
+        "Add the missing test or document why the skip is temporary and tracked.",
+        ["code", "tests", "docs"],
+        8,
+        0,
+        "housekeeping",
+        "test_missing",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "dead_code_lead",
+        r"(?:dead code|unused code|TODO:?[\s\S]{0,80}(?:remove|delete|cleanup)|\bdebugger\s*;|console\.log\s*\()",
+        "info",
+        "Dead-code or debug-code lead found.",
+        "Remove dead/debug code or move intentional diagnostics behind an explicit development guard.",
+        ["code", "tests", "docs"],
+        8,
+        0,
+        "housekeeping",
+        "dead_code",
+        "lead",
+        (),
+        False,
+    ),
+    Detector(
+        "stale_doc_lead",
+        r"(?:stale (?:comment|doc|documentation)|outdated (?:comment|doc|documentation)|wrong doc|TODO:?[\s\S]{0,80}(?:update|fix|sync)[\s\S]{0,40}(?:doc|readme|comment))",
+        "info",
+        "Stale comment or documentation lead found.",
+        "Update the comment or documentation so it matches current behavior, or delete it if it no longer helps.",
+        ["code", "docs", "tests"],
+        8,
+        0,
+        "housekeeping",
+        "stale_doc",
+        "lead",
+        (),
+        False,
+    ),
+    # ------------------------------------------------------------------
+    # BaaS pack — Backend-as-a-Service misconfiguration detectors
+    # ------------------------------------------------------------------
+    Detector(
+        "supabase_url",
+        r"\bhttps://[a-z0-9]{20,}\.supabase\.co\b",
+        "medium",
+        "Supabase project URL exposed in client bundle.",
+        "Verify RLS policies are enforced on all tables. Run `keyleak browser-scan` with BaaS validation to confirm.",
+        ["sourcemaps", "code", "env"],
+        pack="baas",
+        finding_type="supabase_url",
+        validation_status="lead",
+        references=("https://supabase.com/docs/guides/auth/row-level-security",),
+        attack_scenario="Combined with the anon key, the project URL enables direct REST API queries against every table. Missing or misconfigured RLS makes all data readable by anyone.",
+    ),
+    Detector(
+        "supabase_anon_key",
+        r"\beyJ[A-Za-z0-9_-]{30,}\.eyJ[A-Za-z0-9_-]{30,}\.[A-Za-z0-9_-]{20,}\b",
+        "medium",
+        "Supabase anon/publishable key (JWT format) exposed in client bundle.",
+        "Anon keys are designed for client use, but confirm RLS policies protect every table.",
+        ["sourcemaps", "code", "env"],
+        pack="baas",
+        finding_type="supabase_anon_key",
+        validation_status="lead",
+        references=("https://supabase.com/docs/guides/api#api-keys",),
+        attack_scenario="The anon key grants PostgREST API access with the anon role. Without RLS, any table is fully readable and writable.",
+    ),
+    Detector(
+        "supabase_publishable_key",
+        r"\bsb_publishable_[A-Za-z0-9_-]{20,}\b",
+        "medium",
+        "Supabase publishable key (non-standard format) exposed in client bundle.",
+        "Confirm RLS policies protect every table. Run BaaS validation to test.",
+        ["sourcemaps", "code", "env"],
+        pack="baas",
+        finding_type="supabase_publishable_key",
+        validation_status="lead",
+    ),
+    Detector(
+        "firebase_client_config",
+        r"apiKey['\"\s:=]+AIza[0-9A-Za-z_-]{35}",
+        "medium",
+        "Firebase client configuration with API key exposed in client bundle.",
+        "Firebase client config is designed for client use, but verify Firestore Security Rules and Storage Rules deny unauthorized access.",
+        ["sourcemaps", "code", "env"],
+        pack="baas",
+        finding_type="firebase_client_config",
+        validation_status="lead",
+        references=("https://firebase.google.com/docs/rules",),
+        attack_scenario="Firebase config grants access to Firestore, Realtime Database, and Storage. Without security rules, an attacker can read all documents, write arbitrary data, and access every file in Cloud Storage.",
+    ),
+    Detector(
+        "client_side_admin_check",
+        r"(?:is_admin|isAdmin|is_superuser|isSuperuser)\s*(?:===?\s*(?:true|!0)|!==?\s*(?:false|!1))",
+        "high",
+        "Client-side admin/role check found. Authorization decisions in browser JS are trivially bypassable.",
+        "Move all authorization checks to the server. Use Supabase RLS policies or Firebase Security Rules to enforce admin-only access.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="client_side_admin_check",
+        validation_status="lead",
+        references=("https://owasp.org/Top10/A01_2021-Broken_Access_Control/",),
+        attack_scenario="An attacker sets is_admin=true in the browser console or modifies the JS bundle. Every admin-gated mutation (payouts, user management, moderation) becomes accessible.",
+    ),
+    Detector(
+        "baas_select_star",
+        r"\.from\(['\"][a-z_][a-z0-9_]*['\"]\)[\s\S]{0,60}\.select\(['\"]?\*['\"]?\)",
+        "low",
+        "BaaS table query uses select('*'), fetching all columns including potentially sensitive ones.",
+        "Specify only the columns you need in select(). This reduces data exposure and improves performance.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="baas_select_star",
+        validation_status="lead",
+    ),
+    Detector(
+        "baas_table_reference",
+        r"\.from\(['\"]([a-z_][a-z0-9_]{1,62})['\"]\)",
+        "info",
+        "BaaS table name referenced in client bundle.",
+        "Review whether this table's RLS policies are correctly configured.",
+        ["sourcemaps", "code"],
+        1,
+        1,
+        "baas",
+        "baas_table_reference",
+        "lead",
+    ),
+    Detector(
+        "baas_rpc_call",
+        r"\.rpc\(['\"]([a-z_][a-z0-9_]{1,62})['\"]",
+        "info",
+        "BaaS RPC function called from client bundle.",
+        "Verify this RPC function validates caller identity and rate-limits requests.",
+        ["sourcemaps", "code"],
+        1,
+        1,
+        "baas",
+        "baas_rpc_call",
+        "lead",
+    ),
+    Detector(
+        "baas_storage_bucket",
+        r"\.storage\.from\(['\"]([a-z0-9_-]{1,62})['\"]\)",
+        "low",
+        "BaaS storage bucket referenced in client bundle.",
+        "Verify storage bucket policies restrict who can upload, download, and list objects.",
+        ["sourcemaps", "code"],
+        1,
+        1,
+        "baas",
+        "baas_storage_bucket",
+        "lead",
+    ),
+    # Wave 4.2 — Firebase active validation detectors
+    Detector(
+        "firebase_db_url",
+        r"\bhttps://[a-z0-9-]+\.firebaseio\.com\b",
+        "medium",
+        "Firebase Realtime Database URL exposed in client bundle.",
+        "Verify Firebase Security Rules deny unauthorized read/write access.",
+        ["sourcemaps", "code", "env"],
+        pack="baas",
+        finding_type="firebase_db_url",
+        validation_status="lead",
+        references=("https://firebase.google.com/docs/database/security",),
+        attack_scenario="The Realtime Database URL allows direct REST API access. Without security rules, all data is readable and writable by anyone.",
+    ),
+    Detector(
+        "firebase_storage_bucket",
+        r"\b[a-z0-9-]+\.appspot\.com\b",
+        "info",
+        "Firebase/GCP storage bucket referenced in client bundle.",
+        "Verify Cloud Storage security rules restrict access.",
+        ["sourcemaps", "code", "env"],
+        pack="baas",
+        finding_type="firebase_storage_bucket",
+        validation_status="lead",
+    ),
+    # Wave 4.3 — Appwrite & PocketBase detectors
+    Detector(
+        "appwrite_endpoint",
+        r"\.setEndpoint\(['\"]https?://[^'\"]+/v1['\"]\)",
+        "medium",
+        "Appwrite API endpoint exposed in client bundle.",
+        "Verify Appwrite collection permissions deny unauthorized access.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="appwrite_endpoint",
+        validation_status="lead",
+    ),
+    Detector(
+        "pocketbase_url",
+        r"new PocketBase\(['\"]https?://[^'\"]+['\"]\)",
+        "medium",
+        "PocketBase instance URL exposed in client bundle.",
+        "Verify PocketBase collection API rules restrict access.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="pocketbase_url",
+        validation_status="lead",
+    ),
+    # Wave 4.4 — Write operation detection detectors
+    Detector(
+        "baas_insert_call",
+        r"\.(?:insert|upsert)\(",
+        "info",
+        "BaaS insert/upsert mutation found in client code.",
+        "Verify RLS policies restrict who can write to this table.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="baas_insert_call",
+        validation_status="lead",
+    ),
+    Detector(
+        "baas_delete_call",
+        r"\.delete\(\)",
+        "info",
+        "BaaS delete mutation found in client code.",
+        "Verify RLS policies restrict who can delete from this table.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="baas_delete_call",
+        validation_status="lead",
+    ),
+    # Wave 4.5 — Auth flow analysis detector
+    Detector(
+        "baas_password_auth",
+        r"signInWithPassword",
+        "info",
+        "Password-based authentication flow detected in client code.",
+        "Ensure password policies, rate limiting, and email confirmation are configured.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="baas_password_auth",
+        validation_status="lead",
+    ),
+    # Wave 4.6 — Realtime channel security detectors
+    Detector(
+        "baas_realtime_channel",
+        r"\.channel\(['\"]([^'\"]+)['\"]\)",
+        "info",
+        "Supabase Realtime channel subscription in client code.",
+        "Verify channel policies restrict who can subscribe.",
+        ["sourcemaps", "code"],
+        1,
+        1,
+        "baas",
+        "baas_realtime_channel",
+        "lead",
+    ),
+    Detector(
+        "baas_realtime_subscribe",
+        r"\.on\(['\"]postgres_changes['\"]",
+        "info",
+        "Supabase Realtime postgres_changes subscription in client code.",
+        "Verify RLS policies apply to realtime subscriptions.",
+        ["sourcemaps", "code"],
+        pack="baas",
+        finding_type="baas_realtime_subscribe",
+        validation_status="lead",
     ),
 ]
 
 
-def detectors_for_categories(categories: Iterable[str]) -> List[Detector]:
+def normalize_packs(packs: Optional[Iterable[str]] = None, profile: str = "launch-gate", surface: str = "local") -> Tuple[str, ...]:
+    if packs:
+        requested = tuple(dict.fromkeys(pack.strip().lower() for pack in packs if pack and pack.strip()))
+    else:
+        profile_map = EXTENSION_PROFILE_PACKS if surface == "extension" else WEB_PROFILE_PACKS if surface == "web" else PROFILE_PACKS
+        requested = tuple(profile_map.get((profile or "launch-gate").strip().lower(), PROFILE_PACKS["launch-gate"]))
+
+    invalid = [pack for pack in requested if pack not in DETECTOR_PACKS]
+    if invalid:
+        raise ValueError(f"Unknown detector pack(s): {', '.join(invalid)}")
+    if surface in {"extension", "web"}:
+        repo_only = [pack for pack in requested if pack in {"correctness", "housekeeping"}]
+        if repo_only:
+            raise ValueError(f"Repo-only detector pack(s): {', '.join(repo_only)}")
+    return requested
+
+
+def categories_for_packs(packs: Sequence[str]) -> Tuple[str, ...]:
+    categories = set()
+    for detector in DETECTORS:
+        if detector.pack in packs:
+            categories.update(detector.categories)
+    return tuple(sorted(categories))
+
+
+def detectors_for_categories(categories: Iterable[str], packs: Optional[Iterable[str]] = None, extension_only: bool = False) -> List[Detector]:
     requested = {category.strip().lower() for category in categories if category.strip()}
+    requested_packs = set(normalize_packs(packs, profile="full")) if packs else set(DETECTOR_PACKS)
+    detectors = [
+        detector for detector in DETECTORS
+        if detector.pack in requested_packs and (not extension_only or detector.extension)
+    ]
     if not requested:
-        return list(DETECTORS)
-    return [detector for detector in DETECTORS if requested.intersection(detector.categories)]
+        return detectors
+    return [detector for detector in detectors if requested.intersection(detector.categories)]
+
+
+def detectors_for_packs(packs: Iterable[str], extension_only: bool = False) -> List[Detector]:
+    requested_packs = set(normalize_packs(packs, profile="full"))
+    return [
+        detector for detector in DETECTORS
+        if detector.pack in requested_packs and (not extension_only or detector.extension)
+    ]

--- a/keyleak/detectors.py
+++ b/keyleak/detectors.py
@@ -387,6 +387,7 @@ DETECTORS = [
         ["mcp", "env", "docker", "logs"],
         8,
         1,
+        extension=False,
     ),
     Detector(
         "hidden_prompt_injection",
@@ -565,6 +566,7 @@ DETECTORS = [
         "sql_injection",
         "lead",
         ("https://owasp.org/www-community/attacks/SQL_Injection",),
+        False,
     ),
     Detector(
         "xss_sink_lead",

--- a/keyleak/detectors.py
+++ b/keyleak/detectors.py
@@ -759,19 +759,10 @@ DETECTORS = [
         references=("https://supabase.com/docs/guides/auth/row-level-security",),
         attack_scenario="Combined with the anon key, the project URL enables direct REST API queries against every table. Missing or misconfigured RLS makes all data readable by anyone.",
     ),
-    Detector(
-        "supabase_anon_key",
-        r"\beyJ[A-Za-z0-9_-]{30,}\.eyJ[A-Za-z0-9_-]{30,}\.[A-Za-z0-9_-]{20,}\b",
-        "medium",
-        "Supabase anon/publishable key (JWT format) exposed in client bundle.",
-        "Anon keys are designed for client use, but confirm RLS policies protect every table.",
-        ["sourcemaps", "code", "env"],
-        pack="baas",
-        finding_type="supabase_anon_key",
-        validation_status="lead",
-        references=("https://supabase.com/docs/guides/api#api-keys",),
-        attack_scenario="The anon key grants PostgREST API access with the anon role. Without RLS, any table is fully readable and writable.",
-    ),
+    # Note: Supabase JWT-format anon keys are detected by the BaaS validator's
+    # extract_baas_config() via proximity to a Supabase URL, not by a standalone
+    # regex detector.  A standalone JWT regex would overlap with the generic
+    # jwt_token detector and produce false positives on non-Supabase JWTs.
     Detector(
         "supabase_publishable_key",
         r"\bsb_publishable_[A-Za-z0-9_-]{20,}\b",

--- a/keyleak/reporting.py
+++ b/keyleak/reporting.py
@@ -43,7 +43,7 @@ def normalize_findings(findings: Iterable[Any]) -> List[Finding]:
         if isinstance(raw, Finding):
             normalized.append(raw)
         elif isinstance(raw, dict):
-            if "evidence" in raw or "detector_id" in raw or "risk_reason" in raw:
+            if "evidence" in raw or "risk_reason" in raw:
                 normalized.append(Finding.from_dict(raw))
             else:
                 normalized.append(finding_from_legacy(raw))
@@ -118,15 +118,12 @@ def format_html(report: ScanReport) -> str:
     if verdict_status == "BLOCK_SHIP":
         verdict_cls = "block"
         verdict_badge = "Block Ship"
-        verdict_banner_extra = ""
     elif verdict_status == "REVIEW":
         verdict_cls = "review"
         verdict_badge = "Review"
-        verdict_banner_extra = ""
     else:
         verdict_cls = "safe"
         verdict_badge = "Safe to Ship"
-        verdict_banner_extra = ""
 
     # --- findings cards ---
     finding_cards = []

--- a/keyleak/reporting.py
+++ b/keyleak/reporting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import shlex
 from typing import Any, Dict, Iterable, List, Optional
@@ -15,16 +16,24 @@ def build_report(
     findings: Iterable[Any],
     scan_mode: str = "runtime",
     attack_vectors: Optional[Dict[str, Any]] = None,
+    profile: str = "launch-gate",
+    packs: Optional[Iterable[str]] = None,
 ) -> ScanReport:
     normalized = normalize_findings(findings)
     normalized.extend(_attack_vector_findings(attack_vectors or {}))
     normalized.sort(key=lambda finding: SEVERITY_ORDER.get(finding.severity, 0), reverse=True)
+    selected_packs = list(packs or _packs_from_findings(normalized))
 
     return ScanReport(
         target=target,
         scan_mode=scan_mode,
         findings=normalized,
         retest_command=_retest_command(target, scan_mode),
+        extra={
+            "profile": profile,
+            "packs": selected_packs,
+            "pack_summary": _pack_summary(normalized, selected_packs),
+        },
     )
 
 
@@ -34,7 +43,10 @@ def normalize_findings(findings: Iterable[Any]) -> List[Finding]:
         if isinstance(raw, Finding):
             normalized.append(raw)
         elif isinstance(raw, dict):
-            normalized.append(finding_from_legacy(raw))
+            if "evidence" in raw or "detector_id" in raw or "risk_reason" in raw:
+                normalized.append(Finding.from_dict(raw))
+            else:
+                normalized.append(finding_from_legacy(raw))
     return normalized
 
 
@@ -49,6 +61,7 @@ def format_markdown(report: ScanReport) -> str:
         "",
         f"- Target: `{payload['target']}`",
         f"- Scan mode: `{payload['scan_mode']}`",
+        f"- Packs: `{', '.join(payload.get('packs') or []) or 'none'}`",
         f"- Generated: `{payload['generated_at']}`",
         f"- Reason: {payload['verdict']['reason']}",
         f"- Re-test: `{payload['retest_command']}`",
@@ -68,12 +81,207 @@ def format_markdown(report: ScanReport) -> str:
                 f"### {item['severity'].upper()}: {item['type']}",
                 f"- ID: `{item['id']}`",
                 f"- Source: `{item['source']}`",
+                f"- Pack: `{item.get('category') or 'unknown'}`",
                 f"- Evidence: `{item['evidence']['redacted_value']}`",
-                f"- Why it matters: {item['risk_reason']}",
-                f"- Fix: {item['remediation']}",
             ]
         )
+        rem_v2 = item.get("remediation_v2")
+        if rem_v2:
+            lines.extend(
+                [
+                    f"- What leaked: {rem_v2.get('what_leaked') or ''}",
+                    f"- Why it matters: {rem_v2.get('why_it_matters') or item['risk_reason']}",
+                    "- Fix steps:",
+                ]
+            )
+            for index, step in enumerate(rem_v2.get("fix_steps") or [], start=1):
+                lines.append(f"    {index}. {step}")
+            if rem_v2.get("verify_command"):
+                lines.append(f"- Verify: `{rem_v2['verify_command']}`")
+        else:
+            lines.append(f"- Why it matters: {item['risk_reason']}")
+            lines.append(f"- Fix: {item['remediation']}")
     return "\n".join(lines)
+
+
+def format_html(report: ScanReport) -> str:
+    """Return a self-contained HTML vulnerability report."""
+    payload = report.to_dict()
+    verdict = payload["verdict"]
+    summary = payload["summary"]
+    packs = payload.get("packs") or []
+
+    e = html.escape  # shorthand
+
+    # --- verdict class & badge text ---
+    verdict_status = verdict["status"]
+    if verdict_status == "BLOCK_SHIP":
+        verdict_cls = "block"
+        verdict_badge = "Block Ship"
+        verdict_banner_extra = ""
+    elif verdict_status == "REVIEW":
+        verdict_cls = "review"
+        verdict_badge = "Review"
+        verdict_banner_extra = ""
+    else:
+        verdict_cls = "safe"
+        verdict_badge = "Safe to Ship"
+        verdict_banner_extra = ""
+
+    # --- findings cards ---
+    finding_cards = []
+    for finding in report.findings:
+        item = finding.to_dict()
+        sev = e(item["severity"])
+        sev_lower = item["severity"].lower()
+        finding_type = e(item["type"])
+        risk = e(item["risk_reason"])
+        evidence_text = e(item["evidence"]["redacted_value"])
+        remediation_text = e(item["remediation"])
+        validation = item.get("validation_status", "")
+
+        confirmed_badge = ""
+        if validation == "confirmed" or validation == "validated":
+            confirmed_badge = '<span class="badge-confirmed">confirmed</span>'
+
+        card = f"""    <div class="finding {e(sev_lower)}">
+      <div class="finding-head">
+        <span class="sev {e(sev_lower)}">{sev.upper()}</span>
+        <span class="finding-type">{finding_type}</span>
+        {confirmed_badge}
+      </div>
+      <div class="finding-detail">{risk}</div>
+      <div class="finding-evidence">{evidence_text}</div>
+      <div class="finding-fix">Fix: <code>{remediation_text}</code></div>
+    </div>"""
+        finding_cards.append(card)
+
+    findings_html = "\n\n".join(finding_cards) if finding_cards else "    <p>No findings detected.</p>"
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>KeyLeak Vulnerability Report</title>
+<style>
+  :root {{
+    --bg: #0a0a0f;
+    --surface: #12121a;
+    --surface2: #1a1a26;
+    --border: #2a2a3a;
+    --text: #e0e0e8;
+    --text2: #8888a0;
+    --red: #ff4d6a;
+    --red-bg: rgba(255,77,106,.08);
+    --orange: #ff9f43;
+    --orange-bg: rgba(255,159,67,.08);
+    --yellow: #ffd43b;
+    --yellow-bg: rgba(255,212,59,.08);
+    --green: #51cf66;
+    --blue: #4dabf7;
+    --blue-bg: rgba(77,171,247,.06);
+    --mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+    --sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  }}
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.5; padding: 40px 20px; }}
+  .wrap {{ max-width: 860px; margin: 0 auto; }}
+
+  /* Header */
+  .header {{ margin-bottom: 40px; }}
+  .header h1 {{ font-size: 15px; font-weight: 500; color: var(--text2); letter-spacing: .5px; text-transform: uppercase; margin-bottom: 8px; }}
+  .target {{ font-size: 22px; font-weight: 600; color: var(--text); font-family: var(--mono); margin-bottom: 16px; }}
+  .meta {{ display: flex; gap: 24px; font-size: 13px; color: var(--text2); flex-wrap: wrap; }}
+  .meta span {{ display: flex; align-items: center; gap: 6px; }}
+
+  /* Verdict banner */
+  .verdict {{ display: flex; align-items: center; gap: 16px; padding: 16px 20px; border-radius: 10px; margin-bottom: 32px; border: 1px solid; }}
+  .verdict.block {{ background: var(--red-bg); border-color: rgba(255,77,106,.2); }}
+  .verdict.review {{ background: var(--yellow-bg); border-color: rgba(255,212,59,.2); }}
+  .verdict.safe {{ background: rgba(81,207,102,.08); border-color: rgba(81,207,102,.2); }}
+  .verdict-badge {{ font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; padding: 4px 10px; border-radius: 4px; white-space: nowrap; }}
+  .verdict.block .verdict-badge {{ background: var(--red); color: #0a0a0f; }}
+  .verdict.review .verdict-badge {{ background: var(--yellow); color: #0a0a0f; }}
+  .verdict.safe .verdict-badge {{ background: var(--green); color: #0a0a0f; }}
+  .verdict-text {{ font-size: 14px; color: var(--text); }}
+
+  /* Stats row */
+  .stats {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 32px; }}
+  .stat {{ background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; text-align: center; }}
+  .stat-num {{ font-size: 28px; font-weight: 700; font-family: var(--mono); }}
+  .stat-num.crit {{ color: var(--red); }}
+  .stat-num.high {{ color: var(--orange); }}
+  .stat-num.med {{ color: var(--yellow); }}
+  .stat-num.low {{ color: var(--blue); }}
+  .stat-label {{ font-size: 11px; color: var(--text2); text-transform: uppercase; letter-spacing: .5px; margin-top: 4px; }}
+
+  /* Section */
+  .section {{ margin-bottom: 32px; }}
+  .section-title {{ font-size: 13px; font-weight: 600; color: var(--text2); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }}
+
+  /* Finding card */
+  .finding {{ background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 20px; margin-bottom: 10px; border-left: 3px solid transparent; }}
+  .finding.critical {{ border-left-color: var(--red); }}
+  .finding.high {{ border-left-color: var(--orange); }}
+  .finding.medium {{ border-left-color: var(--yellow); }}
+  .finding.low {{ border-left-color: var(--blue); }}
+  .finding-head {{ display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }}
+  .sev {{ font-size: 10px; font-weight: 700; letter-spacing: .5px; text-transform: uppercase; padding: 2px 8px; border-radius: 3px; }}
+  .sev.critical {{ background: var(--red); color: #0a0a0f; }}
+  .sev.high {{ background: var(--orange); color: #0a0a0f; }}
+  .sev.medium {{ background: var(--yellow); color: #0a0a0f; }}
+  .sev.low {{ background: var(--blue); color: #0a0a0f; }}
+  .badge-confirmed {{ font-size: 10px; color: var(--green); border: 1px solid rgba(81,207,102,.3); padding: 1px 6px; border-radius: 3px; }}
+  .finding-type {{ font-size: 14px; font-weight: 600; color: var(--text); }}
+  .finding-detail {{ font-size: 13px; color: var(--text2); margin-bottom: 6px; }}
+  .finding-evidence {{ font-family: var(--mono); font-size: 12px; background: var(--surface2); padding: 8px 12px; border-radius: 6px; color: var(--text); margin: 8px 0; overflow-x: auto; white-space: nowrap; }}
+  .finding-fix {{ font-size: 12px; color: var(--text2); margin-top: 8px; }}
+  .finding-fix code {{ font-family: var(--mono); font-size: 11px; background: var(--surface2); padding: 2px 6px; border-radius: 3px; color: var(--yellow); }}
+
+  /* Footer */
+  .footer {{ margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--border); font-size: 12px; color: var(--text2); display: flex; justify-content: space-between; }}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="header">
+    <h1>KeyLeak Vulnerability Report</h1>
+    <div class="target">{e(payload["target"])}</div>
+    <div class="meta">
+      <span>Scan: {e(payload["scan_mode"])}</span>
+      <span>Packs: {e(", ".join(packs) or "none")}</span>
+      <span>{e(payload["generated_at"])}</span>
+    </div>
+  </div>
+
+  <div class="verdict {e(verdict_cls)}">
+    <span class="verdict-badge">{e(verdict_badge)}</span>
+    <span class="verdict-text">{e(verdict["reason"])}</span>
+  </div>
+
+  <div class="stats">
+    <div class="stat"><div class="stat-num crit">{summary["critical_severity"]}</div><div class="stat-label">Critical</div></div>
+    <div class="stat"><div class="stat-num high">{summary["high_severity"]}</div><div class="stat-label">High</div></div>
+    <div class="stat"><div class="stat-num med">{summary["medium_severity"]}</div><div class="stat-label">Medium</div></div>
+    <div class="stat"><div class="stat-num low">{summary["low_severity"]}</div><div class="stat-label">Low</div></div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Findings</div>
+
+{findings_html}
+  </div>
+
+  <div class="footer">
+    <span>Generated by KeyLeak Detector</span>
+    <span>{e(payload["retest_command"])}</span>
+  </div>
+
+</div>
+</body>
+</html>"""
 
 
 def format_sarif(report: ScanReport) -> str:
@@ -89,6 +297,7 @@ def format_sarif(report: ScanReport) -> str:
             "shortDescription": {"text": item["type"]},
             "fullDescription": {"text": item["risk_reason"]},
             "help": {"text": item["remediation"]},
+            "properties": {"category": item.get("category") or ""},
         }
         results.append(
             {
@@ -104,6 +313,7 @@ def format_sarif(report: ScanReport) -> str:
                     }
                 ],
                 "partialFingerprints": {"findingId": item["id"]},
+                "properties": {"category": item.get("category") or ""},
             }
         )
 
@@ -135,6 +345,7 @@ def report_to_text(report: ScanReport) -> str:
         f"{summary['low_severity']} low",
         payload["verdict"]["reason"],
         f"Re-test: {payload['retest_command']}",
+        f"Packs: {', '.join(payload.get('packs') or []) or 'none'}",
     ]
 
     for finding in payload["findings"][:10]:
@@ -160,8 +371,50 @@ def _attack_vector_findings(attack_vectors: Dict[str, Any]) -> List[Finding]:
             raw = dict(finding)
             raw.setdefault("source", f"Attack Surface: {host}")
             raw.setdefault("url", host_result.get("url", ""))
+            raw.setdefault("category", "access-control")
+            raw.setdefault("validation_status", "lead")
             converted.append(finding_from_legacy(raw, detector_prefix="attack-surface"))
     return converted
+
+
+def _packs_from_findings(findings: Iterable[Finding]) -> List[str]:
+    packs = []
+    seen = set()
+    for finding in findings:
+        category = finding.category or "leak"
+        if category not in seen:
+            seen.add(category)
+            packs.append(category)
+    return packs
+
+
+def _pack_summary(findings: Iterable[Finding], selected_packs: Iterable[str]) -> Dict[str, Dict[str, int]]:
+    summary: Dict[str, Dict[str, int]] = {
+        pack: {
+            "total_findings": 0,
+            "critical_severity": 0,
+            "high_severity": 0,
+            "medium_severity": 0,
+            "low_severity": 0,
+            "info_severity": 0,
+        }
+        for pack in selected_packs
+    }
+    for finding in findings:
+        pack = finding.category or "leak"
+        if pack not in summary:
+            summary[pack] = {
+                "total_findings": 0,
+                "critical_severity": 0,
+                "high_severity": 0,
+                "medium_severity": 0,
+                "low_severity": 0,
+                "info_severity": 0,
+            }
+        summary[pack]["total_findings"] += 1
+        severity_key = f"{finding.severity}_severity"
+        summary[pack][severity_key] = summary[pack].get(severity_key, 0) + 1
+    return summary
 
 
 def _retest_command(target: str, scan_mode: str) -> str:

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -1,4 +1,9 @@
-"""Site-wide scanner with subdomain discovery and page crawling."""
+"""Site-wide scanner with subdomain discovery and page crawling.
+
+Discovers subdomains for a domain, crawls each for internal links,
+then runs ``run_browser_scan()`` on each collected URL. Aggregates
+findings into a single report with deduplication.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +11,7 @@ import socket
 import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Set
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from .browser_scanner import run_browser_scan
 from .models import Finding, ScanReport
@@ -26,7 +31,10 @@ COMMON_SUBDOMAINS = [
 
 
 def discover_subdomains(domain: str) -> List[str]:
+    """Discover subdomains using subfinder (if available) or DNS brute-force."""
     domain = domain.strip().lower()
+
+    # Try subfinder first
     try:
         result = subprocess.run(
             ["subfinder", "-d", domain, "-silent", "-timeout", "10"],
@@ -40,7 +48,8 @@ def discover_subdomains(domain: str) -> List[str]:
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
-    print(f"[keyleak] subfinder not found, trying DNS brute-force", file=sys.stderr)
+    # Fallback: DNS brute-force with common subdomains
+    print(f"[keyleak] subfinder not found, trying {len(COMMON_SUBDOMAINS)} common subdomains via DNS", file=sys.stderr)
     found = []
     for sub in COMMON_SUBDOMAINS:
         hostname = f"{sub}.{domain}"
@@ -50,6 +59,7 @@ def discover_subdomains(domain: str) -> List[str]:
         except socket.gaierror:
             continue
 
+    # Always include the bare domain
     try:
         socket.getaddrinfo(domain, None, socket.AF_INET, socket.SOCK_STREAM)
         if domain not in found:
@@ -68,9 +78,15 @@ def crawl_pages(
     max_pages: int = 20,
     headless: bool = True,
 ) -> List[str]:
+    """Crawl each host for internal links up to ``depth`` levels.
+
+    Uses Playwright to load pages and extract ``<a href>`` links.
+    Returns deduplicated list of URLs to scan.
+    """
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
+        # No Playwright — just return root URLs
         return [f"https://{h}" for h in hosts[:max_pages]]
 
     urls: List[str] = []
@@ -92,6 +108,7 @@ def crawl_pages(
             if depth < 1:
                 continue
 
+            # Crawl for internal links
             try:
                 context = browser.new_context(viewport={"width": 1280, "height": 1024})
                 page = context.new_page()
@@ -99,20 +116,27 @@ def crawl_pages(
                 page.goto(root_url, wait_until="domcontentloaded")
 
                 links = page.evaluate("""() => {
-                    return Array.from(document.querySelectorAll('a[href]'))
-                        .map(a => a.href)
-                        .filter(h => h.startsWith('http'));
+                    const anchors = document.querySelectorAll('a[href]');
+                    return Array.from(anchors).map(a => a.href).filter(h => h.startsWith('http'));
                 }""")
 
                 parsed_root = urlparse(root_url)
-                root_domain = parsed_root.netloc
+                base_domain = parsed_root.netloc
+                # Extract registrable domain (last two labels) for same-site matching
+                domain_parts = base_domain.split(".")
+                if len(domain_parts) >= 2:
+                    registrable = domain_parts[-2] + "." + domain_parts[-1]
+                else:
+                    registrable = base_domain
 
                 for link in links:
                     if len(urls) >= max_pages:
                         break
                     parsed = urlparse(link)
-                    if not parsed.netloc.endswith(root_domain.split(".")[-2] + "." + root_domain.split(".")[-1] if "." in root_domain else root_domain):
+                    # Only follow same-domain links
+                    if not parsed.netloc.endswith(registrable):
                         continue
+                    # Normalize — strip fragments and query params for dedup
                     normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
                     if normalized not in seen:
                         seen.add(normalized)
@@ -138,21 +162,29 @@ def scan_site(
     baas_tables: Optional[List[str]] = None,
     scan_budget_seconds: int = 30,
 ) -> ScanReport:
+    """Discover subdomains, crawl pages, and scan each for secrets.
+
+    Returns an aggregated ScanReport with deduplicated findings.
+    """
+    # Parse domain from URL if given
     parsed = urlparse(domain)
     if parsed.netloc:
         domain = parsed.netloc
-    domain = domain.split(":")[0]
+    domain = domain.split(":")[0]  # strip port
 
     print(f"[keyleak] Starting site scan for {domain}", file=sys.stderr)
 
+    # Step 1: Discover subdomains
     subdomains = discover_subdomains(domain)
     if not subdomains:
         subdomains = [domain]
 
+    # Step 2: Crawl pages
     print(f"[keyleak] Crawling {len(subdomains)} hosts (depth={depth}, max={max_pages})", file=sys.stderr)
     urls = crawl_pages(subdomains, depth=depth, max_pages=max_pages, headless=headless)
     print(f"[keyleak] Found {len(urls)} pages to scan", file=sys.stderr)
 
+    # Step 3: Scan each URL
     all_findings: List[Finding] = []
     for i, url in enumerate(urls):
         print(f"[keyleak] Scanning [{i+1}/{len(urls)}] {url}", file=sys.stderr)
@@ -167,19 +199,28 @@ def scan_site(
             )
             all_findings.extend(report.findings)
         except Exception as exc:
-            print(f"[keyleak]   Error: {exc}", file=sys.stderr)
+            print(f"[keyleak]   Error scanning {url}: {exc}", file=sys.stderr)
             continue
 
-    seen: Dict[str, Finding] = {}
-    for f in all_findings:
-        key = f"{f.type}:{f.evidence.redacted_value}"
-        if key not in seen:
-            seen[key] = f
-    deduped = list(seen.values())
+    # Step 4: Deduplicate — same detector + same redacted value = one finding
+    deduped = _deduplicate_findings(all_findings)
 
     print(f"[keyleak] Site scan complete: {len(deduped)} unique findings from {len(urls)} pages", file=sys.stderr)
 
     return build_report(
-        domain, deduped, scan_mode="site", profile="launch-gate",
+        domain,
+        deduped,
+        scan_mode="site",
+        profile="launch-gate",
         packs=["leak", "appsec", "access-control", "baas"],
     )
+
+
+def _deduplicate_findings(findings: List[Finding]) -> List[Finding]:
+    """Keep one finding per (type, redacted_value) pair."""
+    seen: Dict[str, Finding] = {}
+    for f in findings:
+        key = f"{f.type}:{f.evidence.redacted_value}"
+        if key not in seen:
+            seen[key] = f
+    return list(seen.values())

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -1,0 +1,185 @@
+"""Site-wide scanner with subdomain discovery and page crawling."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urlparse
+
+from .browser_scanner import run_browser_scan
+from .models import Finding, ScanReport
+from .reporting import build_report
+
+
+COMMON_SUBDOMAINS = [
+    "www", "api", "app", "admin", "staging", "dev", "beta",
+    "cdn", "assets", "static", "docs", "blog", "status",
+    "mail", "dashboard", "portal", "auth", "login", "signup",
+    "m", "mobile", "shop", "store", "pay", "billing",
+    "support", "help", "community", "forum", "wiki",
+    "preview", "demo", "sandbox", "test", "qa",
+    "v1", "v2", "graphql", "ws", "realtime",
+    "media", "images", "files", "uploads", "download",
+]
+
+
+def discover_subdomains(domain: str) -> List[str]:
+    domain = domain.strip().lower()
+    try:
+        result = subprocess.run(
+            ["subfinder", "-d", domain, "-silent", "-timeout", "10"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            subs = [s.strip() for s in result.stdout.strip().splitlines() if s.strip()]
+            if subs:
+                print(f"[keyleak] subfinder found {len(subs)} subdomains", file=sys.stderr)
+                return sorted(set(subs))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    print(f"[keyleak] subfinder not found, trying DNS brute-force", file=sys.stderr)
+    found = []
+    for sub in COMMON_SUBDOMAINS:
+        hostname = f"{sub}.{domain}"
+        try:
+            socket.getaddrinfo(hostname, None, socket.AF_INET, socket.SOCK_STREAM)
+            found.append(hostname)
+        except socket.gaierror:
+            continue
+
+    try:
+        socket.getaddrinfo(domain, None, socket.AF_INET, socket.SOCK_STREAM)
+        if domain not in found:
+            found.insert(0, domain)
+    except socket.gaierror:
+        pass
+
+    print(f"[keyleak] DNS resolved {len(found)} subdomains", file=sys.stderr)
+    return found
+
+
+def crawl_pages(
+    hosts: List[str],
+    *,
+    depth: int = 1,
+    max_pages: int = 20,
+    headless: bool = True,
+) -> List[str]:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return [f"https://{h}" for h in hosts[:max_pages]]
+
+    urls: List[str] = []
+    seen: Set[str] = set()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+
+        for host in hosts:
+            if len(urls) >= max_pages:
+                break
+
+            root_url = f"https://{host}"
+            if root_url in seen:
+                continue
+            seen.add(root_url)
+            urls.append(root_url)
+
+            if depth < 1:
+                continue
+
+            try:
+                context = browser.new_context(viewport={"width": 1280, "height": 1024})
+                page = context.new_page()
+                page.set_default_timeout(15000)
+                page.goto(root_url, wait_until="domcontentloaded")
+
+                links = page.evaluate("""() => {
+                    return Array.from(document.querySelectorAll('a[href]'))
+                        .map(a => a.href)
+                        .filter(h => h.startsWith('http'));
+                }""")
+
+                parsed_root = urlparse(root_url)
+                root_domain = parsed_root.netloc
+
+                for link in links:
+                    if len(urls) >= max_pages:
+                        break
+                    parsed = urlparse(link)
+                    if not parsed.netloc.endswith(root_domain.split(".")[-2] + "." + root_domain.split(".")[-1] if "." in root_domain else root_domain):
+                        continue
+                    normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+                    if normalized not in seen:
+                        seen.add(normalized)
+                        urls.append(link)
+
+                context.close()
+            except Exception:
+                continue
+
+        browser.close()
+
+    return urls
+
+
+def scan_site(
+    domain: str,
+    *,
+    depth: int = 1,
+    max_pages: int = 20,
+    headless: bool = True,
+    baas_validate: bool = False,
+    baas_prober: Optional[Any] = None,
+    baas_tables: Optional[List[str]] = None,
+    scan_budget_seconds: int = 30,
+) -> ScanReport:
+    parsed = urlparse(domain)
+    if parsed.netloc:
+        domain = parsed.netloc
+    domain = domain.split(":")[0]
+
+    print(f"[keyleak] Starting site scan for {domain}", file=sys.stderr)
+
+    subdomains = discover_subdomains(domain)
+    if not subdomains:
+        subdomains = [domain]
+
+    print(f"[keyleak] Crawling {len(subdomains)} hosts (depth={depth}, max={max_pages})", file=sys.stderr)
+    urls = crawl_pages(subdomains, depth=depth, max_pages=max_pages, headless=headless)
+    print(f"[keyleak] Found {len(urls)} pages to scan", file=sys.stderr)
+
+    all_findings: List[Finding] = []
+    for i, url in enumerate(urls):
+        print(f"[keyleak] Scanning [{i+1}/{len(urls)}] {url}", file=sys.stderr)
+        try:
+            report = run_browser_scan(
+                url,
+                headless=headless,
+                baas_validate=baas_validate,
+                baas_prober=baas_prober,
+                baas_tables=baas_tables,
+                scan_budget_seconds=scan_budget_seconds,
+            )
+            all_findings.extend(report.findings)
+        except Exception as exc:
+            print(f"[keyleak]   Error: {exc}", file=sys.stderr)
+            continue
+
+    seen: Dict[str, Finding] = {}
+    for f in all_findings:
+        key = f"{f.type}:{f.evidence.redacted_value}"
+        if key not in seen:
+            seen[key] = f
+    deduped = list(seen.values())
+
+    print(f"[keyleak] Site scan complete: {len(deduped)} unique findings from {len(urls)} pages", file=sys.stderr)
+
+    return build_report(
+        domain, deduped, scan_mode="site", profile="launch-gate",
+        packs=["leak", "appsec", "access-control", "baas"],
+    )

--- a/report.html
+++ b/report.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>KeyLeak BaaS Vulnerability Report</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --surface: #12121a;
+    --surface2: #1a1a26;
+    --border: #2a2a3a;
+    --text: #e0e0e8;
+    --text2: #8888a0;
+    --red: #ff4d6a;
+    --red-bg: rgba(255,77,106,.08);
+    --orange: #ff9f43;
+    --orange-bg: rgba(255,159,67,.08);
+    --yellow: #ffd43b;
+    --yellow-bg: rgba(255,212,59,.08);
+    --green: #51cf66;
+    --blue: #4dabf7;
+    --blue-bg: rgba(77,171,247,.06);
+    --mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+    --sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.5; padding: 40px 20px; }
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  /* Header */
+  .header { margin-bottom: 40px; }
+  .header h1 { font-size: 15px; font-weight: 500; color: var(--text2); letter-spacing: .5px; text-transform: uppercase; margin-bottom: 8px; }
+  .target { font-size: 22px; font-weight: 600; color: var(--text); font-family: var(--mono); margin-bottom: 16px; }
+  .meta { display: flex; gap: 24px; font-size: 13px; color: var(--text2); flex-wrap: wrap; }
+  .meta span { display: flex; align-items: center; gap: 6px; }
+
+  /* Verdict banner */
+  .verdict { display: flex; align-items: center; gap: 16px; padding: 16px 20px; border-radius: 10px; margin-bottom: 32px; border: 1px solid; }
+  .verdict.block { background: var(--red-bg); border-color: rgba(255,77,106,.2); }
+  .verdict-badge { font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; padding: 4px 10px; border-radius: 4px; white-space: nowrap; }
+  .verdict.block .verdict-badge { background: var(--red); color: #0a0a0f; }
+  .verdict-text { font-size: 14px; color: var(--text); }
+
+  /* Stats row */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 32px; }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px; text-align: center; }
+  .stat-num { font-size: 28px; font-weight: 700; font-family: var(--mono); }
+  .stat-num.crit { color: var(--red); }
+  .stat-num.high { color: var(--orange); }
+  .stat-num.med { color: var(--yellow); }
+  .stat-num.low { color: var(--blue); }
+  .stat-label { font-size: 11px; color: var(--text2); text-transform: uppercase; letter-spacing: .5px; margin-top: 4px; }
+
+  /* Section */
+  .section { margin-bottom: 32px; }
+  .section-title { font-size: 13px; font-weight: 600; color: var(--text2); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+
+  /* Finding card */
+  .finding { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 20px; margin-bottom: 10px; border-left: 3px solid transparent; }
+  .finding.critical { border-left-color: var(--red); }
+  .finding.high { border-left-color: var(--orange); }
+  .finding.medium { border-left-color: var(--yellow); }
+  .finding.low { border-left-color: var(--blue); }
+  .finding-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+  .sev { font-size: 10px; font-weight: 700; letter-spacing: .5px; text-transform: uppercase; padding: 2px 8px; border-radius: 3px; }
+  .sev.critical { background: var(--red); color: #0a0a0f; }
+  .sev.high { background: var(--orange); color: #0a0a0f; }
+  .sev.medium { background: var(--yellow); color: #0a0a0f; }
+  .sev.low { background: var(--blue); color: #0a0a0f; }
+  .badge-confirmed { font-size: 10px; color: var(--green); border: 1px solid rgba(81,207,102,.3); padding: 1px 6px; border-radius: 3px; }
+  .finding-type { font-size: 14px; font-weight: 600; color: var(--text); }
+  .finding-detail { font-size: 13px; color: var(--text2); margin-bottom: 6px; }
+  .finding-evidence { font-family: var(--mono); font-size: 12px; background: var(--surface2); padding: 8px 12px; border-radius: 6px; color: var(--text); margin: 8px 0; overflow-x: auto; white-space: nowrap; }
+  .finding-fix { font-size: 12px; color: var(--text2); margin-top: 8px; }
+  .finding-fix code { font-family: var(--mono); font-size: 11px; background: var(--surface2); padding: 2px 6px; border-radius: 3px; color: var(--yellow); }
+
+  /* Table probe summary */
+  .probe-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
+  .probe { display: flex; align-items: center; gap: 8px; font-size: 12px; font-family: var(--mono); padding: 6px 10px; border-radius: 6px; background: var(--surface2); }
+  .probe .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .probe .dot.open { background: var(--red); }
+  .probe .dot.locked { background: var(--green); }
+  .probe .tname { color: var(--text); }
+  .probe .tstatus { color: var(--text2); margin-left: auto; font-size: 11px; }
+
+  /* Footer */
+  .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--border); font-size: 12px; color: var(--text2); display: flex; justify-content: space-between; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="header">
+    <h1>KeyLeak BaaS Vulnerability Report</h1>
+    <div class="target">example-app.vercel.app</div>
+    <div class="meta">
+      <span>Scan: browser + active validation</span>
+      <span>Provider: Supabase</span>
+      <span>Packs: leak, baas</span>
+      <span>2026-05-25 13:05 UTC</span>
+    </div>
+  </div>
+
+  <div class="verdict block">
+    <span class="verdict-badge">Block Ship</span>
+    <span class="verdict-text">6 confirmed findings across 12 client-exposed tables. Payment and user data readable without authentication.</span>
+  </div>
+
+  <div class="stats">
+    <div class="stat"><div class="stat-num crit">1</div><div class="stat-label">Critical</div></div>
+    <div class="stat"><div class="stat-num high">3</div><div class="stat-label">High</div></div>
+    <div class="stat"><div class="stat-num med">1</div><div class="stat-label">Medium</div></div>
+    <div class="stat"><div class="stat-num low">1</div><div class="stat-label">Low</div></div>
+  </div>
+
+  <!-- Confirmed findings -->
+  <div class="section">
+    <div class="section-title">Confirmed Findings</div>
+
+    <div class="finding critical">
+      <div class="finding-head">
+        <span class="sev critical">Critical</span>
+        <span class="finding-type">Open Table: payment_details</span>
+        <span class="badge-confirmed">confirmed</span>
+      </div>
+      <div class="finding-detail">Financial payment data readable without authentication. Anyone with the anon key can query earnings, payout methods, and account details.</div>
+      <div class="finding-evidence">GET /rest/v1/payment_details?select=*&amp;limit=1 &rarr; 200 OK &mdash; columns: id, user_id, payout_method, account_details, created_at</div>
+      <div class="finding-fix">Fix: <code>ALTER TABLE payment_details ENABLE ROW LEVEL SECURITY;</code> then create policies restricting access to the owning user.</div>
+    </div>
+
+    <div class="finding high">
+      <div class="finding-head">
+        <span class="sev high">High</span>
+        <span class="finding-type">Open Table: profiles</span>
+        <span class="badge-confirmed">confirmed</span>
+      </div>
+      <div class="finding-detail">User profile data including usernames, emails, and account settings returned to unauthenticated callers.</div>
+      <div class="finding-evidence">GET /rest/v1/profiles?select=*&amp;limit=1 &rarr; 200 OK &mdash; columns: id, username, display_name, avatar_url, email, settings</div>
+      <div class="finding-fix">Fix: <code>ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;</code> &mdash; allow public reads only on non-sensitive columns.</div>
+    </div>
+
+    <div class="finding high">
+      <div class="finding-head">
+        <span class="sev high">High</span>
+        <span class="finding-type">Open Table: orders</span>
+        <span class="badge-confirmed">confirmed</span>
+      </div>
+      <div class="finding-detail">Full order history readable. select(*) returns all columns including internal metadata and pricing.</div>
+      <div class="finding-evidence">GET /rest/v1/orders?select=*&amp;limit=1 &rarr; 200 OK &mdash; columns: id, user_id, total_cents, status, created_at</div>
+      <div class="finding-fix">Fix: Enable RLS. Restrict <code>select()</code> to the owning user &mdash; never expose other users' order data.</div>
+    </div>
+
+    <div class="finding high">
+      <div class="finding-head">
+        <span class="sev high">High</span>
+        <span class="finding-type">Public Storage Bucket: uploads</span>
+        <span class="badge-confirmed">confirmed</span>
+      </div>
+      <div class="finding-detail">The "uploads" storage bucket is marked public. Anyone can list and download all uploaded files.</div>
+      <div class="finding-evidence">GET /storage/v1/bucket &rarr; 200 OK &mdash; {name: "uploads", public: true}</div>
+      <div class="finding-fix">Fix: Set bucket to private in the Supabase dashboard. Add storage policies for authorized upload/download only.</div>
+    </div>
+
+    <div class="finding medium">
+      <div class="finding-head">
+        <span class="sev medium">Medium</span>
+        <span class="finding-type">Unauthenticated RPC: increment_views</span>
+        <span class="badge-confirmed">confirmed</span>
+      </div>
+      <div class="finding-detail">The increment_views function is callable with just the anon key. An attacker can inflate view counts for any record.</div>
+      <div class="finding-evidence">POST /rest/v1/rpc/increment_views &rarr; 200 OK</div>
+      <div class="finding-fix">Fix: Add <code>auth.uid()</code> check inside the function or revoke EXECUTE from the anon role. Add rate limiting.</div>
+    </div>
+
+    <div class="finding low">
+      <div class="finding-head">
+        <span class="sev low">Low</span>
+        <span class="finding-type">Wide-Open CORS</span>
+        <span class="badge-confirmed">confirmed</span>
+      </div>
+      <div class="finding-detail">REST API returns Access-Control-Allow-Origin: *. Any origin can make authenticated requests.</div>
+      <div class="finding-evidence">access-control-allow-origin: *</div>
+      <div class="finding-fix">Fix: Restrict CORS to your application's origin in the Supabase dashboard.</div>
+    </div>
+  </div>
+
+  <!-- Table RLS probe summary -->
+  <div class="section">
+    <div class="section-title">RLS Probe Summary &mdash; 12 Tables Tested</div>
+    <div class="probe-grid">
+      <div class="probe"><span class="dot open"></span><span class="tname">payment_details</span><span class="tstatus">OPEN</span></div>
+      <div class="probe"><span class="dot open"></span><span class="tname">payment_requests</span><span class="tstatus">OPEN</span></div>
+      <div class="probe"><span class="dot open"></span><span class="tname">profiles</span><span class="tstatus">OPEN</span></div>
+      <div class="probe"><span class="dot open"></span><span class="tname">orders</span><span class="tstatus">OPEN</span></div>
+      <div class="probe"><span class="dot open"></span><span class="tname">products</span><span class="tstatus">OPEN</span></div>
+      <div class="probe"><span class="dot open"></span><span class="tname">reviews</span><span class="tstatus">OPEN</span></div>
+      <div class="probe"><span class="dot locked"></span><span class="tname">support_tickets</span><span class="tstatus">RLS</span></div>
+      <div class="probe"><span class="dot locked"></span><span class="tname">notifications</span><span class="tstatus">RLS</span></div>
+      <div class="probe"><span class="dot locked"></span><span class="tname">user_blocks</span><span class="tstatus">RLS</span></div>
+      <div class="probe"><span class="dot locked"></span><span class="tname">sessions</span><span class="tstatus">RLS</span></div>
+      <div class="probe"><span class="dot locked"></span><span class="tname">audit_logs</span><span class="tstatus">RLS</span></div>
+      <div class="probe"><span class="dot locked"></span><span class="tname">api_keys</span><span class="tstatus">RLS</span></div>
+    </div>
+  </div>
+
+  <!-- Client-side auth -->
+  <div class="section">
+    <div class="section-title">Additional Leads</div>
+
+    <div class="finding high" style="border-left-color: var(--orange);">
+      <div class="finding-head">
+        <span class="sev high">High</span>
+        <span class="finding-type">Client-Side Admin Check</span>
+      </div>
+      <div class="finding-detail">Admin authorization is a browser-side boolean. Admin operations (manage users, process refunds) are gated only by a JS check that can be bypassed in the console.</div>
+      <div class="finding-evidence">if (user.is_admin === true) { showAdminPanel(); }</div>
+      <div class="finding-fix">Fix: Move admin checks to RLS policies or Postgres functions. Never trust <code>isAdmin</code> from the client.</div>
+    </div>
+
+    <div class="finding low" style="border-left-color: var(--blue);">
+      <div class="finding-head">
+        <span class="sev low">Low</span>
+        <span class="finding-type">select("*") Overfetch &mdash; 9 tables</span>
+      </div>
+      <div class="finding-detail">9 of 12 client-side queries use select("*"), fetching every column including internal fields. Even with RLS, this leaks column names and potentially sensitive data.</div>
+      <div class="finding-fix">Fix: Replace <code>.select("*")</code> with explicit column lists for every client query.</div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <span>Generated by KeyLeak Detector v0.1.0 &mdash; BaaS active validation</span>
+    <span>keyleak browser-scan https://example-app.vercel.app</span>
+  </div>
+
+</div>
+</body>
+</html>

--- a/tests/test_baas_validator.py
+++ b/tests/test_baas_validator.py
@@ -1,0 +1,533 @@
+"""Tests for BaaS active validation engine (Wave 4.1).
+
+All HTTP probes are mocked via injectable ``prober`` callables.
+No network requests are made.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Dict, List
+
+from keyleak.baas_validator import (
+    BaaSConfig,
+    BaaSProbeResult,
+    BaaSValidation,
+    TABLE_PROBE_CAP,
+    extract_baas_config,
+    validate_baas_config,
+)
+from keyleak.browser_scanner import evaluate_findings_payload
+
+
+def _mock_prober(responses: Dict[str, Dict[str, Any]]):
+    """Build a prober that returns canned responses keyed by URL substring.
+
+    Matches are checked longest-pattern-first so ``/rest/v1/profiles`` is
+    preferred over ``/rest/v1/`` when both are present.
+    """
+    sorted_patterns = sorted(responses.keys(), key=len, reverse=True)
+
+    def prober(method: str, url: str, headers: Dict[str, str]) -> Dict[str, Any]:
+        for pattern in sorted_patterns:
+            if pattern in url:
+                return responses[pattern]
+        return {"status_code": 404, "body": None, "headers": {}}
+
+    return prober
+
+
+class ExtractConfigTests(unittest.TestCase):
+    def test_extract_from_js_extraction(self):
+        js = {
+            "supabase_url": "https://abcdefghijklmnopqrst.supabase.co",
+            "supabase_key": "sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            "tables": ["users", "posts", "users"],
+            "rpcs": ["increment_plays"],
+            "buckets": ["images"],
+        }
+        config = extract_baas_config(js_extraction=js)
+        assert config is not None
+        assert config.provider == "supabase"
+        assert config.project_url == "https://abcdefghijklmnopqrst.supabase.co"
+        assert config.api_key == "sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX"
+        assert config.tables == ["users", "posts"]
+        assert config.rpc_functions == ["increment_plays"]
+        assert config.storage_buckets == ["images"]
+
+    def test_extract_from_raw_findings(self):
+        findings = [
+            {"detector_id": "baas.supabase_url", "value": "https://abcdefghijklmnopqrst.supabase.co"},
+            {"detector_id": "baas.supabase_publishable_key", "value": "sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX"},
+        ]
+        config = extract_baas_config(raw_findings=findings)
+        assert config is not None
+        assert config.project_url == "https://abcdefghijklmnopqrst.supabase.co"
+
+    def test_extract_returns_none_without_url(self):
+        config = extract_baas_config(raw_findings=[
+            {"detector_id": "baas.supabase_publishable_key", "value": "sb_publishable_XXXX"},
+        ])
+        assert config is None
+
+    def test_extract_returns_none_without_key(self):
+        config = extract_baas_config(raw_findings=[
+            {"detector_id": "baas.supabase_url", "value": "https://abcdefghijklmnopqrst.supabase.co"},
+        ])
+        assert config is None
+
+    def test_extract_deduplicates_tables(self):
+        js = {
+            "supabase_url": "https://abcdefghijklmnopqrst.supabase.co",
+            "supabase_key": "sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            "tables": ["t1", "t2", "t1", "t3", "t2"],
+            "rpcs": [],
+            "buckets": [],
+        }
+        config = extract_baas_config(js_extraction=js)
+        assert config is not None
+        assert config.tables == ["t1", "t2", "t3"]
+
+    def test_extract_jwt_key_from_findings(self):
+        jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ2a2xna3RtZGJ5amt4aG9ubmlxIn0.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        findings = [
+            {"detector_id": "baas.supabase_url", "value": "https://abcdefghijklmnopqrst.supabase.co"},
+            {"detector_id": "baas.supabase_anon_key", "value": jwt},
+        ]
+        config = extract_baas_config(raw_findings=findings)
+        assert config is not None
+        assert config.api_key == jwt
+
+
+class ValidateKeyTests(unittest.TestCase):
+    def _config(self, **overrides) -> BaaSConfig:
+        defaults = {
+            "provider": "supabase",
+            "project_url": "https://abcdefghijklmnopqrst.supabase.co",
+            "api_key": "sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            "tables": ["users"],
+            "rpc_functions": [],
+            "storage_buckets": [],
+        }
+        defaults.update(overrides)
+        return BaaSConfig(**defaults)
+
+    def test_valid_key(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/users": {"status_code": 200, "body": [{"id": 1, "name": "alice"}], "headers": {}},
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert result.key_valid is True
+
+    def test_invalid_key_skips_probes(self):
+        call_count = {"n": 0}
+
+        def counting_prober(method, url, headers):
+            call_count["n"] += 1
+            return {"status_code": 401, "body": {"message": "Invalid API key"}, "headers": {}}
+
+        result = validate_baas_config(self._config(), prober=counting_prober)
+        assert result.key_valid is False
+        assert call_count["n"] == 1
+        assert len(result.open_tables) == 0
+
+
+class OpenTableTests(unittest.TestCase):
+    def _config(self, tables=None):
+        return BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            tables=tables or ["profiles", "tracks"],
+            rpc_functions=[],
+            storage_buckets=[],
+        )
+
+    def test_open_table_confirmed(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/profiles": {"status_code": 200, "body": [{"id": 1, "username": "alice"}], "headers": {}},
+            "/rest/v1/tracks": {"status_code": 200, "body": [{"id": 1, "title": "Song"}], "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert len(result.open_tables) == 2
+        assert result.open_tables[0].status == "confirmed"
+        assert result.open_tables[0].columns == ["id", "username"]
+        assert any(f.type == "baas_open_table" and f.validation_status == "confirmed" for f in result.findings)
+
+    def test_rls_protected_table(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/profiles": {"status_code": 403, "body": {"message": "permission denied"}, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(
+            self._config(tables=["profiles"]),
+            prober=prober,
+        )
+        assert len(result.open_tables) == 0
+        assert len(result.protected_tables) == 1
+        assert result.protected_tables[0].status == "denied"
+
+    def test_sensitive_table_is_critical(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/artist_payout_details": {
+                "status_code": 200,
+                "body": [{"id": 1, "payout_method": "paypal"}],
+                "headers": {},
+            },
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(
+            self._config(tables=["artist_payout_details"]),
+            prober=prober,
+        )
+        payout_findings = [f for f in result.findings if "payout" in f.evidence.redacted_value]
+        assert payout_findings
+        assert payout_findings[0].severity == "critical"
+
+    def test_table_probe_capped(self):
+        tables = [f"table_{i}" for i in range(100)]
+        probed_tables: List[str] = []
+
+        def tracking_prober(method, url, headers):
+            if method == "GET" and "/rest/v1/table_" in url:
+                name = url.split("/rest/v1/")[1].split("?")[0]
+                probed_tables.append(name)
+            return {"status_code": 200, "body": [], "headers": {}}
+
+        result = validate_baas_config(
+            self._config(tables=tables),
+            prober=tracking_prober,
+        )
+        assert len(probed_tables) == TABLE_PROBE_CAP
+
+
+class StorageBucketTests(unittest.TestCase):
+    def _config(self, buckets=None):
+        return BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            tables=[],
+            rpc_functions=[],
+            storage_buckets=buckets or ["images"],
+        )
+
+    def test_public_bucket_detected(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/storage/v1/bucket": {
+                "status_code": 200,
+                "body": [{"name": "images", "public": True}],
+                "headers": {},
+            },
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert len(result.accessible_buckets) == 1
+        assert result.accessible_buckets[0].note == "public"
+        assert any(f.type == "baas_open_storage" for f in result.findings)
+
+    def test_listable_bucket_from_client_reference(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 200, "body": [], "headers": {}},
+            "/storage/v1/object/list/images": {
+                "status_code": 200,
+                "body": [{"name": "photo.jpg"}],
+                "headers": {},
+            },
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert len(result.accessible_buckets) == 1
+        assert result.accessible_buckets[0].note == "objects listable"
+
+
+class RPCTests(unittest.TestCase):
+    def _config(self, rpcs=None):
+        return BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            tables=[],
+            rpc_functions=rpcs or ["increment_plays"],
+            storage_buckets=[],
+        )
+
+    def test_callable_rpc_confirmed(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/rpc/increment_plays": {"status_code": 200, "body": None, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert len(result.callable_rpcs) == 1
+        assert any(f.type == "baas_open_rpc" for f in result.findings)
+
+    def test_denied_rpc_no_finding(self):
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/rpc/increment_plays": {"status_code": 401, "body": None, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert len(result.callable_rpcs) == 0
+        assert not any(f.type == "baas_open_rpc" for f in result.findings)
+
+
+class CORSTests(unittest.TestCase):
+    def _config(self):
+        return BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+        )
+
+    def test_cors_wildcard_detected(self):
+        prober = _mock_prober({
+            "/rest/v1/": {
+                "status_code": 200,
+                "body": None,
+                "headers": {"access-control-allow-origin": "*"},
+            },
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert result.cors_open is True
+        assert any(f.type == "baas_cors_wildcard" for f in result.findings)
+
+    def test_restricted_cors_not_flagged(self):
+        prober = _mock_prober({
+            "/rest/v1/": {
+                "status_code": 200,
+                "body": None,
+                "headers": {"access-control-allow-origin": "https://example.com"},
+            },
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(self._config(), prober=prober)
+        assert result.cors_open is False
+
+
+class ProberErrorTests(unittest.TestCase):
+    def _config(self):
+        return BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            tables=["t1"],
+        )
+
+    def test_prober_exception_handled(self):
+        def failing_prober(method, url, headers):
+            raise ConnectionError("network down")
+
+        result = validate_baas_config(self._config(), prober=failing_prober)
+        assert result.key_valid is False
+        assert any("failed" in f.risk_reason for f in result.findings)
+
+
+class EvaluateFindingsIntegrationTests(unittest.TestCase):
+    def test_baas_disabled_skips_validation(self):
+        raw = [{"detector_id": "baas.supabase_url", "type": "supabase_url", "severity": "medium",
+                "source": "document", "value": "https://abcdefghijklmnopqrst.supabase.co"}]
+        report = evaluate_findings_payload(raw, "https://example.com", baas_validate=False)
+        assert not any(f.type == "baas_open_table" for f in report.findings)
+
+    def test_baas_with_extraction_and_prober(self):
+        raw = []
+        js_extraction = {
+            "supabase_url": "https://abcdefghijklmnopqrst.supabase.co",
+            "supabase_key": "sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            "tables": ["public_data"],
+            "rpcs": [],
+            "buckets": [],
+        }
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/rest/v1/public_data": {"status_code": 200, "body": [{"id": 1}], "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+        })
+        report = evaluate_findings_payload(
+            raw, "https://example.com",
+            baas_extraction=js_extraction,
+            baas_validate=True,
+            baas_prober=prober,
+        )
+        open_table_findings = [f for f in report.findings if f.type == "baas_open_table"]
+        assert len(open_table_findings) == 1
+        assert open_table_findings[0].validation_status == "confirmed"
+
+
+class FirebaseValidationTests(unittest.TestCase):
+    def test_open_firebase_db(self):
+        config = BaaSConfig(provider="firebase", project_url="https://test-app.firebaseio.com", api_key="AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+        prober = _mock_prober({
+            "/.json": {"status_code": 200, "body": {"users": True, "posts": True}, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert result.key_valid is True
+        assert len(result.open_tables) == 1
+        assert any(f.type == "baas_open_table" and f.severity == "critical" for f in result.findings)
+
+    def test_closed_firebase_db(self):
+        config = BaaSConfig(provider="firebase", project_url="https://test-app.firebaseio.com", api_key="")
+        prober = _mock_prober({
+            "/.json": {"status_code": 401, "body": {"error": "Permission denied"}, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert result.key_valid is False
+        assert len(result.open_tables) == 0
+
+    def test_firebase_storage_open(self):
+        config = BaaSConfig(provider="firebase", project_url="https://test-app.firebaseio.com", api_key="", storage_buckets=["test-app.appspot.com"])
+        prober = _mock_prober({
+            "/.json": {"status_code": 401, "body": None, "headers": {}},
+            "firebasestorage.googleapis.com": {"status_code": 200, "body": {"items": [{"name": "file.jpg"}]}, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert len(result.accessible_buckets) == 1
+
+
+class AppwriteValidationTests(unittest.TestCase):
+    def test_open_appwrite_collections(self):
+        config = BaaSConfig(provider="appwrite", project_url="https://cloud.appwrite.io/v1", api_key="project123")
+        prober = _mock_prober({
+            "/databases": {"status_code": 200, "body": {"databases": [{"$id": "db1"}]}, "headers": {}},
+            "/databases/db1/collections": {"status_code": 200, "body": {"collections": [{"$id": "c1", "name": "users"}]}, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert result.key_valid is True
+        assert len(result.open_tables) == 1
+
+    def test_closed_appwrite(self):
+        config = BaaSConfig(provider="appwrite", project_url="https://cloud.appwrite.io/v1", api_key="project123")
+        prober = _mock_prober({
+            "/databases": {"status_code": 401, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert result.key_valid is False
+
+
+class PocketbaseValidationTests(unittest.TestCase):
+    def test_open_pocketbase_collections(self):
+        config = BaaSConfig(provider="pocketbase", project_url="https://pb.example.com", api_key="")
+        prober = _mock_prober({
+            "/api/collections": {"status_code": 200, "body": {"items": [{"name": "posts"}]}, "headers": {}},
+            "/api/collections/posts/records": {"status_code": 200, "body": {"items": [{"id": "1"}]}, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert len(result.open_tables) == 1
+
+
+class WriteAccessTests(unittest.TestCase):
+    def _config(self, tables=None):
+        return BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+            tables=tables or ["users"],
+        )
+
+    def test_writable_table_confirmed(self):
+        def smart_prober(method, url, headers):
+            if method == "GET" and "/rest/v1/" in url and url.endswith("/rest/v1/"):
+                return {"status_code": 200, "body": None, "headers": {}}
+            if method == "GET" and "/rest/v1/users" in url:
+                return {"status_code": 200, "body": [{"id": 1}], "headers": {}}
+            if method == "POST" and "/rest/v1/users" in url:
+                return {"status_code": 400, "body": {"message": "schema error"}, "headers": {}}
+            if "/storage/v1/bucket" in url:
+                return {"status_code": 403, "body": None, "headers": {}}
+            if "/auth/v1/settings" in url:
+                return {"status_code": 401, "body": None, "headers": {}}
+            return {"status_code": 404, "body": None, "headers": {}}
+
+        result = validate_baas_config(self._config(), prober=smart_prober)
+        assert result.key_valid is True
+        assert len(result.writable_tables) == 1
+        assert any(f.type == "baas_writable_table" for f in result.findings)
+
+    def test_write_blocked_by_rls(self):
+        def rls_prober(method, url, headers):
+            if "rest/v1/" in url and method == "GET" and url.endswith("/rest/v1/"):
+                return {"status_code": 200, "body": None, "headers": {}}
+            if "rest/v1/users" in url and method == "GET":
+                return {"status_code": 200, "body": [{"id": 1}], "headers": {}}
+            if "rest/v1/users" in url and method == "POST":
+                return {"status_code": 403, "body": {"message": "RLS"}, "headers": {}}
+            if "/storage/v1/bucket" in url:
+                return {"status_code": 403, "body": None, "headers": {}}
+            if "/auth/v1/settings" in url:
+                return {"status_code": 401, "body": None, "headers": {}}
+            return {"status_code": 404, "body": None, "headers": {}}
+
+        result = validate_baas_config(self._config(), prober=rls_prober)
+        assert len(result.writable_tables) == 0
+        assert not any(f.type == "baas_writable_table" for f in result.findings)
+
+
+class AuthFlowTests(unittest.TestCase):
+    def test_service_role_key_detected(self):
+        import base64
+        import json as _json
+        header = base64.urlsafe_b64encode(b'{"alg":"HS256","typ":"JWT"}').rstrip(b'=').decode()
+        payload = base64.urlsafe_b64encode(_json.dumps({"role": "service_role", "iss": "supabase", "exp": 9999999999}).encode()).rstrip(b'=').decode()
+        sig = "x" * 30
+        jwt_key = f"{header}.{payload}.{sig}"
+
+        config = BaaSConfig(provider="supabase", project_url="https://abcdefghijklmnopqrst.supabase.co", api_key=jwt_key)
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 200, "body": [], "headers": {}},
+            "/auth/v1/settings": {"status_code": 401, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert any(f.type == "baas_service_role_exposed" for f in result.findings)
+
+    def test_autoconfirm_detected(self):
+        config = BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+        )
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+            "/auth/v1/settings": {"status_code": 200, "body": {"mailer_autoconfirm": True}, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober)
+        assert any(f.type == "baas_no_email_confirmation" for f in result.findings)
+
+
+class RealtimeAnalysisTests(unittest.TestCase):
+    def test_predictable_channel_flagged(self):
+        config = BaaSConfig(
+            provider="supabase",
+            project_url="https://abcdefghijklmnopqrst.supabase.co",
+            api_key="sb_publishable_XXXXXXXXXXXXXXXXXXXXXXXX",
+        )
+        js_extraction = {
+            "supabase_url": config.project_url,
+            "supabase_key": config.api_key,
+            "tables": [],
+            "rpcs": [],
+            "buckets": [],
+            "realtime_channels": ["notifications-user_123", "public-updates"],
+        }
+        prober = _mock_prober({
+            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
+            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+            "/auth/v1/settings": {"status_code": 401, "body": None, "headers": {}},
+        })
+        result = validate_baas_config(config, prober=prober, js_extraction=js_extraction)
+        channel_findings = [f for f in result.findings if f.type == "baas_predictable_channel"]
+        assert len(channel_findings) == 1
+        assert "notifications" in channel_findings[0].evidence.snippet
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_baas_validator.py
+++ b/tests/test_baas_validator.py
@@ -259,17 +259,23 @@ class RPCTests(unittest.TestCase):
 
     def test_rpc_surfaced_as_lead(self):
         """RPCs are listed as leads without executing them (no POST probe)."""
-        prober = _mock_prober({
+        calls: List = []
+        base = _mock_prober({
             "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
             "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
             "/auth/v1/settings": {"status_code": 401, "body": None, "headers": {}},
         })
-        result = validate_baas_config(self._config(), prober=prober)
+        def tracking_prober(method, url, headers, body=None):
+            calls.append((method, url))
+            return base(method, url, headers)
+
+        result = validate_baas_config(self._config(), prober=tracking_prober)
         assert len(result.callable_rpcs) == 1
         rpc_findings = [f for f in result.findings if f.type == "baas_open_rpc"]
         assert len(rpc_findings) == 1
         assert rpc_findings[0].validation_status == "lead"
         assert rpc_findings[0].confidence < 0.8
+        assert not any(m == "POST" and "/rpc/" in u for m, u in calls), "RPC should not be probed via POST"
 
 
 class CORSTests(unittest.TestCase):

--- a/tests/test_baas_validator.py
+++ b/tests/test_baas_validator.py
@@ -257,25 +257,19 @@ class RPCTests(unittest.TestCase):
             storage_buckets=[],
         )
 
-    def test_callable_rpc_confirmed(self):
+    def test_rpc_surfaced_as_lead(self):
+        """RPCs are listed as leads without executing them (no POST probe)."""
         prober = _mock_prober({
             "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
-            "/rest/v1/rpc/increment_plays": {"status_code": 200, "body": None, "headers": {}},
             "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
+            "/auth/v1/settings": {"status_code": 401, "body": None, "headers": {}},
         })
         result = validate_baas_config(self._config(), prober=prober)
         assert len(result.callable_rpcs) == 1
-        assert any(f.type == "baas_open_rpc" for f in result.findings)
-
-    def test_denied_rpc_no_finding(self):
-        prober = _mock_prober({
-            "/rest/v1/": {"status_code": 200, "body": None, "headers": {}},
-            "/rest/v1/rpc/increment_plays": {"status_code": 401, "body": None, "headers": {}},
-            "/storage/v1/bucket": {"status_code": 403, "body": None, "headers": {}},
-        })
-        result = validate_baas_config(self._config(), prober=prober)
-        assert len(result.callable_rpcs) == 0
-        assert not any(f.type == "baas_open_rpc" for f in result.findings)
+        rpc_findings = [f for f in result.findings if f.type == "baas_open_rpc"]
+        assert len(rpc_findings) == 1
+        assert rpc_findings[0].validation_status == "lead"
+        assert rpc_findings[0].confidence < 0.8
 
 
 class CORSTests(unittest.TestCase):

--- a/tests/test_baas_validator.py
+++ b/tests/test_baas_validator.py
@@ -433,7 +433,7 @@ class WriteAccessTests(unittest.TestCase):
         )
 
     def test_writable_table_confirmed(self):
-        def smart_prober(method, url, headers):
+        def smart_prober(method, url, headers, body=None):
             if method == "GET" and "/rest/v1/" in url and url.endswith("/rest/v1/"):
                 return {"status_code": 200, "body": None, "headers": {}}
             if method == "GET" and "/rest/v1/users" in url:
@@ -452,7 +452,7 @@ class WriteAccessTests(unittest.TestCase):
         assert any(f.type == "baas_writable_table" for f in result.findings)
 
     def test_write_blocked_by_rls(self):
-        def rls_prober(method, url, headers):
+        def rls_prober(method, url, headers, body=None):
             if "rest/v1/" in url and method == "GET" and url.endswith("/rest/v1/"):
                 return {"status_code": 200, "body": None, "headers": {}}
             if "rest/v1/users" in url and method == "GET":

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -343,12 +343,12 @@ class DetectorTests(unittest.TestCase):
         detector_ids = {detector["id"] for detector in payload}
         detector_packs = {detector["pack"] for detector in payload}
 
-        self.assertIn("mcp_config_secret", detector_ids)
+        self.assertNotIn("mcp_config_secret", detector_ids)
+        self.assertNotIn("sql_injection_lead", detector_ids)
         self.assertIn("graphql_introspection_hint", detector_ids)
         self.assertIn("hidden_prompt_injection", detector_ids)
         self.assertIn("source_map_reference", detector_ids)
         self.assertIn("openrouter_api_key", detector_ids)
-        self.assertIn("sql_injection_lead", detector_ids)
         self.assertIn("xss_sink_lead", detector_ids)
         self.assertIn("idor_direct_object_lead", detector_ids)
         self.assertEqual({"leak", "appsec", "access-control", "baas"}, detector_packs)
@@ -360,8 +360,9 @@ class DetectorTests(unittest.TestCase):
 
         self.assertIn("Source of truth: keyleak.detectors.DETECTORS", bundle)
         self.assertIn("PATTERN_DEFINITIONS", bundle)
-        self.assertIn("mcp_config_secret", bundle)
-        self.assertIn("appsec.sql_injection_lead", bundle)
+        self.assertNotIn("mcp_config_secret", bundle)
+        self.assertNotIn("sql_injection_lead", bundle)
+        self.assertIn("openai_api_key", bundle)
 
     def test_extension_bundle_excludes_repo_only_packs_by_default(self):
         payload = extension_pattern_payload()

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -4,13 +4,15 @@ import unittest
 from argparse import Namespace
 from pathlib import Path
 
+from keyleak.access_control import compare_access_control_urls
 from keyleak.cli import _scan_request_payload
+from keyleak.extension_bundle import extension_pattern_payload, extension_patterns_js
 from keyleak.local_scanner import scan_file, scan_path
-from keyleak.detectors import DETECTORS
+from keyleak.detectors import DETECTORS, DETECTOR_PACKS, HEATMAP_ROWS, detectors_for_packs, normalize_packs
 from keyleak.local_scanner import _is_placeholder
 from keyleak.models import Finding, Evidence, ScanReport, finding_from_legacy
 from keyleak.redaction import redact_value
-from keyleak.reporting import build_report, fail_threshold_met, format_sarif
+from keyleak.reporting import build_report, fail_threshold_met, format_html, format_sarif
 from keyleak.suppressions import apply_suppressions, load_suppressions
 
 
@@ -34,6 +36,7 @@ class ReportingTests(unittest.TestCase):
         self.assertEqual(report.verdict["status"], "BLOCK_SHIP")
         self.assertTrue(fail_threshold_met(report, "high"))
         self.assertIn("sarif", format_sarif(report).lower())
+        self.assertEqual(report.to_dict()["profile"], "launch-gate")
 
     def test_attack_vector_findings_contribute_to_report_summary(self):
         report = build_report(
@@ -117,6 +120,123 @@ class ReportingTests(unittest.TestCase):
         self.assertNotEqual(first.id, second.id)
 
 
+class HtmlReportTests(unittest.TestCase):
+    def test_html_report_contains_structure(self):
+        findings = [
+            Finding(
+                type="openai_api_key",
+                severity="critical",
+                confidence=0.95,
+                detector_id="leak:openai_api_key",
+                source="fixture.js",
+                evidence=Evidence(source="fixture.js", redacted_value="sk-pro...[redacted]...wxyz"),
+                risk_reason="OpenAI API key exposed in client bundle.",
+                remediation="Rotate the key immediately.",
+                validation_status="confirmed",
+                category="leak",
+            ),
+            Finding(
+                type="database_url",
+                severity="high",
+                confidence=0.9,
+                detector_id="leak:database_url",
+                source=".env",
+                evidence=Evidence(source=".env", redacted_value="postgres://...[redacted]...5432/db"),
+                risk_reason="Database connection string exposed.",
+                remediation="Move to environment variable and rotate credentials.",
+                validation_status="lead",
+                category="leak",
+            ),
+            Finding(
+                type="wide_open_cors",
+                severity="medium",
+                confidence=0.7,
+                detector_id="baas:wide_open_cors",
+                source="response header",
+                evidence=Evidence(source="response header", redacted_value="access-control-allow-origin: *"),
+                risk_reason="CORS allows any origin.",
+                remediation="Restrict CORS to production domain.",
+                category="baas",
+            ),
+            Finding(
+                type="select_star_overfetch",
+                severity="low",
+                confidence=0.55,
+                detector_id="baas:select_star_overfetch",
+                source="app.js",
+                evidence=Evidence(source="app.js", redacted_value='.select("*")'),
+                risk_reason="Fetching all columns leaks schema.",
+                remediation="Use explicit column lists.",
+                category="baas",
+            ),
+        ]
+        report = build_report(
+            "https://preview.example.com",
+            findings,
+            scan_mode="browser",
+            packs=["leak", "baas"],
+        )
+        output = format_html(report)
+
+        self.assertIn("<!DOCTYPE html>", output)
+        self.assertIn("preview.example.com", output)
+        self.assertIn("Block Ship", output)
+        self.assertIn("CRITICAL", output)
+        self.assertIn("openai_api_key", output)
+        self.assertIn("database_url", output)
+        self.assertIn("wide_open_cors", output)
+        self.assertIn("select_star_overfetch", output)
+        self.assertIn("confirmed", output)
+        self.assertIn("leak, baas", output)
+        self.assertIn("browser", output)
+
+    def test_html_report_escapes_dynamic_content(self):
+        finding = Finding(
+            type="xss_test",
+            severity="high",
+            confidence=0.9,
+            detector_id="test:xss_test",
+            source="fixture",
+            evidence=Evidence(source="fixture", redacted_value='<script>alert("xss")</script>'),
+            risk_reason='Risk with <b>bold</b> & "quotes".',
+            remediation="Sanitize <input> tags.",
+        )
+        report = build_report("<script>evil</script>", [finding], scan_mode="browser")
+        output = format_html(report)
+
+        # Raw angle brackets from dynamic content must be escaped
+        self.assertNotIn("<script>alert", output)
+        self.assertNotIn("<script>evil", output)
+        self.assertIn("&lt;script&gt;alert", output)
+        self.assertIn("&lt;script&gt;evil", output)
+
+    def test_html_safe_verdict(self):
+        report = build_report("https://safe.example.com", [], scan_mode="local")
+        output = format_html(report)
+
+        self.assertIn("<!DOCTYPE html>", output)
+        self.assertIn("Safe to Ship", output)
+        self.assertIn("safe.example.com", output)
+        self.assertIn("No findings detected.", output)
+
+    def test_html_review_verdict(self):
+        finding = Finding(
+            type="minor_issue",
+            severity="medium",
+            confidence=0.7,
+            detector_id="test:minor_issue",
+            source="fixture",
+            evidence=Evidence(source="fixture", redacted_value="medium-value"),
+            risk_reason="Needs review.",
+            remediation="Review and fix.",
+        )
+        report = build_report("https://review.example.com", [finding], scan_mode="browser")
+        output = format_html(report)
+
+        self.assertIn("Review", output)
+        self.assertIn("verdict review", output)
+
+
 class LocalScannerTests(unittest.TestCase):
     def test_vulnerable_fixture_produces_actionable_report(self):
         report = scan_path("fixtures/vulnerable-demo")
@@ -132,7 +252,11 @@ class LocalScannerTests(unittest.TestCase):
         self.assertIn("source_map_reference", finding_types)
         openai_sources = [finding.source for finding in report.findings if finding.type == "openai_api_key"]
         self.assertFalse(any(source.endswith("app.js.map") for source in openai_sources))
-        self.assertTrue(all("[redacted]" in finding.evidence.redacted_value for finding in report.findings))
+        # Wave 1.4 introduced HMAC-tagged redaction (`[redacted:abc12345]`)
+        # alongside the legacy prefix/suffix form (`...[redacted]...`). Both
+        # contain the literal `[redacted` substring; that's the canonical
+        # redaction marker.
+        self.assertTrue(all("[redacted" in finding.evidence.redacted_value for finding in report.findings))
 
     def test_baseline_suppresses_known_findings(self):
         report = scan_path("fixtures/vulnerable-demo")
@@ -170,6 +294,24 @@ class LocalScannerTests(unittest.TestCase):
 
 
 class DetectorTests(unittest.TestCase):
+    def test_heatmap_rows_have_pack_coverage(self):
+        detector_types = {detector.result_type for detector in DETECTORS}
+        detector_packs = {detector.pack for detector in DETECTORS}
+
+        for heatmap_type, pack in HEATMAP_ROWS.items():
+            self.assertIn(pack, DETECTOR_PACKS)
+            self.assertIn(pack, detector_packs)
+            self.assertIn(heatmap_type, detector_types)
+
+    def test_detector_metadata_is_pack_aware(self):
+        for detector in DETECTORS:
+            self.assertIn(detector.pack, DETECTOR_PACKS)
+            self.assertTrue(detector.canonical_id.startswith(f"{detector.pack}."))
+            self.assertTrue(detector.result_type)
+            self.assertTrue(detector.description)
+            self.assertTrue(detector.remediation)
+            self.assertIn(detector.validation_status, {"lead", "validated", "suppressed", "not_applicable"})
+
     def test_private_key_detector_matches_pkcs8(self):
         detector = _detector("private_key")
         content = "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----"
@@ -196,6 +338,100 @@ class DetectorTests(unittest.TestCase):
         self.assertIsNone(detector.compile().search(unrelated_lines))
         self.assertIsNotNone(detector.compile().search(same_line))
 
+    def test_extension_bundle_includes_launch_gate_detectors(self):
+        payload = extension_pattern_payload()
+        detector_ids = {detector["id"] for detector in payload}
+        detector_packs = {detector["pack"] for detector in payload}
+
+        self.assertIn("mcp_config_secret", detector_ids)
+        self.assertIn("graphql_introspection_hint", detector_ids)
+        self.assertIn("hidden_prompt_injection", detector_ids)
+        self.assertIn("source_map_reference", detector_ids)
+        self.assertIn("openrouter_api_key", detector_ids)
+        self.assertIn("sql_injection_lead", detector_ids)
+        self.assertIn("xss_sink_lead", detector_ids)
+        self.assertIn("idor_direct_object_lead", detector_ids)
+        self.assertEqual({"leak", "appsec", "access-control", "baas"}, detector_packs)
+        self.assertTrue(all("remediation" in detector for detector in payload))
+        self.assertTrue(all("detector_id" in detector for detector in payload))
+
+    def test_extension_bundle_is_generated_from_core_registry(self):
+        bundle = extension_patterns_js()
+
+        self.assertIn("Source of truth: keyleak.detectors.DETECTORS", bundle)
+        self.assertIn("PATTERN_DEFINITIONS", bundle)
+        self.assertIn("mcp_config_secret", bundle)
+        self.assertIn("appsec.sql_injection_lead", bundle)
+
+    def test_extension_bundle_excludes_repo_only_packs_by_default(self):
+        payload = extension_pattern_payload()
+        detector_ids = {detector["id"] for detector in payload}
+
+        self.assertNotIn("n_plus_one_query_lead", detector_ids)
+        self.assertNotIn("missing_test_lead", detector_ids)
+
+    def test_profile_pack_defaults(self):
+        self.assertEqual(normalize_packs(None, profile="launch-gate"), ("leak",))
+        self.assertEqual(normalize_packs(None, profile="full"), tuple(DETECTOR_PACKS.keys()))
+        self.assertEqual(
+            normalize_packs(None, profile="launch-gate", surface="extension"),
+            ("leak", "appsec", "access-control", "baas"),
+        )
+
+    def test_full_pack_local_scan_finds_heatmap_leads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "app.js").write_text(
+                """
+const query = `SELECT * FROM users WHERE id=${userId}`;
+element.innerHTML = location.hash;
+const requireAuth = false;
+app.get('/users/123456', handler);
+// TODO add tenant ownership check
+for (const user of users) { db.query("SELECT * FROM orders WHERE user_id=" + user.id); }
+for (let i = 0; i <= items.length; i++) {}
+const parsed = new Date(input);
+test.skip("missing coverage", () => {});
+debugger;
+// stale documentation: old auth model
+""",
+                encoding="utf-8",
+            )
+            (root / ".env").write_text("NODE_ENV=development\nVERIFY_SSL=false\n", encoding="utf-8")
+
+            report = scan_path(str(root), profile="full")
+
+        finding_types = {finding.type for finding in report.findings}
+        self.assertIn("sql_injection", finding_types)
+        self.assertIn("xss", finding_types)
+        self.assertIn("auth_bypass", finding_types)
+        self.assertIn("idor", finding_types)
+        self.assertIn("missing_tenant_check", finding_types)
+        self.assertIn("n_plus_one_query", finding_types)
+        self.assertIn("off_by_one", finding_types)
+        self.assertIn("timezone_date_bug", finding_types)
+        self.assertIn("env_config_bug", finding_types)
+        self.assertIn("test_missing", finding_types)
+        self.assertIn("dead_code", finding_types)
+        self.assertIn("stale_doc", finding_types)
+        self.assertIn("correctness", report.to_dict()["packs"])
+        self.assertEqual(
+            {finding.validation_status for finding in report.findings if finding.category != "leak"},
+            {"lead"},
+        )
+
+    def test_extension_service_worker_handles_extension_page_tab_ids(self):
+        source = Path("extension/service-worker.js").read_text(encoding="utf-8")
+
+        self.assertIn("Number.isInteger(message.tabId)", source)
+        self.assertNotIn("if (!tabId) return;", source)
+
+    def test_web_ui_uses_redacted_finding_values(self):
+        source = Path("static/js/main.js").read_text(encoding="utf-8")
+
+        self.assertIn("const redactedValue", source)
+        self.assertNotIn("finding.value || finding.match", source)
+
 
 class CliTests(unittest.TestCase):
     def test_authenticated_profile_without_credentials_uses_no_auth_mode(self):
@@ -210,6 +446,8 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(payload["scan_mode"], "extensive")
         self.assertEqual(payload["auth_config"]["mode"], "none")
+        self.assertEqual(payload["launch_profile"], "launch-gate")
+        self.assertEqual(tuple(payload["packs"]), ("leak",))
 
     def test_scan_payload_auth_mode_matches_supplied_credentials(self):
         payload = _scan_request_payload(
@@ -218,6 +456,8 @@ class CliTests(unittest.TestCase):
                 profile="browser",
                 bearer=" token ",
                 cookie=" session=abc ",
+                launch_profile="bug-bounty",
+                packs="appsec,access-control",
             )
         )
 
@@ -225,6 +465,71 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["auth_config"]["mode"], "both")
         self.assertEqual(payload["auth_config"]["bearer_token"], "token")
         self.assertEqual(payload["auth_config"]["cookie"], "session=abc")
+        self.assertEqual(tuple(payload["packs"]), ("appsec", "access-control"))
+
+    def test_scan_payload_includes_second_user_auth_when_supplied(self):
+        payload = _scan_request_payload(
+            Namespace(
+                url="https://preview.example.com/users/123456",
+                profile="authenticated",
+                bearer=" user-a-token ",
+                cookie="",
+                bearer_b=" user-b-token ",
+                cookie_b="",
+                launch_profile="bug-bounty",
+                packs="access-control",
+            )
+        )
+
+        self.assertEqual(payload["comparison_auth_config"]["mode"], "bearer")
+        self.assertEqual(payload["comparison_auth_config"]["bearer_token"], "user-b-token")
+
+
+class AccessControlComparisonTests(unittest.TestCase):
+    def test_two_user_comparison_validates_same_object_access(self):
+        class Response:
+            status_code = 200
+            text = '{"id":123456,"email":"redacted@example.com"}'
+
+        calls = []
+
+        def fake_fetch(url, **kwargs):
+            calls.append((url, kwargs["headers"].get("Authorization", "")))
+            return Response()
+
+        findings = compare_access_control_urls(
+            ["https://preview.example.com/users/123456"],
+            {"bearer_token": "user-a-token"},
+            {"bearer_token": "user-b-token"},
+            fetch=fake_fetch,
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].type, "idor")
+        self.assertEqual(findings[0].category, "access-control")
+        self.assertEqual(findings[0].validation_status, "validated")
+        self.assertEqual(calls[0][1], "Bearer user-a-token")
+        self.assertEqual(calls[1][1], "Bearer user-b-token")
+
+    def test_two_user_comparison_ignores_rejected_second_user(self):
+        class Response:
+            def __init__(self, status_code):
+                self.status_code = status_code
+                self.text = "{}"
+
+        statuses = [200, 403]
+
+        def fake_fetch(_url, **_kwargs):
+            return Response(statuses.pop(0))
+
+        findings = compare_access_control_urls(
+            ["https://preview.example.com/users/123456"],
+            {"bearer_token": "user-a-token"},
+            {"bearer_token": "user-b-token"},
+            fetch=fake_fetch,
+        )
+
+        self.assertEqual(findings, [])
 
 
 def _detector(detector_id):


### PR DESCRIPTION
## Why This Matters

Modern web apps built on Supabase, Firebase, Appwrite, and PocketBase ship their BaaS configuration directly in minified JavaScript bundles. **Existing secret scanners completely miss this class of vulnerability** because:

1. **The keys are designed to be client-side** — traditional scanners either ignore them or flag them as low-severity
2. **The real vulnerability is misconfigured access control, not the key itself** — a Supabase anon key is harmless if RLS policies are enforced
3. **Table names, RPC functions, and storage buckets survive minification** — an attacker can extract every endpoint from the bundle
4. **Client-side admin checks are trivially bypassable** — `if (isAdmin)` in JavaScript is a one-liner bypass

KeyLeak's BaaS scanner detects the configuration, extracts the attack surface from minified bundles, and **actively validates** whether access controls are enforced.

## What This PR Adds

### BaaS Vulnerability Scanner (CLI + Python)
- **20 `baas` pack detectors** for Supabase, Firebase, Appwrite, PocketBase
- **Active validation engine** (`baas_validator.py`): table RLS, write access (`Prefer: tx=rollback`), storage buckets, auth config (JWT claims, email confirmation), realtime channels
- **4 providers**: Supabase, Firebase, Appwrite, PocketBase
- `--baas-validate` opt-in, `--baas-tables`, `--html` report output

### Chrome Extension — Real-Time Detection
- **Live BaaS detection**: intercepts Supabase/Firebase API requests and probes endpoints with only the anon key
- **TEST button**: validates found keys against 14 providers (Gemini, OpenAI, Anthropic, GitHub, Stripe, etc.) + JWT claims analysis (decodes role, scope, expiry, admin flags)
- **Finding grouping**: same key in N locations → one card with clickable source URLs
- **AIza key classification**: Maps/Firebase context → medium, no context → critical
- **200+ first-party domain suppression**: Google, Microsoft, AWS, Apple, Meta, Anthropic, Stripe, Cloudflare, and 40+ more providers — their own keys on their own sites are never flagged
- **87 vendor CDN domains**: analytics, tracking, widget, and framework CDN scripts suppressed
- **25 infrastructure headers**: CloudFront trace IDs, cf-ray, x-request-id, etc.
- **11 cloud storage providers**: pre-signed URLs from S3, GCS, Azure, R2, etc.
- Browser service tokens (Translate, reCAPTCHA, Firebase Auth) suppressed
- Clickable source URLs, context-invalidation error fix

### Site Scanner CLI
```bash
keyleak site-scan example.com --depth 1 --baas-validate --html > report.html
```
Discovers subdomains (subfinder or DNS brute-force), crawls pages, scans each with deduplication.

### HTML Report (`--html`)
Self-contained dark-theme vulnerability report with severity badges, evidence blocks, and remediation SQL.

## CLI Usage

```bash
# Single page scan with BaaS validation
keyleak browser-scan https://app.example.com --baas-validate --html > report.html

# Full site scan across subdomains
keyleak site-scan example.com --depth 2 --max-pages 30 --baas-validate --html > report.html

# Pattern detection only (no active probing)
keyleak browser-scan https://app.example.com --html > report.html
```

## Test Plan

- [x] 71 Python tests (BaaS validator, reporting, browser scanner)
- [x] 46 JS tests (BaaS detector, tab state, finding generation)
- [x] Analyzer + false positive tests passing
- [x] 24 commits, all review comments addressed
- [ ] Manual: load extension, browse sites → only real findings shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)