### PR TITLE
Add Full Site Scan (subdomain enumeration + full domain crawl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Static scanners find hardcoded secrets in source code. KeyLeak finds the ones th
 
 - **BaaS vulnerability scanner**: Detects Supabase/Firebase/Appwrite config in minified JS bundles, extracts table names, and actively probes whether Row-Level Security is enforced. A Supabase anon key is harmless if RLS works. KeyLeak tests whether it does.
 - **Chrome extension**: Detects leaked keys in real-time as you browse. TEST button validates whether a found key is still active (supports 14 providers). JWT decoder surfaces suspicious claims (service_role, admin flags, broad scopes).
-- **Site scanner**: Discovers subdomains, crawls pages, scans everything. One command for a full site audit.
+- **Full Site Scan**: Enumerates subdomains (crt.sh certificate transparency + DNS — no external tools needed), crawls every page of the domain, and scans them all, reporting which subdomains/pages each leak appeared on. One command (or one click in the web UI) for a full domain audit. Authorized targets only.
 - **200+ first-party domain suppression**: No false positives when browsing Google, AWS, Azure, GitHub, Stripe, etc.
 
 ## Install
@@ -93,8 +93,8 @@ keyleak browser-scan https://your-app.vercel.app --html > report.html
 # Scan with BaaS validation (tests Supabase RLS, Firebase rules)
 keyleak browser-scan https://your-app.vercel.app --baas-validate --html > report.html
 
-# Scan an entire site (subdomain discovery + page crawling)
-keyleak site-scan example.com --depth 2 --baas-validate --html > report.html
+# Full Site Scan — subdomain enumeration (crt.sh + DNS) + multi-page crawl, all pages scanned
+keyleak site-scan example.com --depth 3 --max-pages 100 --max-subdomains 25 --baas-validate --html > report.html
 
 # Scan local files for secrets
 keyleak local . --fail-on high
@@ -136,7 +136,7 @@ The `--html` flag generates a self-contained dark-theme vulnerability report:
 
 - **BaaS vulnerability scanner** with active validation (Supabase, Firebase, Appwrite, PocketBase)
 - **Chrome extension** with real-time detection, TEST button, and JWT analysis
-- **Site scanner CLI** (`keyleak site-scan`) with subdomain discovery
+- **Full Site Scan** (`keyleak site-scan` + web UI button) with crt.sh + DNS subdomain enumeration, multi-level crawl, and per-finding page provenance
 - **HTML report** output (`--html`)
 - **20 new `baas` pack detectors**
 - **Comprehensive false positive suppression** (200+ first-party domains, 87 vendor CDNs, cloud storage URLs, infra headers)

--- a/app.py
+++ b/app.py
@@ -1408,7 +1408,9 @@ async def _run_full_site_scan(url, parsed_url, scan_id):
     """
     from keyleak.site_scanner import scan_site
 
-    domain = parsed_url.netloc.split(':')[0]
+    domain = parsed_url.hostname
+    if not domain:
+        return jsonify({'error': 'Invalid URL host'}), 400
     _emit_progress(scan_id, f"Full Site Scan: discovering subdomains for {domain}...")
 
     def _progress(ev):
@@ -1427,9 +1429,9 @@ async def _run_full_site_scan(url, parsed_url, scan_id):
     try:
         loop = asyncio.get_event_loop()
         report = await loop.run_in_executor(None, _run)
-    except Exception as e:
-        logger.warning(f"Full site scan failed: {e}")
-        err = {'error': f'Full site scan failed: {str(e)}'}
+    except Exception:
+        logger.exception("Full site scan failed")
+        err = {'error': 'Full site scan failed. Check server logs for details.'}
         if scan_id and scan_id in _scan_queues:
             _scan_queues[scan_id].put({'type': 'result', 'data': err})
         return jsonify(err), 500

--- a/app.py
+++ b/app.py
@@ -1399,6 +1399,66 @@ def scan_events(scan_id):
 def index():
     return render_template('index.html')
 
+async def _run_full_site_scan(url, parsed_url, scan_id):
+    """Full Site Scan: enumerate subdomains + crawl all pages of a domain.
+
+    Runs the synchronous site_scanner engine in a thread executor (it uses
+    sync Playwright, which must not share the async event loop) and streams
+    per-phase progress over the existing SSE channel.
+    """
+    from keyleak.site_scanner import scan_site
+
+    domain = parsed_url.netloc.split(':')[0]
+    _emit_progress(scan_id, f"Full Site Scan: discovering subdomains for {domain}...")
+
+    def _progress(ev):
+        _emit_progress(scan_id, ev.get("message") if isinstance(ev, dict) else str(ev))
+
+    def _run():
+        return scan_site(
+            domain,
+            depth=3,
+            max_pages=100,
+            max_subdomains=25,
+            baas_validate=True,
+            on_progress=_progress,
+        )
+
+    try:
+        loop = asyncio.get_event_loop()
+        report = await loop.run_in_executor(None, _run)
+    except Exception as e:
+        logger.warning(f"Full site scan failed: {e}")
+        err = {'error': f'Full site scan failed: {str(e)}'}
+        if scan_id and scan_id in _scan_queues:
+            _scan_queues[scan_id].put({'type': 'result', 'data': err})
+        return jsonify(err), 500
+
+    findings = [f.to_dict() for f in report.findings]
+    response_data = {
+        'url': url,
+        'status': 'completed',
+        'scan_mode': 'full-site',
+        'verdict': report.verdict,
+        'retest_command': report.retest_command,
+        'report': report.to_dict(),
+        'findings': findings,
+        'scan_summary': report.summary,
+        'subdomains': report.extra.get('subdomains', []),
+        'pages_scanned': report.extra.get('pages_scanned', 0),
+        'provenance': report.extra.get('provenance', {}),
+        'details': {
+            'unique_findings': len(findings),
+            'hosts_scanned': report.extra.get('hosts_scanned', 0),
+            'pages_scanned': report.extra.get('pages_scanned', 0),
+            'scan_timestamp': datetime.now().isoformat(),
+        },
+    }
+    if scan_id and scan_id in _scan_queues:
+        _scan_queues[scan_id].put({'type': 'result', 'data': response_data})
+    return jsonify(response_data)
+
+
 @app.route('/scan', methods=['POST'])
 async def scan():
     global mitm_thread, mitm_running
@@ -1449,8 +1509,12 @@ async def scan():
         _scan_queues[scan_id] = Queue()
         _scan_queue_created[scan_id] = time.monotonic()
 
+    # Full Site Scan: subdomain enumeration + multi-page crawl of the domain.
+    if scan_mode == 'full-site':
+        return await _run_full_site_scan(url, parsed_url, scan_id)
+
     if scan_mode not in {'basic', 'extensive'}:
-        return jsonify({'error': 'Invalid scan mode. Use basic or extensive.'}), 400
+        return jsonify({'error': 'Invalid scan mode. Use basic, extensive, or full-site.'}), 400
     
     try:
         # Reset findings

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -207,10 +207,13 @@ def main(argv: Optional[List[str]] = None) -> int:
                 args.domain,
                 depth=int(args.depth),
                 max_pages=int(args.max_pages),
+                max_subdomains=int(args.max_subdomains),
                 headless=not args.headed,
                 baas_validate=args.baas_validate,
                 baas_tables=extra_tables,
                 scan_budget_seconds=int(args.scan_budget),
+                launch_profile=args.launch_profile,
+                offline=getattr(args, "offline", False),
             )
         except Exception as exc:
             print(f"site-scan failed: {exc}", file=sys.stderr)
@@ -357,11 +360,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     site_scan = subparsers.add_parser(
         "site-scan",
-        help="Discover subdomains, crawl pages, and scan an entire site for secrets and BaaS vulnerabilities.",
+        help=(
+            "Full Site Scan: enumerate subdomains (crt.sh + DNS) and crawl every page of a "
+            "domain for secrets and BaaS misconfigurations. Authorized targets only."
+        ),
     )
     site_scan.add_argument("domain", help="Domain or URL to scan (e.g., example.com)")
-    site_scan.add_argument("--depth", default="1", help="Link crawl depth per host (default: 1).")
-    site_scan.add_argument("--max-pages", default="20", help="Maximum pages to scan (default: 20).")
+    site_scan.add_argument("--depth", default="3", help="Link crawl depth per host (default: 3).")
+    site_scan.add_argument("--max-pages", default="100", help="Maximum pages to scan (default: 100).")
+    site_scan.add_argument("--max-subdomains", default="25", help="Maximum subdomains to scan (default: 25).")
+    site_scan.add_argument("--launch-profile", default="launch-gate", choices=["launch-gate", "local-dev", "bug-bounty", "ci", "full"])
     site_scan.add_argument("--scan-budget", default="30", help="Per-page timeout in seconds.")
     site_scan.add_argument("--headed", action="store_true", help="Show browser windows.")
     site_scan.add_argument("--baas-validate", action="store_true", help="Enable active BaaS validation probes.")

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -1,17 +1,27 @@
-"""Site-wide scanner with subdomain discovery and page crawling.
+"""Full Site Scan — subdomain enumeration and multi-level page crawling.
 
-Discovers subdomains for a domain, crawls each for internal links,
-then runs ``run_browser_scan()`` on each collected URL. Aggregates
-findings into a single report with deduplication.
+Discovers subdomains for a domain (certificate transparency via crt.sh +
+optional ``subfinder`` + DNS brute-force), crawls each host for internal links
+up to a depth, then runs ``run_browser_scan()`` on every collected URL.
+Findings are merged into a single report that preserves provenance — which
+subdomains and pages each leak appeared on.
+
+Scope is limited to the target's registrable domain; hard caps bound the
+number of subdomains and pages. Read-only: crawl + passive scan only.
 """
 
 from __future__ import annotations
 
+import json
 import socket
 import subprocess
 import sys
-from typing import Any, Dict, List, Optional, Set
-from urllib.parse import urljoin, urlparse
+from collections import deque
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from urllib.parse import urlparse
+
+import requests
+import tldextract
 
 from .browser_scanner import run_browser_scan
 from .models import Finding, ScanReport
@@ -29,165 +39,309 @@ COMMON_SUBDOMAINS = [
     "media", "images", "files", "uploads", "download",
 ]
 
+# Hard caps to keep a scan bounded and polite.
+MAX_SUBDOMAINS_DEFAULT = 25
+MAX_PAGES_DEFAULT = 100
 
-def discover_subdomains(domain: str) -> List[str]:
-    """Discover subdomains using subfinder (if available) or DNS brute-force."""
-    domain = domain.strip().lower()
+ProgressFn = Optional[Callable[[Dict[str, Any]], None]]
 
-    # Try subfinder first
+
+def _emit(on_progress: ProgressFn, phase: str, message: str,
+          current: int = 0, total: int = 0) -> None:
+    """Send a progress event to the hook (if any) and mirror to stderr."""
+    print(f"[keyleak] {message}", file=sys.stderr)
+    if on_progress:
+        try:
+            on_progress({"phase": phase, "message": message,
+                         "current": current, "total": total})
+        except Exception:
+            pass
+
+
+def registrable_domain(host: str) -> str:
+    """Return the registrable domain (handles multi-label TLDs like co.uk)."""
+    host = (host or "").strip().lower().split(":")[0]
+    ext = tldextract.extract(host)
+    if ext.domain and ext.suffix:
+        return f"{ext.domain}.{ext.suffix}"
+    return host
+
+
+def _resolves(host: str) -> bool:
+    try:
+        socket.getaddrinfo(host, None, socket.AF_INET, socket.SOCK_STREAM)
+        return True
+    except (socket.gaierror, OSError):
+        return False
+
+
+def _crt_sh_subdomains(domain: str, timeout: int = 12) -> List[str]:
+    """Passive subdomain discovery via crt.sh certificate transparency logs.
+
+    No external binary required. Returns names within the target domain.
+    Degrades to an empty list on any network/parse failure.
+    """
+    found: Set[str] = set()
+    try:
+        resp = requests.get(
+            "https://crt.sh/",
+            params={"q": f"%.{domain}", "output": "json"},
+            timeout=timeout,
+            headers={"User-Agent": "keyleak-detector/full-site-scan"},
+        )
+        resp.raise_for_status()
+        entries = resp.json()
+    except (requests.RequestException, json.JSONDecodeError, ValueError):
+        return []
+
+    for entry in entries:
+        name_value = str(entry.get("name_value", ""))
+        for raw in name_value.splitlines():
+            name = raw.strip().lower().lstrip("*.")
+            if not name or "@" in name:
+                continue
+            if name == domain or name.endswith("." + domain):
+                found.add(name)
+    return sorted(found)
+
+
+def _subfinder_subdomains(domain: str) -> List[str]:
+    """Use the optional subfinder binary if present, else empty."""
     try:
         result = subprocess.run(
             ["subfinder", "-d", domain, "-silent", "-timeout", "10"],
             capture_output=True, text=True, timeout=30,
         )
         if result.returncode == 0 and result.stdout.strip():
-            subs = [s.strip() for s in result.stdout.strip().splitlines() if s.strip()]
-            if subs:
-                print(f"[keyleak] subfinder found {len(subs)} subdomains", file=sys.stderr)
-                return sorted(set(subs))
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+            return sorted({s.strip().lower() for s in result.stdout.splitlines() if s.strip()})
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         pass
+    return []
 
-    # Fallback: DNS brute-force with common subdomains
-    print(f"[keyleak] subfinder not found, trying {len(COMMON_SUBDOMAINS)} common subdomains via DNS", file=sys.stderr)
-    found = []
+
+def discover_subdomains(
+    domain: str,
+    *,
+    max_subdomains: int = MAX_SUBDOMAINS_DEFAULT,
+    offline: bool = False,
+    on_progress: ProgressFn = None,
+) -> List[str]:
+    """Discover subdomains within ``domain``, scoped and capped.
+
+    Sources (union): subfinder (if installed) + crt.sh + DNS brute-force of
+    common names. Each candidate is DNS-resolved to drop dead names, then the
+    list is capped at ``max_subdomains``. With ``offline=True`` no network is
+    used and only the bare domain is returned.
+    """
+    domain = domain.strip().lower().split(":")[0]
+
+    if offline:
+        _emit(on_progress, "subdomains", "Offline mode — skipping subdomain discovery", 1, 1)
+        return [domain]
+
+    candidates: Set[str] = {domain}
+    candidates.update(_subfinder_subdomains(domain))
+
+    crt = _crt_sh_subdomains(domain)
+    if crt:
+        candidates.update(crt)
+        _emit(on_progress, "subdomains", f"crt.sh returned {len(crt)} candidate names")
+
     for sub in COMMON_SUBDOMAINS:
-        hostname = f"{sub}.{domain}"
-        try:
-            socket.getaddrinfo(hostname, None, socket.AF_INET, socket.SOCK_STREAM)
-            found.append(hostname)
-        except socket.gaierror:
+        candidates.add(f"{sub}.{domain}")
+
+    # Keep only names that actually resolve, capped.
+    resolved: List[str] = []
+    # Always try the bare domain first so it leads the list.
+    ordered = [domain] + sorted(c for c in candidates if c != domain)
+    for host in ordered:
+        if len(resolved) >= max_subdomains:
+            break
+        if _resolves(host):
+            resolved.append(host)
+
+    if not resolved:
+        resolved = [domain]
+    _emit(on_progress, "subdomains",
+          f"Discovered {len(resolved)} live host(s)", len(resolved), len(resolved))
+    return resolved
+
+
+def _normalize_url(url: str) -> str:
+    """Scheme + netloc + path, no fragment/query — for crawl dedup."""
+    p = urlparse(url)
+    path = p.path or "/"
+    return f"{p.scheme}://{p.netloc}{path}".rstrip("/") or f"{p.scheme}://{p.netloc}/"
+
+
+def _filter_links(
+    links: List[str],
+    registrable: str,
+    seen: Set[str],
+    remaining: int,
+) -> List[str]:
+    """Pure helper: keep in-scope, http(s), de-duplicated links.
+
+    Updates ``seen`` in place with normalized URLs. Returns up to
+    ``remaining`` newly discovered normalized URLs, in order.
+    """
+    out: List[str] = []
+    if remaining <= 0:
+        return out
+    for link in links:
+        if len(out) >= remaining:
+            break
+        p = urlparse(link)
+        if p.scheme not in ("http", "https") or not p.netloc:
             continue
-
-    # Always include the bare domain
-    try:
-        socket.getaddrinfo(domain, None, socket.AF_INET, socket.SOCK_STREAM)
-        if domain not in found:
-            found.insert(0, domain)
-    except socket.gaierror:
-        pass
-
-    print(f"[keyleak] DNS resolved {len(found)} subdomains", file=sys.stderr)
-    return found
+        if registrable_domain(p.netloc) != registrable:
+            continue
+        normalized = _normalize_url(link)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append(normalized)
+    return out
 
 
 def crawl_pages(
     hosts: List[str],
     *,
     depth: int = 1,
-    max_pages: int = 20,
+    max_pages: int = MAX_PAGES_DEFAULT,
     headless: bool = True,
+    on_progress: ProgressFn = None,
 ) -> List[str]:
-    """Crawl each host for internal links up to ``depth`` levels.
+    """Breadth-first crawl across ``hosts`` up to ``depth`` link levels.
 
-    Uses Playwright to load pages and extract ``<a href>`` links.
-    Returns deduplicated list of URLs to scan.
+    Same-registrable-domain scope, normalized dedup, global ``max_pages`` cap.
+    Falls back to host roots only when Playwright is unavailable.
     """
+    seen: Set[str] = set()
+    roots = []
+    for h in hosts:
+        root = _normalize_url(f"https://{h}")
+        if root not in seen:
+            seen.add(root)
+            roots.append(root)
+
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
-        # No Playwright — just return root URLs
-        return [f"https://{h}" for h in hosts[:max_pages]]
+        return roots[:max_pages]
 
-    urls: List[str] = []
-    seen: Set[str] = set()
+    results: List[str] = []
+    queue: deque = deque((r, 0) for r in roots)
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=headless)
+        try:
+            while queue and len(results) < max_pages:
+                url, level = queue.popleft()
+                results.append(url)
+                if level >= depth:
+                    continue
+                try:
+                    context = browser.new_context(viewport={"width": 1280, "height": 1024})
+                    page = context.new_page()
+                    page.set_default_timeout(15000)
+                    page.goto(url, wait_until="domcontentloaded")
+                    links = page.evaluate(
+                        "() => Array.from(document.querySelectorAll('a[href]'))"
+                        ".map(a => a.href).filter(h => h.startsWith('http'))"
+                    )
+                    context.close()
+                except Exception:
+                    continue
+                registrable = registrable_domain(urlparse(url).netloc)
+                remaining = max_pages - (len(results) + len(queue))
+                for nu in _filter_links(links, registrable, seen, remaining):
+                    queue.append((nu, level + 1))
+        finally:
+            browser.close()
 
-        for host in hosts:
-            if len(urls) >= max_pages:
-                break
+    _emit(on_progress, "crawl", f"Found {len(results)} page(s) to scan",
+          len(results), len(results))
+    return results
 
-            root_url = f"https://{host}"
-            if root_url in seen:
-                continue
-            seen.add(root_url)
-            urls.append(root_url)
 
-            if depth < 1:
-                continue
+def _merge_findings(
+    pairs: List[Tuple[Finding, str]],
+) -> Tuple[List[Finding], Dict[str, List[str]]]:
+    """Merge findings across pages, preserving per-finding provenance.
 
-            # Crawl for internal links
-            try:
-                context = browser.new_context(viewport={"width": 1280, "height": 1024})
-                page = context.new_page()
-                page.set_default_timeout(15000)
-                page.goto(root_url, wait_until="domcontentloaded")
+    ``pairs`` is a list of (finding, source_url). Keeps one Finding per
+    (type, redacted_value); returns the deduped list plus a map of
+    ``finding.id -> sorted list of URLs`` it was seen on.
+    """
+    kept: Dict[str, Finding] = {}
+    urls_by_key: Dict[str, Set[str]] = {}
+    for finding, url in pairs:
+        key = f"{finding.type}:{finding.evidence.redacted_value}"
+        if key not in kept:
+            if not finding.evidence.request_url and url:
+                finding.evidence.request_url = url
+            kept[key] = finding
+        if url:
+            urls_by_key.setdefault(key, set()).add(url)
 
-                links = page.evaluate("""() => {
-                    const anchors = document.querySelectorAll('a[href]');
-                    return Array.from(anchors).map(a => a.href).filter(h => h.startsWith('http'));
-                }""")
+    findings = list(kept.values())
+    provenance = {
+        kept[key].id: sorted(urls)
+        for key, urls in urls_by_key.items()
+        if key in kept
+    }
+    return findings, provenance
 
-                parsed_root = urlparse(root_url)
-                base_domain = parsed_root.netloc
-                # Extract registrable domain (last two labels) for same-site matching
-                domain_parts = base_domain.split(".")
-                if len(domain_parts) >= 2:
-                    registrable = domain_parts[-2] + "." + domain_parts[-1]
-                else:
-                    registrable = base_domain
 
-                for link in links:
-                    if len(urls) >= max_pages:
-                        break
-                    parsed = urlparse(link)
-                    # Only follow same-domain links
-                    if not parsed.netloc.endswith(registrable):
-                        continue
-                    # Normalize — strip fragments and query params for dedup
-                    normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-                    if normalized not in seen:
-                        seen.add(normalized)
-                        urls.append(link)
-
-                context.close()
-            except Exception:
-                continue
-
-        browser.close()
-
-    return urls
+def _deduplicate_findings(findings: List[Finding]) -> List[Finding]:
+    """Backward-compatible dedup by (type, redacted_value)."""
+    merged, _ = _merge_findings([(f, "") for f in findings])
+    return merged
 
 
 def scan_site(
     domain: str,
     *,
     depth: int = 1,
-    max_pages: int = 20,
+    max_pages: int = MAX_PAGES_DEFAULT,
+    max_subdomains: int = MAX_SUBDOMAINS_DEFAULT,
     headless: bool = True,
     baas_validate: bool = False,
     baas_prober: Optional[Any] = None,
     baas_tables: Optional[List[str]] = None,
     scan_budget_seconds: int = 30,
+    launch_profile: str = "launch-gate",
+    offline: bool = False,
+    on_progress: ProgressFn = None,
 ) -> ScanReport:
-    """Discover subdomains, crawl pages, and scan each for secrets.
+    """Full Site Scan: discover subdomains, crawl pages, scan each for secrets.
 
-    Returns an aggregated ScanReport with deduplicated findings.
+    Returns an aggregated ScanReport whose ``extra`` carries the scanned
+    subdomains, page count, and a ``provenance`` map (finding id -> URLs).
     """
-    # Parse domain from URL if given
     parsed = urlparse(domain)
     if parsed.netloc:
         domain = parsed.netloc
-    domain = domain.split(":")[0]  # strip port
+    domain = domain.strip().lower().split(":")[0]
 
-    print(f"[keyleak] Starting site scan for {domain}", file=sys.stderr)
+    _emit(on_progress, "start", f"Starting full site scan for {domain}")
 
-    # Step 1: Discover subdomains
-    subdomains = discover_subdomains(domain)
+    subdomains = discover_subdomains(
+        domain, max_subdomains=max_subdomains, offline=offline, on_progress=on_progress
+    )
     if not subdomains:
         subdomains = [domain]
 
-    # Step 2: Crawl pages
-    print(f"[keyleak] Crawling {len(subdomains)} hosts (depth={depth}, max={max_pages})", file=sys.stderr)
-    urls = crawl_pages(subdomains, depth=depth, max_pages=max_pages, headless=headless)
-    print(f"[keyleak] Found {len(urls)} pages to scan", file=sys.stderr)
+    urls = crawl_pages(
+        subdomains, depth=depth, max_pages=max_pages,
+        headless=headless, on_progress=on_progress,
+    )
 
-    # Step 3: Scan each URL
-    all_findings: List[Finding] = []
+    pairs: List[Tuple[Finding, str]] = []
+    total = len(urls)
     for i, url in enumerate(urls):
-        print(f"[keyleak] Scanning [{i+1}/{len(urls)}] {url}", file=sys.stderr)
+        _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {url}", i + 1, total)
         try:
             report = run_browser_scan(
                 url,
@@ -197,30 +351,29 @@ def scan_site(
                 baas_tables=baas_tables,
                 scan_budget_seconds=scan_budget_seconds,
             )
-            all_findings.extend(report.findings)
+            for f in report.findings:
+                pairs.append((f, url))
         except Exception as exc:
             print(f"[keyleak]   Error scanning {url}: {exc}", file=sys.stderr)
             continue
 
-    # Step 4: Deduplicate — same detector + same redacted value = one finding
-    deduped = _deduplicate_findings(all_findings)
+    findings, provenance = _merge_findings(pairs)
+    _emit(on_progress, "done",
+          f"Full site scan complete: {len(findings)} unique finding(s) from {total} page(s)",
+          total, total)
 
-    print(f"[keyleak] Site scan complete: {len(deduped)} unique findings from {len(urls)} pages", file=sys.stderr)
-
-    return build_report(
+    report = build_report(
         domain,
-        deduped,
-        scan_mode="site",
-        profile="launch-gate",
+        findings,
+        scan_mode="full-site",
+        profile=launch_profile,
         packs=["leak", "appsec", "access-control", "baas"],
     )
-
-
-def _deduplicate_findings(findings: List[Finding]) -> List[Finding]:
-    """Keep one finding per (type, redacted_value) pair."""
-    seen: Dict[str, Finding] = {}
-    for f in findings:
-        key = f"{f.type}:{f.evidence.redacted_value}"
-        if key not in seen:
-            seen[key] = f
-    return list(seen.values())
+    report.extra.update({
+        "subdomains": subdomains,
+        "hosts_scanned": len(subdomains),
+        "pages_scanned": total,
+        "scanned_urls": urls,
+        "provenance": provenance,
+    })
+    return report

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -213,7 +213,7 @@ def _filter_links(
 def crawl_pages(
     hosts: List[str],
     *,
-    depth: int = 1,
+    depth: int = 3,
     max_pages: int = MAX_PAGES_DEFAULT,
     headless: bool = True,
     on_progress: ProgressFn = None,
@@ -317,7 +317,7 @@ def _deduplicate_findings(findings: List[Finding]) -> List[Finding]:
 def scan_site(
     domain: str,
     *,
-    depth: int = 1,
+    depth: int = 3,
     max_pages: int = MAX_PAGES_DEFAULT,
     max_subdomains: int = MAX_SUBDOMAINS_DEFAULT,
     headless: bool = True,
@@ -334,10 +334,12 @@ def scan_site(
     Returns an aggregated ScanReport whose ``extra`` carries the scanned
     subdomains, page count, and a ``provenance`` map (finding id -> URLs).
     """
-    parsed = urlparse(domain)
-    if parsed.netloc:
-        domain = parsed.netloc
-    domain = domain.strip().lower().split(":")[0]
+    # Normalize to the registrable domain (eTLD+1), tolerating full URLs,
+    # credentials, ports, and IPv6 literals (parsed.hostname drops user/port).
+    raw = domain.strip()
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    host = (parsed.hostname or raw).strip().lower()
+    domain = registrable_domain(host)
 
     _emit(on_progress, "start", f"Starting full site scan for {domain}")
 

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -69,7 +69,8 @@ def registrable_domain(host: str) -> str:
 
 def _resolves(host: str) -> bool:
     try:
-        socket.getaddrinfo(host, None, socket.AF_INET, socket.SOCK_STREAM)
+        # AF_UNSPEC so IPv6-only hosts are also treated as live.
+        socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         return True
     except (socket.gaierror, OSError):
         return False
@@ -139,21 +140,26 @@ def discover_subdomains(
         _emit(on_progress, "subdomains", "Offline mode — skipping subdomain discovery", 1, 1)
         return [domain]
 
-    candidates: Set[str] = {domain}
-    candidates.update(_subfinder_subdomains(domain))
-
-    crt = _crt_sh_subdomains(domain)
+    subfinder = set(_subfinder_subdomains(domain))
+    crt = set(_crt_sh_subdomains(domain))
     if crt:
-        candidates.update(crt)
         _emit(on_progress, "subdomains", f"crt.sh returned {len(crt)} candidate names")
+    brute_force = {f"{sub}.{domain}" for sub in COMMON_SUBDOMAINS}
 
-    for sub in COMMON_SUBDOMAINS:
-        candidates.add(f"{sub}.{domain}")
+    # Build the candidate list in source-priority order — bare domain, then
+    # passive discovery (subfinder, crt.sh), then guessed names last — so a
+    # small cap never drops a real hit in favour of a brute-force guess that
+    # merely sorts earlier alphabetically.
+    ordered: List[str] = [domain]
+    seen = {domain}
+    for bucket in (sorted(subfinder), sorted(crt), sorted(brute_force)):
+        for host in bucket:
+            if host not in seen:
+                seen.add(host)
+                ordered.append(host)
 
-    # Keep only names that actually resolve, capped.
+    # Keep only names that actually resolve, capped at max_subdomains.
     resolved: List[str] = []
-    # Always try the bare domain first so it leads the list.
-    ordered = [domain] + sorted(c for c in candidates if c != domain)
     for host in ordered:
         if len(resolved) >= max_subdomains:
             break
@@ -241,6 +247,7 @@ def crawl_pages(
                 results.append(url)
                 if level >= depth:
                     continue
+                context = None
                 try:
                     context = browser.new_context(viewport={"width": 1280, "height": 1024})
                     page = context.new_page()
@@ -250,9 +257,16 @@ def crawl_pages(
                         "() => Array.from(document.querySelectorAll('a[href]'))"
                         ".map(a => a.href).filter(h => h.startsWith('http'))"
                     )
-                    context.close()
                 except Exception:
                     continue
+                finally:
+                    # Always release the context, even when goto/evaluate raised,
+                    # so failed hosts don't leak browser contexts during a crawl.
+                    if context is not None:
+                        try:
+                            context.close()
+                        except Exception:
+                            pass
                 registrable = registrable_domain(urlparse(url).netloc)
                 remaining = max_pages - (len(results) + len(queue))
                 for nu in _filter_links(links, registrable, seen, remaining):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keyleak-detector"
-version = "0.5.1"
+version = "0.5.2"
 description = "Runtime leak detector for modern web apps — finds exposed API keys, BaaS misconfigurations (Supabase/Firebase RLS), and secrets in JS bundles, with a Chrome extension for real-time detection."
 authors = ["Amal David <amal@utopianlabs.co>"]
 license = "MIT"
@@ -45,7 +45,7 @@ build-backend = "poetry.core.masonry.api"
 # PEP 621 project table for uv / pip compatibility
 [project]
 name = "keyleak-detector"
-version = "0.5.1"
+version = "0.5.2"
 description = "Runtime leak detector for modern web apps — finds exposed API keys, BaaS misconfigurations (Supabase/Firebase RLS), and secrets in JS bundles."
 requires-python = ">=3.12,<4.0"
 license = {text = "MIT"}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const urlInput = document.getElementById('urlInput');
     const scanButton = document.getElementById('scanButton');
     const extensiveScanButton = document.getElementById('extensiveScanButton');
+    const fullSiteScanButton = document.getElementById('fullSiteScanButton');
     const buttonText = document.getElementById('buttonText');
     const buttonSpinner = document.getElementById('buttonSpinner');
     const resultsSection = document.getElementById('results');
@@ -39,6 +40,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     scanButton.addEventListener('click', () => startScan('basic'));
     extensiveScanButton.addEventListener('click', openExtensiveModal);
+    if (fullSiteScanButton) {
+        fullSiteScanButton.addEventListener('click', () => startScan('full-site'));
+    }
 
     if (closeExtensiveModal) {
         closeExtensiveModal.addEventListener('click', closeExtensiveScanModal);
@@ -221,16 +225,21 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function setLoading(isLoading, scanMode = 'basic') {
+        const label = scanMode === 'extensive' ? 'EXTENSIVE...'
+            : scanMode === 'full-site' ? 'SITE SCAN...'
+            : 'BASIC SCAN';
         if (isLoading) {
             scanButton.disabled = true;
             extensiveScanButton.disabled = true;
-            buttonText.textContent = scanMode === 'extensive' ? 'EXTENSIVE...' : 'BASIC SCAN';
+            if (fullSiteScanButton) fullSiteScanButton.disabled = true;
+            buttonText.textContent = label;
             buttonSpinner.classList.remove('hidden');
             scanButton.classList.remove('hover:bg-emerald-500');
             extensiveScanButton.classList.remove('hover:bg-violet-500');
         } else {
             scanButton.disabled = false;
             extensiveScanButton.disabled = false;
+            if (fullSiteScanButton) fullSiteScanButton.disabled = false;
             buttonText.textContent = 'BASIC SCAN';
             buttonSpinner.classList.add('hidden');
             scanButton.classList.add('hover:bg-emerald-500');
@@ -288,10 +297,30 @@ document.addEventListener('DOMContentLoaded', function() {
             `;
         }
 
-        displayFilters(data.findings || []);
+        // Full Site Scan: show subdomain + page-count summary
+        const subdomains = data.subdomains || (data.report && data.report.subdomains) || [];
+        if (Array.isArray(subdomains) && subdomains.length) {
+            const pages = data.pages_scanned || (data.report && data.report.pages_scanned) || 0;
+            const chip = document.createElement('div');
+            chip.className = 'mt-3 text-xs font-mono text-sky-300 bg-sky-900/20 border border-sky-800 rounded px-3 py-2';
+            chip.innerHTML = `<span class="text-sky-400 font-bold">FULL SITE</span> &middot; ${subdomains.length} subdomain(s) &middot; ${pages} page(s) scanned`
+                + `<div class="text-slate-400 mt-1 break-all">${subdomains.map(escapeHtml).join(', ')}</div>`;
+            scanSummary.appendChild(chip);
+        }
 
-        if (data.findings && data.findings.length > 0) {
-            data.findings.forEach(finding => {
+        const normalizedFindings = data.report && Array.isArray(data.report.findings)
+            ? data.report.findings
+            : (data.findings || []);
+
+        const provenance = data.provenance || (data.report && data.report.provenance) || {};
+
+        displayFilters(normalizedFindings);
+
+        if (normalizedFindings.length > 0) {
+            normalizedFindings.forEach(finding => {
+                if (finding.id && Array.isArray(provenance[finding.id])) {
+                    finding._seenOn = provenance[finding.id];
+                }
                 findingsList.appendChild(renderFinding(finding));
             });
         } else {
@@ -310,8 +339,9 @@ document.addEventListener('DOMContentLoaded', function() {
             title.textContent = 'NO PAGE SECRETS FOUND';
             copy.textContent = 'The verdict includes attack-surface findings. Review the attack vectors below.';
         } else {
-            title.textContent = 'NO SECRETS FOUND';
-            copy.textContent = 'Target appears clean for this scan profile.';
+            const packs = data.report && Array.isArray(data.report.packs) ? data.report.packs.join(', ') : 'selected';
+            title.textContent = 'NO FINDINGS IN COVERED PACKS';
+            copy.textContent = `No findings were detected in the ${packs} pack coverage for this scan profile.`;
         }
 
         noFindings.classList.remove('hidden');
@@ -322,7 +352,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
-        const reportFindings = data.report && Array.isArray(data.report.findings) ? data.report.findings : [];
+        const reportFindings = data.report && Array.isArray(data.report.findings) ? data.report.findings : (data.findings || []);
         const firstFinding = reportFindings[0];
         const verdict = data.verdict || (data.report && data.report.verdict) || {
             label: reportFindings.length ? 'REVIEW' : 'SAFE TO SHIP',
@@ -391,12 +421,39 @@ document.addEventListener('DOMContentLoaded', function() {
             filterDiv.appendChild(btn);
         });
 
+        const packs = Array.from(new Set(findings.map(finding => finding.category).filter(Boolean))).sort();
+        packs.forEach(pack => {
+            const btn = document.createElement('button');
+            btn.className = 'filter-button font-mono border-slate-600 text-slate-300 bg-slate-900/70';
+            btn.dataset.pack = pack;
+            btn.dataset.active = 'true';
+            btn.textContent = pack.toUpperCase();
+            btn.addEventListener('click', () => {
+                const nowActive = btn.dataset.active !== 'true';
+                btn.dataset.active = nowActive ? 'true' : 'false';
+                document.querySelectorAll(`.finding-card.pack-${cssToken(pack)}`).forEach(el => {
+                    el.classList.toggle('filtered-out', !nowActive);
+                });
+            });
+            filterDiv.appendChild(btn);
+        });
+
         resultsFilters.appendChild(filterDiv);
     }
 
     function renderFinding(finding) {
         const findingElement = document.createElement('div');
-        findingElement.className = `p-6 finding-card severity-${finding.severity || 'low'}`;
+        const category = finding.category || 'unknown';
+        findingElement.className = `p-6 finding-card severity-${finding.severity || 'low'} pack-${cssToken(category)}`;
+        const evidence = finding.evidence || {};
+        const redactedValue = evidence.redacted_value || finding.redacted_value || '[redacted]';
+        const source = evidence.source || finding.source || '';
+        const line = evidence.line || finding.line;
+        const snippet = evidence.snippet || finding.context_lines || '';
+        const fix = finding.remediation || finding.recommendation || 'Review and remove exposed sensitive data.';
+        const detectorId = finding.detector_id || '';
+        const confidence = finding.confidence !== undefined ? String(finding.confidence) : '';
+        const validationStatus = finding.validation_status || '';
 
         let severityIcon = '○';
         let severityColor = 'text-blue-400';
@@ -434,14 +491,19 @@ document.addEventListener('DOMContentLoaded', function() {
                     <div>
                         <p class="text-slate-500 text-xs font-mono mb-1">VALUE:</p>
                         <div class="bg-slate-900 border border-slate-700 rounded p-2 overflow-x-auto">
-                            <code class="text-xs font-mono text-emerald-400 break-all">${escapeHtml(finding.value || finding.match || 'N/A')}</code>
+                            <code class="text-xs font-mono text-emerald-400 break-all">${escapeHtml(redactedValue)}</code>
                         </div>
                     </div>
 
-                    ${finding.source ? `<div class="text-xs font-mono break-all"><span class="text-slate-500">SOURCE:</span><span class="text-slate-400 ml-2">${escapeHtml(finding.source)}</span></div>` : ''}
-                    ${finding.line ? `<div class="text-xs font-mono"><span class="text-slate-500">LINE:</span><span class="text-slate-400 ml-2">${finding.line}</span></div>` : ''}
-                    ${finding.context_lines ? `<div><p class="text-slate-500 text-xs font-mono mb-1">CONTEXT:</p><div class="bg-slate-900 rounded p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-slate-400 whitespace-pre"><code>${escapeHtml(finding.context_lines)}</code></pre></div></div>` : ''}
-                    ${finding.recommendation ? `<div class="bg-slate-900/50 border border-slate-700 rounded p-3"><p class="text-slate-500 text-xs font-mono mb-1">FIX:</p><p class="text-slate-400 text-xs leading-relaxed">${escapeHtml(finding.recommendation)}</p></div>` : ''}
+                    ${source ? `<div class="text-xs font-mono break-all"><span class="text-slate-500">SOURCE:</span><span class="text-slate-400 ml-2">${escapeHtml(source)}</span></div>` : ''}
+                    ${Array.isArray(finding._seenOn) && finding._seenOn.length ? `<div class="text-xs font-mono break-all"><span class="text-slate-500">SEEN ON:</span><span class="text-sky-400 ml-2">${finding._seenOn.length} page(s)</span><div class="text-slate-500 mt-1">${finding._seenOn.slice(0, 5).map(escapeHtml).join('<br>')}</div></div>` : ''}
+                    <div class="text-xs font-mono"><span class="text-slate-500">PACK:</span><span class="text-slate-400 ml-2">${escapeHtml(category)}</span></div>
+                    ${detectorId ? `<div class="text-xs font-mono break-all"><span class="text-slate-500">DETECTOR:</span><span class="text-slate-400 ml-2">${escapeHtml(detectorId)}</span></div>` : ''}
+                    ${confidence ? `<div class="text-xs font-mono"><span class="text-slate-500">CONFIDENCE:</span><span class="text-slate-400 ml-2">${escapeHtml(confidence)}</span></div>` : ''}
+                    ${validationStatus ? `<div class="text-xs font-mono"><span class="text-slate-500">STATUS:</span><span class="text-slate-400 ml-2">${escapeHtml(validationStatus)}</span></div>` : ''}
+                    ${line ? `<div class="text-xs font-mono"><span class="text-slate-500">LINE:</span><span class="text-slate-400 ml-2">${line}</span></div>` : ''}
+                    ${snippet ? `<div><p class="text-slate-500 text-xs font-mono mb-1">CONTEXT:</p><div class="bg-slate-900 rounded p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-slate-400 whitespace-pre"><code>${escapeHtml(snippet)}</code></pre></div></div>` : ''}
+                    <div class="bg-slate-900/50 border border-slate-700 rounded p-3"><p class="text-slate-500 text-xs font-mono mb-1">FIX:</p><p class="text-slate-400 text-xs leading-relaxed">${escapeHtml(fix)}</p></div>
                 </div>
             </div>
         `;
@@ -515,7 +577,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         </div>
                         <div class="text-xs font-mono text-slate-500">${escapeHtml((finding.severity || 'low').toUpperCase())}</div>
                     </div>
-                    <div class="mt-2 text-xs text-slate-400 font-mono break-words">${escapeHtml(finding.details || finding.value || '')}</div>
+                    <div class="mt-2 text-xs text-slate-400 font-mono break-words">${escapeHtml(finding.details || finding.redacted_value || '')}</div>
                     ${finding.url ? `
                         <div class="mt-2 text-xs text-slate-500 font-mono break-all">URL: ${escapeHtml(finding.url)}</div>
                     ` : ''}
@@ -574,6 +636,10 @@ document.addEventListener('DOMContentLoaded', function() {
             return 'UNKNOWN';
         }
         return String(type).split('_').join(' ').toUpperCase();
+    }
+
+    function cssToken(value) {
+        return String(value || 'unknown').toLowerCase().replace(/[^a-z0-9_-]/g, '-');
     }
 
     function escapeHtml(text) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,6 +73,17 @@
                                     <p class="text-violet-200 text-xs font-mono leading-relaxed">Use throwaway bearer tokens or session cookies only. Authenticated scans help catch runtime leaks that appear after login.</p>
                                     <p class="text-slate-500 text-xs font-mono leading-relaxed">Everything runs locally. Basic scan stays unauthenticated.</p>
                                 </div>
+                                <button
+                                    id="fullSiteScanButton"
+                                    class="w-full mt-3 bg-sky-600 hover:bg-sky-500 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 font-mono text-sm border border-sky-400/50"
+                                    title="Enumerate subdomains and crawl every page of the domain"
+                                >
+                                    <span aria-hidden="true">SITE</span>
+                                    <span>FULL SITE SCAN (SUBDOMAINS + CRAWL)</span>
+                                </button>
+                                <div class="scanner-helper">
+                                    <p class="text-sky-200 text-xs font-mono leading-relaxed">Enumerates subdomains (crt.sh + DNS) and crawls every page of the domain, then scans each one. This is an active scan &mdash; only run it against systems you own or are authorized to test.</p>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/tests/test_site_scanner.py
+++ b/tests/test_site_scanner.py
@@ -1,0 +1,155 @@
+"""Tests for the Full Site Scan engine (keyleak/site_scanner.py).
+
+All network and browser access is mocked — no real DNS, HTTP, or Playwright.
+Uses unittest to match the repo's existing test style.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import keyleak.site_scanner as ss
+from keyleak.models import Evidence, Finding, ScanReport
+
+
+def _finding(value: str, type_: str = "openai_api_key", sev: str = "critical") -> Finding:
+    return Finding(
+        type=type_,
+        severity=sev,
+        confidence=0.9,
+        detector_id="leak.openai_api_key",
+        source="bundle",
+        evidence=Evidence(source="bundle", redacted_value=value),
+        risk_reason="exposed key",
+        remediation="rotate it",
+    )
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class CrtShTests(unittest.TestCase):
+    def test_parses_filters_and_dedups(self):
+        payload = [
+            {"name_value": "a.example.com\n*.b.example.com"},
+            {"name_value": "example.com\nexample.com"},   # dup + apex
+            {"name_value": "mail@example.com"},            # email — dropped
+            {"name_value": "evil.com\nnotexample.com"},    # out of scope
+        ]
+        with mock.patch.object(ss.requests, "get", return_value=_FakeResp(payload)):
+            out = ss._crt_sh_subdomains("example.com")
+        self.assertIn("a.example.com", out)
+        self.assertIn("b.example.com", out)        # leading "*." stripped
+        self.assertIn("example.com", out)
+        self.assertEqual(out.count("example.com"), 1)
+        self.assertNotIn("evil.com", out)
+        self.assertNotIn("notexample.com", out)
+        self.assertFalse(any("@" in n for n in out))
+
+    def test_degrades_on_network_error(self):
+        with mock.patch.object(ss.requests, "get",
+                               side_effect=ss.requests.RequestException("no net")):
+            self.assertEqual(ss._crt_sh_subdomains("example.com"), [])
+
+
+class DiscoverTests(unittest.TestCase):
+    def test_offline_uses_no_network(self):
+        def fail(*a, **k):
+            raise AssertionError("network must not be touched in offline mode")
+        with mock.patch.object(ss, "_crt_sh_subdomains", fail), \
+             mock.patch.object(ss, "_subfinder_subdomains", fail), \
+             mock.patch.object(ss, "_resolves", fail):
+            self.assertEqual(ss.discover_subdomains("example.com", offline=True),
+                             ["example.com"])
+
+    def test_caps_and_requires_resolution(self):
+        with mock.patch.object(ss, "_subfinder_subdomains", lambda d: []), \
+             mock.patch.object(ss, "_crt_sh_subdomains",
+                               lambda d, **k: [f"s{i}.example.com" for i in range(50)]), \
+             mock.patch.object(ss, "_resolves", lambda h: True):
+            out = ss.discover_subdomains("example.com", max_subdomains=5)
+        self.assertEqual(len(out), 5)
+        self.assertEqual(out[0], "example.com")     # apex leads
+
+
+class FilterLinksTests(unittest.TestCase):
+    def test_scope_dedup_and_normalize(self):
+        seen = {"https://example.com"}
+        links = [
+            "https://example.com/pricing",
+            "https://app.example.com/login",      # subdomain — in registrable scope
+            "https://evil.com/phish",             # out of scope
+            "ftp://example.com/file",             # non-http
+            "https://example.com/pricing#frag",   # dup after normalize
+            "https://example.com/about",
+        ]
+        out = ss._filter_links(links, "example.com", seen, remaining=10)
+        self.assertIn("https://example.com/pricing", out)
+        self.assertIn("https://app.example.com/login", out)
+        self.assertIn("https://example.com/about", out)
+        self.assertTrue(all("evil.com" not in u for u in out))
+        self.assertTrue(all(not u.startswith("ftp") for u in out))
+        self.assertEqual(sum(u == "https://example.com/pricing" for u in out), 1)
+
+    def test_respects_remaining(self):
+        out = ss._filter_links(
+            ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
+            "example.com", set(), remaining=2,
+        )
+        self.assertEqual(len(out), 2)
+
+
+class ScanSiteTests(unittest.TestCase):
+    def test_merges_findings_with_provenance(self):
+        urls = [
+            "https://example.com/",
+            "https://example.com/pricing",
+            "https://api.example.com/",
+        ]
+
+        def fake_scan(url, **kwargs):
+            if url.startswith("https://api."):
+                findings = [_finding("sk-BBB", type_="stripe_secret_key")]
+            else:
+                findings = [_finding("sk-AAA")]
+            return ScanReport(target=url, scan_mode="browser", findings=findings)
+
+        with mock.patch.object(ss, "discover_subdomains",
+                               lambda d, **k: ["example.com", "api.example.com"]), \
+             mock.patch.object(ss, "crawl_pages", lambda hosts, **k: urls), \
+             mock.patch.object(ss, "run_browser_scan", fake_scan):
+            report = ss.scan_site("https://example.com")
+
+        self.assertEqual(len(report.findings), 2)
+        self.assertEqual(report.scan_mode, "full-site")
+        self.assertEqual(report.extra["pages_scanned"], 3)
+        self.assertEqual(report.extra["subdomains"], ["example.com", "api.example.com"])
+
+        prov = report.extra["provenance"]
+        shared = next(f for f in report.findings if f.evidence.redacted_value == "sk-AAA")
+        self.assertEqual(sorted(prov[shared.id]),
+                         ["https://example.com/", "https://example.com/pricing"])
+
+    def test_handles_page_scan_errors(self):
+        def boom(url, **kwargs):
+            raise RuntimeError("playwright exploded")
+
+        with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["example.com"]), \
+             mock.patch.object(ss, "crawl_pages", lambda hosts, **k: ["https://example.com/"]), \
+             mock.patch.object(ss, "run_browser_scan", boom):
+            report = ss.scan_site("example.com")   # must not raise
+        self.assertEqual(report.findings, [])
+        self.assertEqual(report.extra["pages_scanned"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_site_scanner.py
+++ b/tests/test_site_scanner.py
@@ -150,6 +150,23 @@ class ScanSiteTests(unittest.TestCase):
         self.assertEqual(report.findings, [])
         self.assertEqual(report.extra["pages_scanned"], 1)
 
+    def test_normalizes_url_to_registrable_domain(self):
+        captured = {}
+
+        def fake_discover(domain, **kwargs):
+            captured["domain"] = domain
+            return [domain]
+
+        with mock.patch.object(ss, "discover_subdomains", fake_discover), \
+             mock.patch.object(ss, "crawl_pages", lambda hosts, **k: []), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda url, **k: ScanReport(target=url, scan_mode="browser", findings=[])):
+            report = ss.scan_site("https://user:pass@app.example.com:8443/dashboard")
+
+        # Credentials/port stripped, reduced to the registrable domain (eTLD+1).
+        self.assertEqual(captured["domain"], "example.com")
+        self.assertEqual(report.target, "example.com")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds a first-class **Full Site Scan** — subdomain enumeration + crawl-all-pages of a domain — surfaced in both the **web UI** (a new button) and the **CLI** (`keyleak site-scan`), backed by a strengthened `site_scanner` engine.

## Engine (`keyleak/site_scanner.py`)
- **crt.sh certificate-transparency** subdomain discovery (uses existing `requests` — no `subfinder` binary needed), unioned with subfinder-if-present + DNS brute-force, each DNS-verified and capped at `--max-subdomains` (default 25).
- **True multi-level BFS crawl** (the old code never recursed past 1 level), scoped to the registrable domain via `tldextract`, normalized dedup, default **depth 3**, up to **100 pages**.
- **Per-finding provenance** — one finding per `(type, value)`, recording every subdomain/page it appeared on (in `ScanReport.extra`).
- **Progress hook** streamed over the web UI's existing SSE channel; the sync-Playwright engine runs in a thread executor (off the async event loop).

## Surfaces
- **Web UI**: new "FULL SITE SCAN (subdomains + crawl)" button + authorized-use notice; `/scan` accepts `scan_mode=full-site`; results show a subdomain/page-count chip and per-finding "seen on N pages".
- **CLI**: `site-scan` rebranded as Full Site Scan; new `--max-subdomains` and `--launch-profile`.

## Guardrails (defensive posture)
Registrable-domain scope only; hard caps; read-only (crawl + passive scan + existing read-only BaaS probes — no exploitation); `--offline` skips network discovery; "authorized targets only" notice in UI + CLI help.

## Tests & verification
- New `tests/test_site_scanner.py` (8 cases: crt.sh parse/filter/dedup, network-degrade, offline skip, cap+resolution, `_filter_links`, provenance, error-handling) — all pass; existing core suite unaffected.
- **Live end-to-end + browser click-test** against an owned domain: crt.sh discovered apex + `www`, depth-3 BFS reached deep blog pages (6 total), aggregated as `full-site` → `SAFE TO SHIP` with the subdomain chip rendered.

The existing single-page authenticated "Extensive" scan is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/keyleak-detector/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Site Scan mode: subdomain enumeration + multi‑page crawl with provenance and scan-summary metadata.

* **API**
  * Scan endpoint accepts full-site scans and streams progress/results.

* **UI**
  * Full Site Scan button, updated loading states, enriched finding cards (pack/category, seen‑on) and revised “no findings” messaging.

* **Improvements**
  * Higher defaults and caps, offline mode, CLI launch-profile and max-subdomains options.

* **Tests**
  * New unit tests for discovery, link filtering, crawling, provenance merging, and error handling.

* **Docs**
  * README updated with Full Site Scan usage and v0.5.0 notes.

* **Chores**
  * Version bumped to v0.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->