### PR TITLE
Add OTP-in-response and hardcoded credential detectors

### DIFF
--- a/extension/lib/detector-info.js
+++ b/extension/lib/detector-info.js
@@ -791,6 +791,25 @@ export const DETECTOR_INFO = {
     "severity": "critical",
     "validation_status": "validated"
   },
+  "otp_in_response": {
+    "attack_scenario": "The server sends the OTP value in the API response. An attacker reads it from the network tab and enters it \u2014 bypassing two-factor authentication entirely. This was exploited in the CBSE exam portal breach (2026).",
+    "categories": [
+      "sourcemaps",
+      "code",
+      "logs"
+    ],
+    "description": "OTP or verification code found in API response body. Server sends the code to the client instead of validating server-side.",
+    "detector_id": "appsec.otp_in_response",
+    "finding_type": "otp_in_response",
+    "id": "otp_in_response",
+    "pack": "appsec",
+    "references": [
+      "https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/"
+    ],
+    "remediation": "Move OTP validation server-side. The server should verify the code, never send it to the client. This enables client-side OTP bypass.",
+    "severity": "critical",
+    "validation_status": "validated"
+  },
   "perplexity_api_key": {
     "attack_scenario": null,
     "categories": [

--- a/extension/lib/patterns.js
+++ b/extension/lib/patterns.js
@@ -1370,6 +1370,29 @@ const PATTERN_DEFINITIONS = [
     "remediation": "Verify RLS policies apply to realtime subscriptions.",
     "severity": "info",
     "validation_status": "lead"
+  },
+  {
+    "capture_group": 1,
+    "categories": [
+      "sourcemaps",
+      "code",
+      "logs"
+    ],
+    "category": "appsec",
+    "description": "OTP or verification code found in API response body. Server sends the code to the client instead of validating server-side.",
+    "detector_id": "appsec.otp_in_response",
+    "finding_type": "otp_in_response",
+    "flags": "gim",
+    "id": "otp_in_response",
+    "min_match_length": 4,
+    "pack": "appsec",
+    "pattern": "(?:\"otp\"|\"OTP\"|\"verification_code\"|\"verificationCode\"|\"2fa_code\"|\"twoFactorCode\"|\"sms_code\"|\"smsCode\"|\"pin_code\"|\"pinCode\"|\"one_time_password\"|\"mfa_code\")\\s*:\\s*[\"']?(\\d{4,8}|[A-Z0-9]{4,8})[\"']?",
+    "references": [
+      "https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/"
+    ],
+    "remediation": "Move OTP validation server-side. The server should verify the code, never send it to the client. This enables client-side OTP bypass.",
+    "severity": "critical",
+    "validation_status": "validated"
   }
 ];
 

--- a/extension/lib/patterns.js
+++ b/extension/lib/patterns.js
@@ -1386,7 +1386,7 @@ const PATTERN_DEFINITIONS = [
     "id": "otp_in_response",
     "min_match_length": 4,
     "pack": "appsec",
-    "pattern": "(?:\"otp\"|\"OTP\"|\"verification_code\"|\"verificationCode\"|\"2fa_code\"|\"twoFactorCode\"|\"sms_code\"|\"smsCode\"|\"pin_code\"|\"pinCode\"|\"one_time_password\"|\"mfa_code\")\\s*:\\s*[\"']?(\\d{4,8}|[A-Z0-9]{4,8})[\"']?",
+    "pattern": "(?:\"otp\"|\"OTP\"|\"verification_code\"|\"verificationCode\"|\"2fa_code\"|\"twoFactorCode\"|\"sms_code\"|\"smsCode\"|\"pin_code\"|\"pinCode\"|\"one_time_password\"|\"mfa_code\")\\s*:\\s*[\"']?(\\d{4,8}|(?=[A-Za-z0-9]{4,8}\\b)(?=[A-Za-z0-9]*\\d)[A-Za-z0-9]{4,8})[\"']?",
     "references": [
       "https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/"
     ],

--- a/keyleak/detectors.py
+++ b/keyleak/detectors.py
@@ -965,7 +965,7 @@ DETECTORS = [
     # ------------------------------------------------------------------
     Detector(
         "otp_in_response",
-        r"""(?:"otp"|"OTP"|"verification_code"|"verificationCode"|"2fa_code"|"twoFactorCode"|"sms_code"|"smsCode"|"pin_code"|"pinCode"|"one_time_password"|"mfa_code")\s*:\s*["']?(\d{4,8}|[A-Z0-9]{4,8})["']?""",
+        r"""(?:"otp"|"OTP"|"verification_code"|"verificationCode"|"2fa_code"|"twoFactorCode"|"sms_code"|"smsCode"|"pin_code"|"pinCode"|"one_time_password"|"mfa_code")\s*:\s*["']?(\d{4,8}|(?=[A-Za-z0-9]{4,8}\b)(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{4,8})["']?""",
         "critical",
         "OTP or verification code found in API response body. Server sends the code to the client instead of validating server-side.",
         "Move OTP validation server-side. The server should verify the code, never send it to the client. This enables client-side OTP bypass.",

--- a/keyleak/detectors.py
+++ b/keyleak/detectors.py
@@ -960,6 +960,42 @@ DETECTORS = [
         finding_type="baas_realtime_subscribe",
         validation_status="lead",
     ),
+    # ------------------------------------------------------------------
+    # Runtime-only detectors — patterns only visible in live HTTP traffic
+    # ------------------------------------------------------------------
+    Detector(
+        "otp_in_response",
+        r"""(?:"otp"|"OTP"|"verification_code"|"verificationCode"|"2fa_code"|"twoFactorCode"|"sms_code"|"smsCode"|"pin_code"|"pinCode"|"one_time_password"|"mfa_code")\s*:\s*["']?(\d{4,8}|[A-Z0-9]{4,8})["']?""",
+        "critical",
+        "OTP or verification code found in API response body. Server sends the code to the client instead of validating server-side.",
+        "Move OTP validation server-side. The server should verify the code, never send it to the client. This enables client-side OTP bypass.",
+        ["sourcemaps", "code", "logs"],
+        4,
+        1,
+        "appsec",
+        "otp_in_response",
+        "validated",
+        ("https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/",),
+        True,
+        attack_scenario="The server sends the OTP value in the API response. An attacker reads it from the network tab and enters it — bypassing two-factor authentication entirely. This was exploited in the CBSE exam portal breach (2026).",
+    ),
+    Detector(
+        "hardcoded_credential_in_bundle",
+        r"(?:(?:master[_-]?)?(?:password|passwd|pwd)|secret[_-]?key|admin[_-]?(?:password|secret|token)|default[_-]?(?:password|secret))\s*[:=]\s*[\"']([A-Za-z0-9!@#$%^&*_\-+=.]{8,64})[\"']",
+        "high",
+        "Hardcoded password or secret found in code.",
+        "Remove the hardcoded credential, use environment variables or a secret manager, and rotate the exposed value.",
+        ["code", "sourcemaps", "logs"],
+        8,
+        1,
+        "appsec",
+        "hardcoded_credential",
+        "lead",
+        (),
+        False,
+        attack_scenario="A hardcoded password in a JS bundle is accessible to any user who downloads the file. If it's a master password or admin secret, it grants full access bypass.",
+        min_entropy=3.5,
+    ),
 ]
 
 


### PR DESCRIPTION
## Context

Inspired by the [CBSE exam portal breach writeup](https://ni5arga.com/blog/posts/hacking-cbse/) where a master password was hardcoded in the frontend JS bundle and OTP validation happened entirely client-side.

## New Detectors

### 1. `otp_in_response` (CRITICAL)

Detects OTP/verification codes in API response bodies. When a server sends the OTP value in the JSON response instead of validating server-side, any user can read it from the network tab — completely bypassing 2FA.

**This is a runtime-only finding.** Static scanners cannot catch it because the OTP only appears in live HTTP responses. KeyLeak's extension intercepts fetch/XHR responses and runs this detector in real-time.

Matches: `"otp": "483921"`, `"verification_code": "AB1234"`, `"2fa_code": "123456"`, `"sms_code": "..."`, etc.

### 2. `hardcoded_credential_in_bundle` (HIGH)

Detects hardcoded passwords, master keys, admin secrets, and default credentials in JS bundles and source code.

Matches: `password = "SecretPass123"`, `admin_password: "changeme"`, `master_password = "..."`, `secretKey = "..."`

Uses entropy gate (3.5 bits/char) to reject dictionary-word false positives. CLI-only (`extension=false`) to avoid noise on minified JS.

## Test Plan

- [x] OTP detector matches `{"otp": "483921"}` in response bodies
- [x] Credential detector matches `master_password = "SecretPass123"` 
- [x] Entropy gate rejects `password = "password"` (dictionary word)
- [x] 71 Python tests passing, 0 regressions
- [x] Extension JS tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/keyleak-detector/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects OTP/verification codes exposed in API/JSON responses to surface client-side OTP disclosure risks.
  * Detects hardcoded credentials embedded in application bundles to identify shipped secret leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Amal-David/keyleak-detector/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->