### PR TITLE
Commit missing keyleak modules + sync stale tracked files (repo completeness)

### DIFF
--- a/keyleak/access_control.py
+++ b/keyleak/access_control.py
@@ -1,0 +1,144 @@
+"""Two-user access-control comparison helpers."""
+
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+import re
+from typing import Any, Callable, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from .models import Evidence, Finding
+from .redaction import redact_url
+
+
+_OBJECT_ID_RE = re.compile(
+    r"(?:/(?:users?|accounts?|customers?|tenants?|organizations?|orgs?|projects?|orders?)/[0-9a-fA-F-]{6,}"
+    r"|[?&](?:user|account|customer|tenant|organization|project|order)[_-]?id=[0-9a-fA-F-]{6,})"
+)
+
+
+def compare_access_control_urls(
+    candidate_urls: Iterable[str],
+    user_a_auth: Dict[str, Any],
+    user_b_auth: Optional[Dict[str, Any]],
+    fetch: Callable[..., Any] = requests.get,
+    max_urls: int = 10,
+) -> List[Finding]:
+    """Compare object-looking URLs with two explicit auth contexts."""
+    if not _has_auth(user_a_auth) or not _has_auth(user_b_auth or {}):
+        return []
+
+    findings: List[Finding] = []
+    for url in _candidate_object_urls(candidate_urls)[:max_urls]:
+        try:
+            response_a = fetch(
+                url,
+                headers=_auth_headers(user_a_auth),
+                cookies=_auth_cookies(user_a_auth),
+                timeout=15,
+                allow_redirects=False,
+            )
+            response_b = fetch(
+                url,
+                headers=_auth_headers(user_b_auth or {}),
+                cookies=_auth_cookies(user_b_auth or {}),
+                timeout=15,
+                allow_redirects=False,
+            )
+        except requests.RequestException:
+            continue
+
+        if not _successful(response_a) or not _successful(response_b):
+            continue
+
+        similarity = _body_similarity(getattr(response_a, "text", ""), getattr(response_b, "text", ""))
+        if similarity < 0.85:
+            continue
+
+        safe_url = redact_url(url)
+        evidence = Evidence(
+            source="Two-user access-control comparison",
+            snippet=f"User A and user B both received similar 2xx responses for {safe_url}.",
+            request_url=safe_url,
+            response_status=getattr(response_b, "status_code", None),
+            redacted_value=f"GET {urlparse(url).path} similarity={similarity:.2f}",
+        )
+        findings.append(
+            Finding(
+                type="idor",
+                severity="high",
+                confidence=0.82,
+                detector_id="access-control.two_user_comparison",
+                source="Two-user access-control comparison",
+                evidence=evidence,
+                risk_reason=(
+                    "Two explicit user contexts received similar successful responses for an object-looking URL. "
+                    "This is validated evidence of a possible missing ownership or tenant check."
+                ),
+                remediation=(
+                    "Require server-side ownership checks on this object path, scope queries by tenant/user, "
+                    "and add a negative test proving user B cannot read user A objects."
+                ),
+                validation_status="validated",
+                category="access-control",
+                references=["https://owasp.org/Top10/A01_2021-Broken_Access_Control/"],
+            )
+        )
+
+    return findings
+
+
+def _candidate_object_urls(urls: Iterable[str]) -> List[str]:
+    seen = set()
+    candidates = []
+    for url in urls:
+        text = str(url or "")
+        if text in seen:
+            continue
+        seen.add(text)
+        try:
+            parsed = urlparse(text)
+        except ValueError:
+            continue
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            continue
+        if _OBJECT_ID_RE.search(text):
+            candidates.append(text)
+    return candidates
+
+
+def _has_auth(auth: Dict[str, Any]) -> bool:
+    return bool(str(auth.get("bearer_token") or "").strip() or str(auth.get("cookie") or "").strip())
+
+
+def _auth_headers(auth: Dict[str, Any]) -> Dict[str, str]:
+    bearer = str(auth.get("bearer_token") or "").strip()
+    if bearer:
+        return {"Authorization": f"Bearer {bearer}"}
+    return {}
+
+
+def _auth_cookies(auth: Dict[str, Any]) -> Dict[str, str]:
+    cookie_header = str(auth.get("cookie") or "").strip()
+    cookies: Dict[str, str] = {}
+    for part in cookie_header.split(";"):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        cookies[key.strip()] = value.strip()
+    return cookies
+
+
+def _successful(response: Any) -> bool:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    return 200 <= status_code < 300
+
+
+def _body_similarity(left: str, right: str) -> float:
+    left_sample = str(left or "")[:5000]
+    right_sample = str(right or "")[:5000]
+    if not left_sample and not right_sample:
+        return 1.0
+    return SequenceMatcher(None, left_sample, right_sample).ratio()

--- a/keyleak/access_control.py
+++ b/keyleak/access_control.py
@@ -49,6 +49,9 @@ def compare_access_control_urls(
             )
         except requests.RequestException:
             continue
+        except Exception:
+            # Injectable `fetch` may raise non-requests exceptions; skip the URL.
+            continue
 
         if not _successful(response_a) or not _successful(response_b):
             continue

--- a/keyleak/allowlist_diff.py
+++ b/keyleak/allowlist_diff.py
@@ -1,0 +1,217 @@
+"""Allowlist provenance gate.
+
+A malicious PR pattern: in the same commit, the contributor (a) ships a leaking
+file and (b) edits ``keyleak-allowlist.yaml`` to add a rule that suppresses
+exactly that finding. The launch-gate runs the scan after suppressions are
+applied, so the malicious payload ships green.
+
+This module compares the *added* entries in an allowlist YAML diff against the
+files changed in the same PR. Any added entry whose scope matches a changed
+file (and that would suppress a real finding in that file) is reported as a
+``critical`` self-shield finding.
+
+The intended caller is ``.github/workflows/allowlist-provenance.yml`` which
+runs::
+
+    keyleak allowlist-diff \\
+        --base-allowlist <(git show ${GITHUB_BASE_REF}:keyleak-allowlist.yaml) \\
+        --head-allowlist keyleak-allowlist.yaml \\
+        --changed-files <(git diff --name-only ${GITHUB_BASE_REF}..HEAD)
+
+In tests, the inputs are passed directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import yaml  # PyYAML
+
+from .local_scanner import scan_file
+from .detectors import detectors_for_packs, normalize_packs
+from .models import Evidence, Finding, ScanReport
+from .reporting import build_report, fail_threshold_met, format_json, format_markdown, format_sarif, report_to_text
+
+
+def audit_pr_diff(
+    repo_root: Path,
+    base_allowlist_text: str,
+    head_allowlist_text: str,
+    changed_files: Sequence[Path],
+) -> ScanReport:
+    """Return a ScanReport containing any same-PR self-shield findings."""
+
+    repo_root = Path(repo_root).resolve()
+    added = _added_entries(base_allowlist_text, head_allowlist_text)
+
+    detectors = list(detectors_for_packs(normalize_packs(None, profile="ci")))
+
+    self_shield: List[Finding] = []
+    for entry in added:
+        for file_path in changed_files:
+            abs_path = (repo_root / file_path).resolve()
+            if not _is_safe_under_root(abs_path, repo_root):
+                continue
+            if not abs_path.is_file():
+                continue
+            # Skip the allowlist itself.
+            if abs_path.name.startswith("keyleak-allowlist"):
+                continue
+
+            if not _entry_matches_path(entry, file_path):
+                continue
+
+            findings = scan_file(abs_path, detectors)
+            for finding in findings:
+                if _entry_suppresses(entry, finding):
+                    self_shield.append(_self_shield_finding(entry, file_path, finding))
+
+    return build_report(
+        str(repo_root),
+        self_shield,
+        scan_mode="allowlist-diff",
+        profile="allowlist-diff",
+        packs=["allowlist-diff"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _added_entries(base_text: str, head_text: str) -> List[Dict[str, Any]]:
+    base = _entries_set(base_text)
+    head_entries = _entries_list(head_text)
+    return [entry for entry in head_entries if _entry_key(entry) not in base]
+
+
+def _entries_set(text: str) -> set:
+    return {_entry_key(entry) for entry in _entries_list(text)}
+
+
+def _entries_list(text: str) -> List[Dict[str, Any]]:
+    if not text.strip():
+        return []
+    data = yaml.safe_load(text) or {}
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("entries") or []
+    return [entry for entry in raw if isinstance(entry, dict)]
+
+
+def _entry_key(entry: Dict[str, Any]) -> str:
+    return "|".join([
+        str(entry.get("id") or ""),
+        str(entry.get("detector") or ""),
+        str(entry.get("type") or ""),
+        str(entry.get("source_contains") or ""),
+    ])
+
+
+def _is_safe_under_root(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _entry_matches_path(entry: Dict[str, Any], file_path: Path) -> bool:
+    source_contains = entry.get("source_contains")
+    if source_contains:
+        return source_contains.lower() in str(file_path).lower()
+    # Entries with only `id`/`detector`/`type` apply repo-wide. We assume yes
+    # and let the finding-level match decide.
+    return True
+
+
+def _entry_suppresses(entry: Dict[str, Any], finding: Finding) -> bool:
+    entry_detector = (entry.get("detector") or "").strip()
+    entry_type = (entry.get("type") or "").strip()
+    entry_source = (entry.get("source_contains") or "").strip().lower()
+    entry_id = (entry.get("id") or "").strip()
+
+    if entry_id and entry_id == finding.id:
+        return True
+    if entry_detector and entry_detector == finding.detector_id:
+        return True
+    if entry_type and entry_type == finding.type:
+        return True
+    if entry_source and entry_source in finding.source.lower():
+        return True
+    return False
+
+
+def _self_shield_finding(entry: Dict[str, Any], file_path: Path, finding: Finding) -> Finding:
+    snippet = (
+        f"entry={entry.get('detector') or entry.get('source_contains') or entry.get('id')} "
+        f"suppresses {finding.detector_id} in {file_path}"
+    )
+    return Finding(
+        type="allowlist_self_shield",
+        severity="critical",
+        confidence=0.99,
+        detector_id="allowlist_diff.self_shield",
+        source=str(file_path),
+        evidence=Evidence(
+            source=str(file_path),
+            snippet=snippet,
+            line=finding.evidence.line,
+            redacted_value=finding.evidence.redacted_value,
+        ),
+        risk_reason=(
+            "A new allowlist entry was added in the same PR that introduced a finding the entry "
+            "now suppresses. This is the supply-chain-on-the-tool pattern — a single PR cannot "
+            "both ship a payload and grant itself a waiver."
+        ),
+        remediation=(
+            "Either remove the new allowlist entry, remove the leaking file, or open a separate "
+            "PR that adds the allowlist entry first and gets an `allowlist-approved` label from a "
+            "CODEOWNER outside the PR author's org."
+        ),
+        validation_status="validated",
+        category="allowlist-diff",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (used by .github/workflows/allowlist-provenance.yml)
+# ---------------------------------------------------------------------------
+
+
+def cli_main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="keyleak allowlist-diff")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--base-allowlist", required=True, help="Path to allowlist YAML before the PR (use /dev/stdin or a file).")
+    parser.add_argument("--head-allowlist", required=True, help="Path to allowlist YAML after the PR.")
+    parser.add_argument("--changed-files", required=True, help="Path to a file listing one changed path per line.")
+    parser.add_argument("--fail-on", default="critical", choices=["low", "medium", "high", "critical"])
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--sarif", action="store_true")
+    parser.add_argument("--markdown", action="store_true")
+    args = parser.parse_args(argv)
+
+    base_text = Path(args.base_allowlist).read_text(encoding="utf-8") if args.base_allowlist != "/dev/null" else ""
+    head_text = Path(args.head_allowlist).read_text(encoding="utf-8")
+    changed = [Path(line.strip()) for line in Path(args.changed_files).read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    report = audit_pr_diff(Path(args.repo_root), base_text, head_text, changed)
+
+    if args.json:
+        print(format_json(report))
+    elif args.sarif:
+        print(format_sarif(report))
+    elif args.markdown:
+        print(format_markdown(report))
+    else:
+        print(report_to_text(report))
+
+    return 2 if fail_threshold_met(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/keyleak/archive_scanner.py
+++ b/keyleak/archive_scanner.py
@@ -1,0 +1,110 @@
+"""Time-machine archive scanner (Wave 3.1).
+
+Scans an existing deployment archive (a tarball, zip, or pre-extracted dir)
+to answer the IR question: *what shipped to prod on date X?* Wraps the
+findings in a chain-of-custody envelope so the artifact is defensible.
+
+Supported inputs:
+- ``.tar.gz`` / ``.tgz`` / ``.tar`` tarballs.
+- ``.zip`` archives.
+- Pre-extracted directories.
+
+Out of scope (intentionally): S3 / Vercel / Netlify API integration. Those
+sit on top of this module via small wrappers; this module is the engine.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+from .chain_of_custody import build_envelope
+from .local_scanner import scan_path
+from .models import ScanReport
+
+
+class ArchiveScanError(RuntimeError):
+    pass
+
+
+def extract_archive(archive_path: Path, dest: Path) -> Path:
+    """Extract ``archive_path`` into ``dest``. Returns the directory used."""
+
+    archive_path = Path(archive_path)
+    if archive_path.is_dir():
+        return archive_path
+
+    suffixes = "".join(archive_path.suffixes).lower()
+    if archive_path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            _safe_extract_zip(zf, dest)
+        return dest
+
+    if archive_path.suffix.lower() in {".tar", ".tgz"} or suffixes.endswith(".tar.gz") or suffixes.endswith(".tar.bz2"):
+        with tarfile.open(archive_path) as tf:
+            _safe_extract_tar(tf, dest)
+        return dest
+
+    raise ArchiveScanError(f"Unsupported archive format: {archive_path}")
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
+    dest = dest.resolve()
+    for info in zf.infolist():
+        target = (dest / info.filename).resolve()
+        if not str(target).startswith(str(dest)):
+            raise ArchiveScanError(f"Path traversal in zip entry: {info.filename}")
+    zf.extractall(dest)
+
+
+def _safe_extract_tar(tf: tarfile.TarFile, dest: Path) -> None:
+    dest = dest.resolve()
+    for member in tf.getmembers():
+        target = (dest / member.name).resolve()
+        if not str(target).startswith(str(dest)):
+            raise ArchiveScanError(f"Path traversal in tar entry: {member.name}")
+    # Python 3.12+: pass filter='data' for additional safety. We resolve paths
+    # ourselves above; the filter argument is a defense-in-depth.
+    try:
+        tf.extractall(dest, filter="data")
+    except TypeError:
+        tf.extractall(dest)
+
+
+def scan_archive(
+    archive_path: str,
+    *,
+    as_of: Optional[str] = None,
+    profile: str = "ci",
+    signer: str = "anonymous",
+    prev_hash: str = "",
+) -> dict:
+    """Scan ``archive_path`` and return a chain-of-custody envelope.
+
+    ``as_of`` is informational metadata stored on the envelope (e.g. the
+    deploy timestamp the archive represents); it does not influence scan
+    semantics.
+    """
+
+    archive = Path(archive_path).expanduser().resolve()
+    if not archive.exists():
+        raise ArchiveScanError(f"Archive not found: {archive}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        extracted = extract_archive(archive, Path(tmp))
+        report: ScanReport = scan_path(str(extracted), profile=profile)
+
+    report_dict = report.to_dict()
+    report_dict["archive_path"] = str(archive)
+    report_dict["scan_mode"] = "archive"
+    if as_of:
+        report_dict["as_of"] = as_of
+
+    return build_envelope(
+        report_dict,
+        prev_hash=prev_hash,
+        signer=signer,
+    )

--- a/keyleak/archive_scanner.py
+++ b/keyleak/archive_scanner.py
@@ -55,7 +55,9 @@ def _safe_extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
     dest = dest.resolve()
     for info in zf.infolist():
         target = (dest / info.filename).resolve()
-        if not str(target).startswith(str(dest)):
+        try:
+            target.relative_to(dest)
+        except ValueError:
             raise ArchiveScanError(f"Path traversal in zip entry: {info.filename}")
     zf.extractall(dest)
 
@@ -64,7 +66,9 @@ def _safe_extract_tar(tf: tarfile.TarFile, dest: Path) -> None:
     dest = dest.resolve()
     for member in tf.getmembers():
         target = (dest / member.name).resolve()
-        if not str(target).startswith(str(dest)):
+        try:
+            target.relative_to(dest)
+        except ValueError:
             raise ArchiveScanError(f"Path traversal in tar entry: {member.name}")
     # Python 3.12+: pass filter='data' for additional safety. We resolve paths
     # ourselves above; the filter argument is a defense-in-depth.

--- a/keyleak/chain_of_custody.py
+++ b/keyleak/chain_of_custody.py
@@ -1,0 +1,121 @@
+"""Chain-of-custody envelope for KeyLeak reports.
+
+Wraps a :class:`~keyleak.models.ScanReport` with a hash-chained signature so
+the report becomes legally defensible: identifier, timestamp, finding hash,
+previous-record hash, and (optionally) a cryptographic signature. The same
+envelope is used by Wave 3.1 (time-machine archive scans) and the Wave 1.7
+disclosure flow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+COC_HMAC_KEY_ENV = "KEYLEAK_COC_KEY"
+
+
+def canonical_findings_bytes(report_dict: Dict[str, Any]) -> bytes:
+    """Deterministic serialization of just the findings list."""
+
+    findings = report_dict.get("findings") or []
+    return json.dumps(findings, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def findings_sha256(report_dict: Dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_findings_bytes(report_dict)).hexdigest()
+
+
+def build_envelope(
+    report_dict: Dict[str, Any],
+    *,
+    prev_hash: str = "",
+    signer: str = "anonymous",
+    signature_mode: str = "hmac-sha256",
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build the chain-of-custody envelope for ``report_dict``.
+
+    Returns a dict shaped like::
+
+        {
+          "version": "1",
+          "envelope": "keyleak.chain_of_custody",
+          "generated_at": "...",
+          "signer": "...",
+          "prev_hash": "...",
+          "findings_sha256": "...",
+          "self_hash": "...",
+          "signature_mode": "hmac-sha256" | "none",
+          "signature": "...",
+          "report": <original report dict>
+        }
+
+    ``self_hash`` is HMAC-SHA256 over ``prev_hash + findings_sha256 +
+    generated_at + signer``. The signature is HMAC-SHA256 over ``self_hash``
+    when ``signature_mode == 'hmac-sha256'``.
+    """
+
+    generated_at = (now or datetime.now(timezone.utc)).isoformat()
+    digest = findings_sha256(report_dict)
+
+    self_payload = f"{prev_hash}|{digest}|{generated_at}|{signer}".encode("utf-8")
+    self_hash = hashlib.sha256(self_payload).hexdigest()
+
+    signature = ""
+    if signature_mode == "hmac-sha256":
+        key = os.environ.get(COC_HMAC_KEY_ENV)
+        if not key:
+            signature_mode = "none"
+        else:
+            signature = hmac.new(key.encode("utf-8"), self_hash.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    return {
+        "version": "1",
+        "envelope": "keyleak.chain_of_custody",
+        "generated_at": generated_at,
+        "signer": signer,
+        "prev_hash": prev_hash,
+        "findings_sha256": digest,
+        "self_hash": self_hash,
+        "signature_mode": signature_mode,
+        "signature": signature,
+        "report": report_dict,
+    }
+
+
+def verify_envelope(envelope: Dict[str, Any]) -> bool:
+    """Verify ``envelope``'s self-hash + signature.
+
+    Returns True if every check passes:
+    - Recomputed self_hash matches the embedded one.
+    - HMAC signature verifies under ``KEYLEAK_COC_KEY`` (if mode is hmac).
+    - ``findings_sha256`` matches the embedded report.
+    """
+
+    report = envelope.get("report") or {}
+    digest = findings_sha256(report)
+    if digest != envelope.get("findings_sha256"):
+        return False
+
+    self_payload = f"{envelope.get('prev_hash', '')}|{digest}|{envelope.get('generated_at', '')}|{envelope.get('signer', '')}".encode("utf-8")
+    expected_self_hash = hashlib.sha256(self_payload).hexdigest()
+    if expected_self_hash != envelope.get("self_hash"):
+        return False
+
+    mode = envelope.get("signature_mode") or "none"
+    sig = envelope.get("signature") or ""
+    if mode == "none":
+        return not sig
+    if mode == "hmac-sha256":
+        key = os.environ.get(COC_HMAC_KEY_ENV)
+        if not key:
+            return False
+        expected = hmac.new(key.encode("utf-8"), expected_self_hash.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, sig.strip().lower())
+    return False

--- a/keyleak/demo.py
+++ b/keyleak/demo.py
@@ -1,0 +1,44 @@
+"""`keyleak demo` — first-finding-in-60-seconds onboarding.
+
+Runs ``keyleak local`` against the bundled vulnerable fixture
+(``fixtures/vulnerable-demo/``) and prints a redacted Markdown report. The
+goal is "pip install → first real finding" without the user having to point
+KeyLeak at their own repo.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from .local_scanner import scan_path
+from .reporting import format_markdown, report_to_text
+
+
+FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "vulnerable-demo"
+
+
+def cli_main(args) -> int:
+    target = Path(getattr(args, "path", "") or FIXTURE_PATH)
+    if not target.is_dir():
+        print(
+            f"demo fixture not found at {target}.\n"
+            "Pass --path to point at any directory you want to demo against.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"KeyLeak demo: scanning {target}\n")
+    report = scan_path(str(target), profile="ci")
+    if getattr(args, "markdown", False):
+        print(format_markdown(report))
+    else:
+        print(report_to_text(report))
+        print()
+        print(
+            "Next steps:\n"
+            "  - `keyleak local . --launch-profile ci --fail-on high` against your own repo.\n"
+            "  - `keyleak self-audit .` to harden the launch-gate workflow itself.\n"
+            "  - `keyleak explain <detector_id>` to see remediation guidance.\n"
+        )
+    return 0

--- a/keyleak/detectors_ast.py
+++ b/keyleak/detectors_ast.py
@@ -1,0 +1,170 @@
+"""Behavioral worm-shape detector (Wave 2.2).
+
+Catches the Mini Shai-Hulud capability triad inside an npm install script
+(``prepare``/``preinstall``/``postinstall``) or in any JS/TS file under
+``node_modules/.../*.js``:
+
+  (a) **env-var read** matching ``/TOKEN|SECRET|KEY|NPM|GH|AWS|OIDC/``
+  (b) **network egress**: ``fetch``, ``https`` / ``http``, ``dgram``,
+      ``child_process.spawn`` of ``curl`` / ``wget`` / ``nc`` / ``python``
+  (c) **persistence write** to ``~/.config``, ``~/Library/LaunchAgents``,
+      ``~/.local/share``, ``~/.ssh``, ``/etc/systemd``
+
+If a single source exhibits all three within ``MAX_CAPABILITY_WINDOW_LINES``
+of each other, it is flagged as ``critical`` regardless of which specific
+strings or hostnames are used. This is behavioral coverage — the next worm
+variant can rotate every string and still trip the triad.
+
+The detector is intentionally syntactic-not-semantic. We don't try to follow
+imports or evaluate conditionals. A real worm has all three capabilities in
+the same file; that's the bar this guard enforces.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+MAX_CAPABILITY_WINDOW_LINES = 200  # generous window — variants stretch the payload
+
+
+# ----- Capability detectors (each finds one shape, returns line numbers) -----
+
+_ENV_READ_RE = re.compile(
+    r"(?:process\.env|os\.environ|getenv|Deno\.env|Bun\.env)"
+    r"[\.\[]"
+    r"['\"]?"
+    r"([A-Za-z0-9_-]*(?:TOKEN|SECRET|KEY|NPM|GH|GITHUB|AWS|OIDC|CREDENTIAL|API)[A-Za-z0-9_-]*)"
+    r"['\"]?",
+    re.IGNORECASE,
+)
+
+_NET_EGRESS_RE = re.compile(
+    r"\b(?:"
+    r"fetch\s*\(|"
+    r"axios\s*\.|"
+    r"https?\.request\s*\(|"
+    r"require\(['\"]https?['\"]\)|"
+    r"import\s+[\w*\s{},]+from\s+['\"]https?['\"]|"
+    r"require\(['\"]dgram['\"]\)|"
+    r"net\.(?:connect|createConnection)\s*\(|"
+    r"child_process[\s\S]{0,40}(?:spawn|exec)\s*\(\s*['\"](?:curl|wget|nc|python|python3|sh|bash)['\"]"
+    r")"
+)
+
+_PERSISTENCE_WRITE_RE = re.compile(
+    r"(?:fs|node:fs)[\s\S]{0,40}(?:writeFile|appendFile|createWriteStream|"
+    r"writeFileSync|appendFileSync)[\s\S]{0,200}?"
+    r"(?:"
+    r"~/\.config|~/Library/LaunchAgents|~/Library/LaunchDaemons|"
+    r"~/\.local/share|~/\.ssh|~/\.aws/credentials|"
+    r"/etc/systemd|com\.user\.[\w.-]+\.plist"
+    r")",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class CapabilityHit:
+    capability: str  # "env_read" | "net_egress" | "persistence_write"
+    line: int
+    excerpt: str
+
+
+def find_capabilities(text: str) -> List[CapabilityHit]:
+    """Return every capability hit in ``text`` with its line number."""
+
+    hits: List[CapabilityHit] = []
+    for capability, regex in (
+        ("env_read", _ENV_READ_RE),
+        ("net_egress", _NET_EGRESS_RE),
+        ("persistence_write", _PERSISTENCE_WRITE_RE),
+    ):
+        for match in regex.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            excerpt = _line_at(text, match.start())
+            hits.append(CapabilityHit(capability=capability, line=line, excerpt=excerpt))
+    return hits
+
+
+@dataclass(frozen=True)
+class WormShapeMatch:
+    source: str
+    env_read_line: int
+    net_egress_line: int
+    persistence_write_line: int
+    excerpt_window: str
+
+
+def detect_worm_shape(text: str, source: str) -> Optional[WormShapeMatch]:
+    """Return a ``WormShapeMatch`` if env-read + net-egress + write coexist."""
+
+    hits = find_capabilities(text)
+    by_cap = {"env_read": [], "net_egress": [], "persistence_write": []}
+    for hit in hits:
+        by_cap[hit.capability].append(hit)
+
+    if not all(by_cap.values()):
+        return None
+
+    # Look for any window of size MAX_CAPABILITY_WINDOW_LINES that contains
+    # at least one hit from each capability. Earliest-line combination wins.
+    for env_hit in by_cap["env_read"]:
+        for net_hit in by_cap["net_egress"]:
+            for write_hit in by_cap["persistence_write"]:
+                lines = [env_hit.line, net_hit.line, write_hit.line]
+                if max(lines) - min(lines) <= MAX_CAPABILITY_WINDOW_LINES:
+                    window_start = min(lines)
+                    window_end = max(lines)
+                    excerpt = _slice_lines(text, window_start, window_end)
+                    return WormShapeMatch(
+                        source=source,
+                        env_read_line=env_hit.line,
+                        net_egress_line=net_hit.line,
+                        persistence_write_line=write_hit.line,
+                        excerpt_window=excerpt,
+                    )
+    return None
+
+
+# ----- Integration helpers used by ``scan_file`` ----------------------------
+
+_TARGET_SUFFIXES = (".js", ".mjs", ".cjs", ".ts", ".tsx", ".sh", ".py")
+
+
+def is_worm_shape_target(path: Path) -> bool:
+    """Whether the AST detector should run on ``path``.
+
+    Targets: any source file under ``node_modules/`` or any file named
+    ``package.json`` (because ``scripts.prepare`` literal strings count).
+    """
+
+    full = str(path).replace("\\", "/")
+    if path.name == "package.json":
+        return True
+    parts_lower = [part.lower() for part in path.parts]
+    if "node_modules" in parts_lower and path.suffix.lower() in _TARGET_SUFFIXES:
+        return True
+    if "/node_modules/" in full and path.suffix.lower() in _TARGET_SUFFIXES:
+        return True
+    return False
+
+
+# ----- Internals -----------------------------------------------------------
+
+def _line_at(text: str, offset: int, radius: int = 80) -> str:
+    """Return a short snippet centered on ``offset``."""
+
+    start = max(0, offset - radius)
+    end = min(len(text), offset + radius)
+    return text[start:end].replace("\n", " ").strip()
+
+
+def _slice_lines(text: str, start_line: int, end_line: int) -> str:
+    lines = text.splitlines()
+    start = max(0, start_line - 1)
+    end = min(len(lines), end_line)
+    return "\n".join(lines[start:end])

--- a/keyleak/detectors_dynamic.py
+++ b/keyleak/detectors_dynamic.py
@@ -1,0 +1,89 @@
+"""Dynamic IOC detector loader (Wave 3.2).
+
+Loads a signed manifest from disk (typically written by ``keyleak feed sync``)
+and converts the per-package IOC entries into :class:`Detector` instances
+that the existing scanner pipeline can use without any further plumbing.
+
+Each manifest entry produces one regex that matches the package@version pair
+in lockfiles (``package-lock.json``, ``yarn.lock``, ``pnpm-lock.yaml``,
+``requirements.txt``, ``poetry.lock``, ``Pipfile.lock``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .detectors import Detector
+from .feeds import verify_manifest
+
+
+DEFAULT_MANIFEST_PATH = Path(__file__).parent / "data" / "ioc_feed.json"
+
+
+def load_dynamic_detectors(
+    manifest_path: Optional[Path] = None,
+    *,
+    require_signature: bool = False,
+) -> List[Detector]:
+    """Return Detector instances built from a signed IOC manifest."""
+
+    path = Path(manifest_path) if manifest_path else DEFAULT_MANIFEST_PATH
+    if not path.is_file():
+        return []
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if require_signature and not verify_manifest(document):
+        raise ValueError(f"signature verification failed for {path}")
+
+    entries = document.get("entries") or []
+    detectors: List[Detector] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        pkg = entry.get("package")
+        if not pkg:
+            continue
+        eco = entry.get("ecosystem") or "npm"
+        versions = entry.get("versions") or []
+        pattern = _build_pattern(pkg, versions, eco)
+        if not pattern:
+            continue
+        advisory_id = str(entry.get("id") or "MAL-UNKNOWN").lower().replace("-", "_")
+        detector = Detector(
+            id=f"ioc_{advisory_id}",
+            pattern=pattern,
+            severity="critical",
+            description=f"Malicious package match: {pkg} via {entry.get('id') or 'IOC feed'}.",
+            remediation=(
+                "Remove the package immediately. Rotate every credential reachable from the "
+                "install step. Audit egress logs."
+            ),
+            categories=["env", "ci", "docker", "code", "config"],
+            min_match_length=4,
+            pack="leak",
+            validation_status="validated",
+            references=tuple(entry.get("references") or ()),
+            extension=False,  # CLI-only; the bundle stays small
+            attack_scenario=str(entry.get("summary") or ""),
+        )
+        detectors.append(detector)
+    return detectors
+
+
+def _build_pattern(pkg: str, versions: Iterable[str], ecosystem: str) -> str:
+    """Build a regex that matches the package@version pair in common lockfiles."""
+
+    quoted_pkg = re.escape(pkg)
+    versions = [str(v) for v in versions]
+    if not versions:
+        # No specific versions provided — match any usage of the package name
+        # in a lockfile context. Conservative: only match in JSON-like contexts.
+        return rf"\"{quoted_pkg}\"\s*:\s*\""
+    version_alt = "|".join(re.escape(v) for v in versions)
+    if ecosystem.lower() == "npm":
+        # npm lockfile entries: "@x/y": { "version": "1.0.0" } OR "@x/y@1.0.0"
+        return rf"\"{quoted_pkg}\"[\s\S]{{0,80}}\"version\"\s*:\s*\"(?:{version_alt})\""
+    # Generic fallback for other ecosystems.
+    return rf"\b{quoted_pkg}\b[\s,=<>:@]+(?:{version_alt})\b"

--- a/keyleak/detectors_fuzzy.py
+++ b/keyleak/detectors_fuzzy.py
@@ -1,0 +1,211 @@
+"""Fuzzy content fingerprint detector (Wave 2.3).
+
+The string-IOC pack has a 7-day half-life — attackers rotate the C2 hostname,
+the file name, and the embedded comment within hours of a wave breaking.
+What changes more slowly is the *shape* of the payload itself: the same
+loader, the same data-exfil branch, the same persistence block.
+
+This module fingerprints candidate scripts against a small corpus of known-bad
+payloads. Two strategies coexist:
+
+- **Exact normalized SHA256**: strip whitespace / comments / quoted strings,
+  lowercase identifiers, then SHA256. Catches the byte-identical re-uploaded
+  variant.
+- **Shingle Jaccard similarity**: tokenize the normalized text into 8-character
+  shingles, compare the set against each corpus entry. A Jaccard score above
+  the threshold (default 0.70) flags a renamed-strings variant.
+
+The corpus ships signed (HMAC over canonical JSON) in
+``keyleak/data/worm_fingerprints.json``. Without the matching key, loading
+the corpus emits a clear warning; the corpus is published so downstream users
+can verify integrity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+SHINGLE_SIZE = 8
+DEFAULT_SIMILARITY_THRESHOLD = 0.70
+
+FINGERPRINT_HMAC_KEY_ENV = "KEYLEAK_FINGERPRINTS_KEY"
+FINGERPRINT_CORPUS_PATH = Path(__file__).parent / "data" / "worm_fingerprints.json"
+
+
+# ---------------------------------------------------------------------------
+# Normalization + shingle helpers
+# ---------------------------------------------------------------------------
+
+_COMMENT_LINE_RE = re.compile(r"//.*$|#.*$", re.MULTILINE)
+_COMMENT_BLOCK_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_STRING_LITERAL_RE = re.compile(r"\"[^\"]*\"|'[^']*'|`[^`]*`")
+_NON_TOKEN_RE = re.compile(r"[^a-z0-9]+")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_for_fingerprint(text: str) -> str:
+    """Strip comments + quoted strings, lowercase, collapse whitespace.
+
+    Two payloads that differ only in their embedded C2 host string normalize
+    to the same byte sequence.
+    """
+
+    out = _COMMENT_BLOCK_RE.sub(" ", text)
+    out = _COMMENT_LINE_RE.sub(" ", out)
+    out = _STRING_LITERAL_RE.sub('""', out)
+    out = out.lower()
+    out = _WHITESPACE_RE.sub(" ", out)
+    return out.strip()
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def normalized_sha256(text: str) -> str:
+    return sha256_hex(normalize_for_fingerprint(text))
+
+
+def shingle_set(text: str, size: int = SHINGLE_SIZE) -> set:
+    """Return the set of ``size``-character shingles over the normalized text."""
+
+    normalized = normalize_for_fingerprint(text)
+    if len(normalized) < size:
+        return {normalized}
+    return {normalized[i : i + size] for i in range(len(normalized) - size + 1)}
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 1.0
+    intersection = len(a & b)
+    union = len(a | b)
+    return intersection / union if union else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Corpus + signed manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WormFingerprint:
+    name: str
+    description: str
+    references: List[str]
+    normalized_sha256: str
+    shingles: List[str]
+
+
+@dataclass(frozen=True)
+class FingerprintHit:
+    name: str
+    description: str
+    references: List[str]
+    matched: str  # "exact" | "fuzzy"
+    score: float  # 1.0 for exact, jaccard score for fuzzy
+
+
+def load_corpus(path: Optional[Path] = None, *, require_signature: bool = False) -> List[WormFingerprint]:
+    """Load and verify the worm-fingerprint corpus.
+
+    If ``require_signature`` is true (or KEYLEAK_FINGERPRINTS_KEY is set), the
+    corpus signature is verified via HMAC-SHA256.
+    """
+
+    path = path or FINGERPRINT_CORPUS_PATH
+    if not path.is_file():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return []
+
+    entries = data.get("entries") or []
+    if not isinstance(entries, list):
+        return []
+
+    key = os.environ.get(FINGERPRINT_HMAC_KEY_ENV)
+    signature = data.get("signature") or ""
+    if require_signature or key:
+        canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        if not key:
+            raise ValueError(
+                "fingerprint corpus signature verification requires "
+                f"{FINGERPRINT_HMAC_KEY_ENV} env var"
+            )
+        expected = hmac.new(key.encode("utf-8"), canonical, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, signature.strip().lower()):
+            raise ValueError("fingerprint corpus signature mismatch")
+
+    return [
+        WormFingerprint(
+            name=entry.get("name") or "",
+            description=entry.get("description") or "",
+            references=list(entry.get("references") or []),
+            normalized_sha256=entry.get("normalized_sha256") or "",
+            shingles=list(entry.get("shingles") or []),
+        )
+        for entry in entries
+        if isinstance(entry, dict)
+    ]
+
+
+def sign_corpus_entries(entries: List[dict], key: str) -> str:
+    """Helper used by tests + the build tooling."""
+
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(key.encode("utf-8"), canonical, hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def match_fingerprints(
+    text: str,
+    corpus: List[WormFingerprint],
+    *,
+    threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> List[FingerprintHit]:
+    """Return any fingerprint that matches ``text`` either exactly or fuzzily."""
+
+    if not corpus:
+        return []
+
+    normalized_hash = normalized_sha256(text)
+    candidate_shingles = shingle_set(text)
+
+    hits: List[FingerprintHit] = []
+    for entry in corpus:
+        if entry.normalized_sha256 and entry.normalized_sha256 == normalized_hash:
+            hits.append(
+                FingerprintHit(
+                    name=entry.name,
+                    description=entry.description,
+                    references=list(entry.references),
+                    matched="exact",
+                    score=1.0,
+                )
+            )
+            continue
+        if entry.shingles:
+            score = jaccard(candidate_shingles, set(entry.shingles))
+            if score >= threshold:
+                hits.append(
+                    FingerprintHit(
+                        name=entry.name,
+                        description=entry.description,
+                        references=list(entry.references),
+                        matched="fuzzy",
+                        score=score,
+                    )
+                )
+    return hits

--- a/keyleak/detectors_splittoken.py
+++ b/keyleak/detectors_splittoken.py
@@ -1,0 +1,182 @@
+"""Cross-file split-token reassembly detector (Wave 3.4).
+
+Every existing detector in :mod:`keyleak.detectors` runs against a single
+file. An attacker who knows that defeats the regex by splitting:
+
+    // a.ts
+    const part1 = "ghp_aBcD";
+    // b.ts
+    const part2 = "EfGhI1234567890abcdef1234567";
+
+at runtime the bundle does ``part1 + part2`` and a valid ``ghp_*`` shows up
+in the browser. None of the current detectors catch this — both files look
+benign on their own.
+
+This module collects every >=12-char alphanumeric fragment across a set of
+files and checks whether any concatenation (in either order, with no
+separator) starts with a known key prefix (``ghp_``, ``sk-``, ``AKIA``,
+``xoxb-``, ``eyJ``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+# Fragments must be at least this long to be considered. Shorter fragments
+# produce too many false-positive concatenations.
+MIN_FRAGMENT_LENGTH = 12
+# Known key prefixes; the concatenation must START with one of these for a
+# match. We intentionally don't try to enforce the full token shape — the
+# downstream Finding directs the dev to verify.
+KEY_PREFIXES: Tuple[str, ...] = (
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "sk-",
+    "sk_live_",
+    "sk_test_",
+    "rk_live_",
+    "AKIA",
+    "ASIA",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxr-",
+    "xoxs-",
+    "eyJ",
+    "glpat-",
+    "AIza",
+    "hf_",
+    "r8_",
+    "pplx-",
+    "gsk_",
+    "esecret_",
+    "npm_",
+    "SG.",
+    "pypi-AgEI",
+)
+
+
+_FRAGMENT_RE = re.compile(r"[A-Za-z0-9_-]{%d,}" % MIN_FRAGMENT_LENGTH)
+
+
+@dataclass(frozen=True)
+class Fragment:
+    file: str
+    line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class SplitTokenMatch:
+    prefix: str
+    fragment_a: Fragment
+    fragment_b: Fragment
+    assembled: str  # truncated at 80 chars for the report
+
+
+def extract_fragments(text: str, file: str, *, min_length: int = MIN_FRAGMENT_LENGTH) -> List[Fragment]:
+    """Return every >=``min_length`` alphanumeric fragment in ``text``."""
+
+    fragments: List[Fragment] = []
+    for match in _FRAGMENT_RE.finditer(text):
+        if len(match.group(0)) < min_length:
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        fragments.append(Fragment(file=file, line=line, text=match.group(0)))
+    return fragments
+
+
+def collect_fragments(files: Iterable[Path]) -> Dict[str, List[Fragment]]:
+    """Walk ``files`` and return ``{prefix_seen_as_substring: [Fragment...]}``.
+
+    We index by fragment text so the reassembly step is O(F^2) over fragments
+    rather than O(file^2 * fragment^2).
+    """
+
+    by_file: Dict[str, List[Fragment]] = {}
+    for path in files:
+        try:
+            text = Path(path).read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        by_file[str(path)] = extract_fragments(text, str(path))
+    return by_file
+
+
+def find_split_tokens(
+    fragments_by_file: Dict[str, List[Fragment]],
+    *,
+    prefixes: Tuple[str, ...] = KEY_PREFIXES,
+) -> List[SplitTokenMatch]:
+    """Return every pair (a, b) across distinct files where ``a.text + b.text``
+    starts with a known key prefix.
+
+    Fast path: a fragment can only be the *lead* of a reassembly if it either
+      (a) already starts with one of the key prefixes (e.g. ``ghp_aBcD``), or
+      (b) is a partial-prefix lead (e.g. ``gh`` + ``p_aBcD...`` -> ``ghp_...``)
+          where the fragment is a strict prefix of a key prefix.
+
+    We index fragments by both classes, then pair only candidate leads with
+    every other-file fragment. This turns the worst case from O(F²) on the
+    full corpus to O(L × F) where L is the (small) number of candidate leads.
+
+    Same-file pairs are skipped — those are already caught by the regular
+    regex pack since the merged string would live in the bundle.
+    """
+
+    # A fragment is a useful split-token *lead* only if its text begins with
+    # one of the known key prefixes. This is intentionally narrow: pairing
+    # every prefix-first-char-match against every other-file fragment, as the
+    # original implementation did, produced 7M+ duplicate findings on real
+    # corpora (cline/cline, deepset-ai/haystack) during the dogfood scan.
+    #
+    # Cross-file callers are opt-in via ``KEYLEAK_ENABLE_SPLIT_TOKEN=1`` so
+    # the default ``scan_path`` flow is quiet on real-world repos. v0.3 will
+    # redesign with proper prefix-bridging gates.
+    def is_lead_candidate(text: str) -> bool:
+        return any(text.startswith(p) for p in prefixes)
+
+    # Bucket fragments per file into "leads" (worth checking as fragment_a) and
+    # "any" (every fragment, used as fragment_b).
+    leads_by_file: Dict[str, List[Fragment]] = {}
+    for file, frags in fragments_by_file.items():
+        leads_by_file[file] = [f for f in frags if is_lead_candidate(f.text)]
+
+    matches: List[SplitTokenMatch] = []
+    files = list(fragments_by_file.keys())
+
+    for i, file_a in enumerate(files):
+        leads_a = leads_by_file.get(file_a) or ()
+        if not leads_a and not any(leads_by_file.get(fb) for fb in files[i + 1 :]):
+            continue
+        for file_b in files[i + 1 :]:
+            leads_b = leads_by_file.get(file_b) or ()
+            # For each *lead* in either file, pair against every fragment in
+            # the other file. The non-lead fragment fills the tail.
+            for lead, others in (
+                (leads_a, fragments_by_file[file_b]),
+                (leads_b, fragments_by_file[file_a]),
+            ):
+                for fa in lead:
+                    for fb in others:
+                        combined = fa.text + fb.text
+                        for prefix in prefixes:
+                            if combined.startswith(prefix):
+                                matches.append(
+                                    SplitTokenMatch(
+                                        prefix=prefix,
+                                        fragment_a=fa,
+                                        fragment_b=fb,
+                                        assembled=combined[:80],
+                                    )
+                                )
+                                break  # one prefix per pair is enough
+    return matches

--- a/keyleak/diff.py
+++ b/keyleak/diff.py
@@ -1,0 +1,94 @@
+"""Finding diff between two KeyLeak reports (Wave 3.3).
+
+In the first hour of an incident, the question that matters is *what is new*
+between the last known-good report and the current one. ``keyleak diff``
+takes two reports and emits only the findings present in the second but not
+the first, sorted by severity.
+
+Inputs accepted:
+- KeyLeak JSON reports (the native format).
+- SARIF 2.1.0 reports.
+
+We identify findings by their stable ``id`` field (already a SHA256 over
+detector + source + line + value, set in :meth:`Finding.__post_init__`).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from .models import Finding, ScanReport
+from .reporting import build_report
+
+
+def load_report(path: Path) -> ScanReport:
+    """Load a JSON or SARIF report. Returns a normalized ``ScanReport``."""
+
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    if isinstance(data, dict) and "runs" in data:
+        return _sarif_to_report(data, target=str(path))
+    return ScanReport.from_dict(data)
+
+
+def _sarif_to_report(sarif: Dict[str, Any], target: str = "") -> ScanReport:
+    findings: List[Dict[str, Any]] = []
+    runs = sarif.get("runs") or []
+    if not runs:
+        return ScanReport(target=target, scan_mode="diff", findings=[])
+    rules_by_id: Dict[str, Dict[str, Any]] = {}
+    for run in runs:
+        tool = run.get("tool") or {}
+        driver = tool.get("driver") or {}
+        for rule in driver.get("rules") or []:
+            if rule.get("id"):
+                rules_by_id[rule["id"]] = rule
+        for result in run.get("results") or []:
+            rule_id = result.get("ruleId") or "sarif:unknown"
+            locations = result.get("locations") or []
+            location = locations[0] if locations else {}
+            phys = (location.get("physicalLocation") or {})
+            artifact = (phys.get("artifactLocation") or {}).get("uri") or ""
+            region = phys.get("region") or {}
+            findings.append({
+                "id": (result.get("partialFingerprints") or {}).get("findingId") or "",
+                "type": (rules_by_id.get(rule_id, {}).get("name")) or rule_id,
+                "severity": _sarif_level_to_severity(result.get("level")),
+                "detector_id": rule_id,
+                "source": artifact,
+                "risk_reason": (result.get("message") or {}).get("text") or "",
+                "remediation": ((rules_by_id.get(rule_id, {}).get("help") or {}).get("text")) or "",
+                "evidence": {
+                    "source": artifact,
+                    "line": region.get("startLine"),
+                    "redacted_value": "",
+                },
+                "validation_status": "lead",
+                "category": ((result.get("properties") or {}).get("category")) or "",
+            })
+    return ScanReport(target=target, scan_mode="diff", findings=[Finding.from_dict(f) for f in findings])
+
+
+def _sarif_level_to_severity(level: Any) -> str:
+    text = str(level or "").lower()
+    if text == "error":
+        return "high"
+    if text == "warning":
+        return "medium"
+    return "low"
+
+
+def diff_reports(baseline: ScanReport, current: ScanReport) -> ScanReport:
+    """Return a ScanReport containing only findings *new* in ``current``."""
+
+    baseline_ids: Set[str] = {f.id for f in baseline.findings if f.id}
+    new_findings = [f for f in current.findings if f.id and f.id not in baseline_ids]
+    return build_report(
+        current.target or baseline.target,
+        new_findings,
+        scan_mode="diff",
+        profile=current.extra.get("profile") if isinstance(current.extra, dict) else "diff",
+        packs=current.extra.get("packs") if isinstance(current.extra, dict) else None,
+    )

--- a/keyleak/disclose.py
+++ b/keyleak/disclose.py
@@ -1,0 +1,213 @@
+"""Responsible-disclosure CLI (Wave 1.7).
+
+When KeyLeak finds a third-party credential during a pentest or launch-gate
+scan, the operator becomes a knowing possessor of an active credential. This
+module emits a signed, timestamped disclosure packet that routes to the
+vendor's published security contact, mitigating CFAA / Computer Misuse Act
+exposure.
+
+Signing modes (same as :mod:`keyleak.suppressions`):
+- ``hmac-sha256`` (default in tests, deterministic): HMAC-SHA256 over the
+  canonical JSON payload using a key from ``KEYLEAK_DISCLOSE_KEY``.
+- ``cosign`` (production): shells out to ``cosign sign-blob`` if installed.
+- ``none``: emits the packet unsigned. Suitable for offline review only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+VENDOR_CONTACTS_PATH = Path(__file__).parent / "data" / "vendor_contacts.json"
+DISCLOSE_HMAC_KEY_ENV = "KEYLEAK_DISCLOSE_KEY"
+
+
+class DiscloseError(RuntimeError):
+    """Raised on a recoverable error in the disclose pipeline."""
+
+
+def load_vendor_contacts(path: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
+    """Load the in-repo vendor-contacts table."""
+
+    path = path or VENDOR_CONTACTS_PATH
+    if not path.is_file():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {key: value for key, value in data.items() if not key.startswith("_")}
+
+
+def build_packet(
+    finding: Dict[str, Any],
+    vendor_contacts: Optional[Dict[str, Dict[str, Any]]] = None,
+    reporter: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build the unsigned disclosure packet for ``finding``.
+
+    ``finding`` is the dict shape produced by ``Finding.to_dict()``.
+    """
+
+    contacts = vendor_contacts if vendor_contacts is not None else load_vendor_contacts()
+    detector_id = finding.get("detector_id") or ""
+    vendor = contacts.get(detector_id) or {}
+
+    now = (now or datetime.now(timezone.utc)).isoformat()
+
+    return {
+        "version": "1",
+        "kind": "keyleak.disclosure",
+        "generated_at": now,
+        "reporter": reporter or "anonymous",
+        "finding": {
+            "id": finding.get("id"),
+            "detector_id": detector_id,
+            "severity": finding.get("severity"),
+            "source": finding.get("source"),
+            "redacted_value": (finding.get("evidence") or {}).get("redacted_value") or finding.get("redacted_value") or "",
+        },
+        "vendor": {
+            "contact": vendor.get("contact") or "(no contact mapping; consult vendor documentation)",
+            "form": vendor.get("form"),
+        },
+        "narrative": (
+            "KeyLeak Detector observed a credential matching the detector above in the public "
+            "scan target listed in 'source'. The credential is redacted in this packet; the raw "
+            "value was not retained, copied, or used. Please rotate and acknowledge receipt."
+        ),
+    }
+
+
+def canonical_payload(packet: Dict[str, Any]) -> bytes:
+    """Return the deterministic byte string used for signing/verification."""
+
+    return json.dumps(packet, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sign_packet(packet: Dict[str, Any], mode: str = "hmac-sha256") -> Dict[str, Any]:
+    """Return a copy of ``packet`` with ``signature_mode`` / ``signature`` set."""
+
+    payload = canonical_payload(packet)
+    if mode == "none":
+        return {**packet, "signature_mode": "none", "signature": ""}
+    if mode == "hmac-sha256":
+        key = os.environ.get(DISCLOSE_HMAC_KEY_ENV)
+        if not key:
+            raise DiscloseError(
+                f"signature mode 'hmac-sha256' requires {DISCLOSE_HMAC_KEY_ENV} env var"
+            )
+        sig = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        return {**packet, "signature_mode": mode, "signature": sig}
+    if mode == "cosign":
+        cosign = shutil.which("cosign")
+        if not cosign:
+            raise DiscloseError("signature mode 'cosign' but cosign is not on PATH")
+        result = subprocess.run(
+            [cosign, "sign-blob", "--yes", "-"],
+            input=payload,
+            capture_output=True,
+            check=False,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise DiscloseError(
+                f"cosign sign-blob failed: {result.stderr.decode('utf-8', errors='replace')}"
+            )
+        return {**packet, "signature_mode": mode, "signature": result.stdout.decode("utf-8").strip()}
+    raise DiscloseError(f"unknown signature mode: {mode!r}")
+
+
+def verify_packet(packet: Dict[str, Any]) -> bool:
+    """Verify a previously-signed packet. Returns True on success."""
+
+    mode = packet.get("signature_mode") or "none"
+    sig = packet.get("signature") or ""
+    if mode == "none":
+        return not sig
+
+    body = {k: v for k, v in packet.items() if k not in {"signature", "signature_mode"}}
+    payload = canonical_payload(body)
+
+    if mode == "hmac-sha256":
+        key = os.environ.get(DISCLOSE_HMAC_KEY_ENV)
+        if not key:
+            return False
+        expected = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, sig.strip().lower())
+    if mode == "cosign":
+        cosign = shutil.which("cosign")
+        if not cosign:
+            return False
+        # Best-effort verification.
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("wb", delete=False, suffix=".payload") as payload_file:
+            payload_file.write(payload)
+            payload_path = payload_file.name
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".sig") as sig_file:
+            sig_file.write(sig)
+            sig_path = sig_file.name
+        try:
+            result = subprocess.run(
+                [cosign, "verify-blob", "--signature", sig_path, payload_path],
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+        finally:
+            Path(payload_path).unlink(missing_ok=True)
+            Path(sig_path).unlink(missing_ok=True)
+        return result.returncode == 0
+    return False
+
+
+def find_finding_in_report(report_data: Dict[str, Any], finding_id: str) -> Optional[Dict[str, Any]]:
+    """Locate a finding by id within a serialized scan report."""
+
+    for finding in report_data.get("findings") or []:
+        if finding.get("id") == finding_id:
+            return finding
+    return None
+
+
+def cli(args) -> int:
+    """Implement ``keyleak disclose`` (called from :mod:`keyleak.cli`)."""
+
+    report_path = Path(args.from_report)
+    if not report_path.is_file():
+        print(f"--from-report not found: {report_path}", file=sys.stderr)
+        return 1
+
+    try:
+        report_data = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Could not parse report: {exc}", file=sys.stderr)
+        return 1
+
+    finding = find_finding_in_report(report_data, args.finding_id)
+    if finding is None:
+        print(f"Finding not in report: {args.finding_id}", file=sys.stderr)
+        return 1
+
+    packet = build_packet(finding, reporter=args.reporter)
+    try:
+        signed = sign_packet(packet, mode=args.signature_mode)
+    except DiscloseError as exc:
+        print(f"Disclosure signing failed: {exc}", file=sys.stderr)
+        return 1
+
+    payload = json.dumps(signed, indent=2, sort_keys=True)
+    if args.out:
+        Path(args.out).write_text(payload, encoding="utf-8")
+        print(f"Wrote {args.out}")
+    else:
+        print(payload)
+    return 0

--- a/keyleak/doctor.py
+++ b/keyleak/doctor.py
@@ -1,0 +1,188 @@
+"""`keyleak doctor` — green/yellow/red checklist for a working KeyLeak install.
+
+Goal: from `pip install keyleak-detector` to "all systems go" inside 60 seconds.
+Outputs a check-by-check report with copy-paste fixes for anything red.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str  # "ok" | "warn" | "fail"
+    message: str
+    fix: Optional[str] = None
+
+
+def _ok(name: str, message: str) -> CheckResult:
+    return CheckResult(name=name, status="ok", message=message)
+
+
+def _warn(name: str, message: str, fix: Optional[str] = None) -> CheckResult:
+    return CheckResult(name=name, status="warn", message=message, fix=fix)
+
+
+def _fail(name: str, message: str, fix: Optional[str] = None) -> CheckResult:
+    return CheckResult(name=name, status="fail", message=message, fix=fix)
+
+
+def check_python_version() -> CheckResult:
+    major, minor = sys.version_info[:2]
+    if (major, minor) >= (3, 11):
+        return _ok("python", f"Python {sys.version.split()[0]}")
+    if (major, minor) >= (3, 9):
+        return _warn(
+            "python",
+            f"Python {sys.version.split()[0]} works but 3.11+ is recommended.",
+            fix="Install Python 3.11+ from https://www.python.org/ or via pyenv.",
+        )
+    return _fail(
+        "python",
+        f"Python {sys.version.split()[0]} is too old.",
+        fix="Install Python 3.9+ from https://www.python.org/",
+    )
+
+
+def check_keyleak_imports() -> CheckResult:
+    """Verify the core package + its critical optional deps import."""
+
+    missing = []
+    for mod in ("requests", "regex", "tldextract", "yaml"):
+        if importlib.util.find_spec(mod) is None:
+            missing.append(mod)
+    if missing:
+        return _fail(
+            "keyleak-imports",
+            f"Missing modules: {', '.join(missing)}",
+            fix="Run `pip install -e .` (or `poetry install`) from the repo root.",
+        )
+    return _ok("keyleak-imports", "Core deps importable.")
+
+
+def check_playwright() -> CheckResult:
+    """Optional — needed only for `keyleak browser-scan` and `keyleak scan`."""
+
+    if importlib.util.find_spec("playwright") is None:
+        return _warn(
+            "playwright",
+            "Playwright is not installed (browser-scan + live-URL scan unavailable).",
+            fix="`pip install playwright && python -m playwright install chromium`",
+        )
+    return _ok("playwright", "Playwright Python bindings installed.")
+
+
+def check_mitmproxy_cert() -> CheckResult:
+    """Verify mitmproxy CA cert exists if a previous run installed it."""
+
+    if importlib.util.find_spec("mitmproxy") is None:
+        return _warn(
+            "mitmproxy",
+            "mitmproxy not installed; `keyleak scan` traffic capture unavailable.",
+            fix="`pip install mitmproxy` (already a project dep — run `poetry install`)",
+        )
+    return _ok("mitmproxy", "mitmproxy Python bindings installed.")
+
+
+def check_node() -> CheckResult:
+    """Required for the extension-bundle smoke test."""
+
+    if shutil.which("node") is None:
+        return _warn(
+            "node",
+            "node is not on PATH; `tools/extension_smoke.mjs` can't run locally.",
+            fix="Install Node 20+ (https://nodejs.org/) and re-run.",
+        )
+    return _ok("node", "node is available.")
+
+
+def check_poetry() -> CheckResult:
+    if shutil.which("poetry") is None:
+        return _warn(
+            "poetry",
+            "poetry not on PATH; lockfile drift cannot be checked.",
+            fix="`pipx install poetry` (or `pip install --user poetry`)",
+        )
+    return _ok("poetry", "poetry is available.")
+
+
+def check_network_egress() -> CheckResult:
+    """Loopback should always work; external is informational."""
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.5)
+    try:
+        sock.connect(("127.0.0.1", 1))
+    except (ConnectionRefusedError, OSError):
+        # Either is fine — both mean the socket call succeeded.
+        pass
+    finally:
+        sock.close()
+    return _ok("network", "Loopback connectivity OK.")
+
+
+def check_allowlist_sanity() -> CheckResult:
+    """If a YAML allowlist is present, ensure it parses."""
+
+    for candidate in ("keyleak-allowlist.yaml", "keyleak-allowlist.yml"):
+        if os.path.isfile(candidate):
+            try:
+                from .suppressions import load_suppressions
+
+                load_suppressions(candidate)
+                return _ok("allowlist", f"{candidate} parses cleanly.")
+            except Exception as exc:
+                return _fail("allowlist", f"{candidate}: {exc}", fix="Fix the YAML schema; see SECURITY.md.")
+    return _ok("allowlist", "No YAML allowlist (legacy .txt may still apply).")
+
+
+CHECKS = (
+    check_python_version,
+    check_keyleak_imports,
+    check_playwright,
+    check_mitmproxy_cert,
+    check_node,
+    check_poetry,
+    check_network_egress,
+    check_allowlist_sanity,
+)
+
+
+def run_doctor() -> List[CheckResult]:
+    return [check() for check in CHECKS]
+
+
+def format_results(results: List[CheckResult]) -> str:
+    icons = {"ok": "✓", "warn": "!", "fail": "✗"}
+    lines: List[str] = ["KeyLeak Doctor"]
+    for r in results:
+        lines.append(f"  [{icons[r.status]}] {r.name}: {r.message}")
+        if r.fix and r.status != "ok":
+            lines.append(f"      fix: {r.fix}")
+    fails = sum(1 for r in results if r.status == "fail")
+    warns = sum(1 for r in results if r.status == "warn")
+    summary = f"\n{len(results)} checks · {fails} fail · {warns} warn"
+    lines.append(summary)
+    return "\n".join(lines)
+
+
+def cli_main(args) -> int:
+    results = run_doctor()
+    if getattr(args, "json", False):
+        print(json.dumps([
+            {"name": r.name, "status": r.status, "message": r.message, "fix": r.fix}
+            for r in results
+        ], indent=2, sort_keys=True))
+    else:
+        print(format_results(results))
+    return 1 if any(r.status == "fail" for r in results) else 0

--- a/keyleak/extension_bundle.py
+++ b/keyleak/extension_bundle.py
@@ -1,0 +1,194 @@
+"""Generate the Chrome extension detector bundle from the core registry."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Iterable, List, Optional
+
+from .detectors import DETECTORS, Detector, detectors_for_packs, normalize_packs
+
+
+EXTENSION_PATTERN_FLAGS = "gim"
+
+
+class IncompatibleExtensionPattern(ValueError):
+    """Raised when a detector pattern uses Python-only regex features."""
+
+
+# Wave 1.3 — Python-side JS-compat guard. The JS shim in
+# ``extension/lib/patterns.js`` wraps every ``new RegExp(...)`` in a try/catch
+# that ``console.warn``s on failure. Without a validation step here, a pattern
+# valid in Python but invalid in JS silently disappears at runtime and the
+# extension reports a clean page. The patterns below are known to be
+# Python-only and must trip the build.
+_JS_INCOMPATIBLE_PATTERNS = [
+    (r"\(\?P[<=!]", "named/Python-style group syntax (?P<name>...) is Python-only"),
+    (r"\(\?#", "Python inline comment groups (?#...) are not JS"),
+    (r"\\A", "Python \\A start-of-string anchor is not JS"),
+    (r"\\Z", "Python \\Z end-of-string anchor is not JS"),
+    (r"\(\?\(", "Python conditional group (?(...)...) is not JS"),
+    (r"\(\?[smix-]+\)", "Python inline flag groups (?s), (?i), (?m) are Python-only — use flags arg in JS instead"),
+]
+
+
+def validate_extension_pattern(pattern: str) -> None:
+    """Compile a pattern with Python's ``re`` AND flag known JS-incompat features.
+
+    Raises ``IncompatibleExtensionPattern`` if either check fails. A failure here
+    fails the build loudly instead of silently producing a JS shim that drops
+    the detector.
+    """
+
+    try:
+        re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+    except re.error as exc:
+        raise IncompatibleExtensionPattern(f"Python regex compile failed: {exc}") from exc
+
+    for incompat_pattern, reason in _JS_INCOMPATIBLE_PATTERNS:
+        if re.search(incompat_pattern, pattern):
+            raise IncompatibleExtensionPattern(f"{reason}: {pattern}")
+
+
+def extension_pattern_payload(detectors: Optional[Iterable[Detector]] = None, packs: Optional[Iterable[str]] = None) -> List[dict]:
+    """Return serializable detector metadata for the extension runtime.
+
+    Validates each detector's regex for JS compatibility before serialization.
+    Raises ``IncompatibleExtensionPattern`` if a pattern would silently drop at
+    extension runtime.
+    """
+
+    if detectors is None:
+        detectors = detectors_for_packs(normalize_packs(packs, profile="launch-gate", surface="extension"), extension_only=True)
+    payload = []
+    for detector in detectors:
+        try:
+            validate_extension_pattern(detector.pattern)
+        except IncompatibleExtensionPattern as exc:
+            raise IncompatibleExtensionPattern(
+                f"Detector {detector.canonical_id!r} has a JS-incompatible pattern: {exc}"
+            ) from exc
+        payload.append(
+            {
+                "id": detector.id,
+                "detector_id": detector.canonical_id,
+                "finding_type": detector.result_type,
+                "pattern": detector.pattern,
+                "flags": EXTENSION_PATTERN_FLAGS,
+                "severity": detector.severity,
+                "description": detector.description,
+                "remediation": detector.remediation,
+                "pack": detector.pack,
+                "category": detector.pack,
+                "categories": detector.categories,
+                "min_match_length": detector.min_match_length,
+                "capture_group": detector.capture_group,
+                "validation_status": detector.validation_status,
+                "references": list(detector.references),
+            }
+        )
+    return payload
+
+
+def extension_patterns_js(detectors: Optional[Iterable[Detector]] = None, packs: Optional[Iterable[str]] = None) -> str:
+    """Render the checked-in ES module used by the Chrome extension."""
+    payload = extension_pattern_payload(detectors, packs=packs)
+    encoded = json.dumps(payload, indent=2, sort_keys=True)
+    return "\n".join(
+        [
+            "/**",
+            " * Generated detector bundle for KeyLeak Detector.",
+            " * Source of truth: keyleak.detectors.DETECTORS.",
+            " * Regenerate with: python3 scripts/generate_extension_patterns.py",
+            " */",
+            "",
+            f"const PATTERN_DEFINITIONS = {encoded};",
+            "",
+            "const PATTERNS = {};",
+            "const COMPILED_PATTERNS = {};",
+            "",
+            "for (const definition of PATTERN_DEFINITIONS) {",
+            "  try {",
+            "    const entry = {",
+            "      id: definition.id,",
+            "      detector_id: definition.detector_id,",
+            "      finding_type: definition.finding_type || definition.id,",
+            "      pattern: new RegExp(definition.pattern, definition.flags),",
+            "      severity: definition.severity,",
+            "      description: definition.description,",
+            "      remediation: definition.remediation,",
+            "      pack: definition.pack || definition.category || 'leak',",
+            "      category: definition.category || definition.pack || 'leak',",
+            "      categories: definition.categories || [],",
+            "      min_match_length: definition.min_match_length || 8,",
+            "      capture_group: definition.capture_group || 0,",
+            "      validation_status: definition.validation_status || 'lead',",
+            "      references: definition.references || [],",
+            "    };",
+            "    PATTERNS[definition.id] = entry;",
+            "    COMPILED_PATTERNS[definition.id] = entry;",
+            "  } catch (error) {",
+            "    console.warn(`[KeyLeak] Skipping invalid detector pattern: ${definition.id}`, error);",
+            "  }",
+            "}",
+            "",
+            "export { PATTERN_DEFINITIONS, PATTERNS, COMPILED_PATTERNS };",
+            "",
+        ]
+    )
+
+
+def extension_info_payload(detectors: Optional[Iterable[Detector]] = None, packs: Optional[Iterable[str]] = None) -> List[dict]:
+    """Return rich educational metadata for the extension Learn/Reference UI.
+
+    Kept separate from the runtime pattern bundle so the regex bundle stays small
+    and the prose is only loaded when the user opens an educational surface.
+    """
+    if detectors is None:
+        detectors = detectors_for_packs(normalize_packs(packs, profile="full", surface="extension"), extension_only=True)
+    payload = []
+    for detector in detectors:
+        payload.append(
+            {
+                "id": detector.id,
+                "detector_id": detector.canonical_id,
+                "finding_type": detector.result_type,
+                "severity": detector.severity,
+                "pack": detector.pack,
+                "categories": list(detector.categories),
+                "description": detector.description,
+                "remediation": detector.remediation,
+                "references": list(detector.references),
+                "validation_status": detector.validation_status,
+                "attack_scenario": detector.attack_scenario,
+            }
+        )
+    return payload
+
+
+def extension_info_js(detectors: Optional[Iterable[Detector]] = None, packs: Optional[Iterable[str]] = None) -> str:
+    """Render the checked-in ES module that powers the Learn/Reference panels."""
+    payload = extension_info_payload(detectors, packs=packs)
+    by_id = {entry["id"]: entry for entry in payload}
+    encoded = json.dumps(by_id, indent=2, sort_keys=True)
+    return "\n".join(
+        [
+            "/**",
+            " * Generated detector knowledge base for KeyLeak Detector UI.",
+            " * Source of truth: keyleak.detectors.DETECTORS.",
+            " * Regenerate with: python3 scripts/generate_extension_patterns.py",
+            " */",
+            "",
+            f"export const DETECTOR_INFO = {encoded};",
+            "",
+            "export function getDetectorInfo(detectorId) {",
+            "  if (!detectorId) return null;",
+            "  if (DETECTOR_INFO[detectorId]) return DETECTOR_INFO[detectorId];",
+            "  // Detector IDs surface as either bare ids (`openai_api_key`)",
+            "  // or canonical ids (`leak.openai_api_key`). Fall back to the trailing segment.",
+            "  const tail = String(detectorId).split('.').pop();",
+            "  return DETECTOR_INFO[tail] || null;",
+            "}",
+            "",
+        ]
+    )

--- a/keyleak/feeds.py
+++ b/keyleak/feeds.py
@@ -1,0 +1,168 @@
+"""IOC feed ingestion (Wave 3.2).
+
+Pulls upstream IOC feeds (OSV.dev MAL- advisories + OpenSSF malicious-packages)
+and normalizes them into the KeyLeak IOC schema:
+
+    {
+      "version": 1,
+      "generated_at": "<ISO>",
+      "signature_mode": "hmac-sha256" | "none",
+      "signature": "...",
+      "entries": [
+        {
+          "id": "MAL-2026-1234",
+          "ecosystem": "npm",
+          "package": "@x/y",
+          "versions": ["1.0.0", "1.0.1"],
+          "references": ["..."],
+          "summary": "..."
+        }
+      ]
+    }
+
+The pull functions are abstracted behind a ``fetcher`` callable so tests can
+inject mock responses without touching the network. The free public tier
+uses OSV.dev (CC-BY 4.0). The paid ``keyleak-feed-pro`` tier (Wave 3.10) is
+a separate signed bundle distributed via GitHub Releases.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+
+OSV_API_BASE = "https://api.osv.dev/v1"
+FEED_HMAC_KEY_ENV = "KEYLEAK_FEED_KEY"
+
+
+@dataclass
+class FeedEntry:
+    id: str
+    ecosystem: str  # e.g. "npm", "PyPI"
+    package: str
+    versions: List[str] = field(default_factory=list)
+    references: List[str] = field(default_factory=list)
+    summary: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "ecosystem": self.ecosystem,
+            "package": self.package,
+            "versions": list(self.versions),
+            "references": list(self.references),
+            "summary": self.summary,
+        }
+
+
+# Type alias for the fetcher callable. Tests inject a mock that returns a
+# pre-canned payload.
+Fetcher = Callable[[str, Dict[str, Any]], Dict[str, Any]]
+
+
+def http_post_json(url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Default HTTP fetcher — used in production, mocked in tests."""
+
+    import requests
+
+    response = requests.post(url, json=payload, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def query_osv_malicious(
+    ecosystem: str = "npm",
+    *,
+    fetcher: Optional[Fetcher] = None,
+) -> List[FeedEntry]:
+    """Query OSV.dev for malicious-package advisories in ``ecosystem``.
+
+    Note: OSV's ``MAL-*`` advisory IDs cover malicious-package reports across
+    npm / PyPI / Maven / RubyGems / cargo. This function only requests
+    advisories that have a ``MAL-`` prefix in their ID.
+    """
+
+    fetcher = fetcher or (lambda u, p: http_post_json(u, p))
+    payload = {"query": {"package": {"ecosystem": ecosystem}}}
+    raw = fetcher(f"{OSV_API_BASE}/querybatch", payload)
+    return _parse_osv_response(raw, ecosystem)
+
+
+def _parse_osv_response(raw: Dict[str, Any], ecosystem: str) -> List[FeedEntry]:
+    entries: List[FeedEntry] = []
+    for vuln in raw.get("vulns") or []:
+        vid = str(vuln.get("id") or "")
+        if not vid.startswith("MAL-"):
+            continue
+        affected = vuln.get("affected") or []
+        for a in affected:
+            pkg = (a.get("package") or {}).get("name") or ""
+            if not pkg:
+                continue
+            versions = a.get("versions") or []
+            entries.append(
+                FeedEntry(
+                    id=vid,
+                    ecosystem=ecosystem,
+                    package=pkg,
+                    versions=[str(v) for v in versions],
+                    references=[ref.get("url") for ref in vuln.get("references") or [] if ref.get("url")],
+                    summary=str(vuln.get("summary") or ""),
+                )
+            )
+    return entries
+
+
+def sign_entries(entries: List[Dict[str, Any]], key: str) -> str:
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(key.encode("utf-8"), canonical, hashlib.sha256).hexdigest()
+
+
+def build_manifest(
+    entries: List[FeedEntry],
+    *,
+    now: Optional[datetime] = None,
+    sign: bool = True,
+) -> Dict[str, Any]:
+    """Build the signed manifest from a list of feed entries."""
+
+    generated_at = (now or datetime.now(timezone.utc)).isoformat()
+    payload = [entry.to_dict() for entry in entries]
+    document: Dict[str, Any] = {
+        "version": 1,
+        "generated_at": generated_at,
+        "entries": payload,
+    }
+    if sign:
+        key = os.environ.get(FEED_HMAC_KEY_ENV)
+        if key:
+            document["signature_mode"] = "hmac-sha256"
+            document["signature"] = sign_entries(payload, key)
+        else:
+            document["signature_mode"] = "none"
+            document["signature"] = ""
+    else:
+        document["signature_mode"] = "none"
+        document["signature"] = ""
+    return document
+
+
+def verify_manifest(document: Dict[str, Any]) -> bool:
+    mode = document.get("signature_mode") or "none"
+    sig = document.get("signature") or ""
+    if mode == "none":
+        return not sig
+    if mode == "hmac-sha256":
+        key = os.environ.get(FEED_HMAC_KEY_ENV)
+        if not key:
+            return False
+        canonical = json.dumps(document.get("entries") or [], sort_keys=True, separators=(",", ":")).encode("utf-8")
+        expected = hmac.new(key.encode("utf-8"), canonical, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, sig.strip().lower())
+    return False

--- a/keyleak/local_scanner.py
+++ b/keyleak/local_scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import re
 from pathlib import Path
@@ -603,7 +604,6 @@ def _shannon_entropy(value: object) -> float:
     counts: dict = {}
     for ch in text:
         counts[ch] = counts.get(ch, 0) + 1
-    import math
 
     total = len(text)
     return -sum((c / total) * math.log2(c / total) for c in counts.values())

--- a/keyleak/local_scanner.py
+++ b/keyleak/local_scanner.py
@@ -5,12 +5,31 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Optional, Sequence, Tuple
 
-from .detectors import Detector, detectors_for_categories
+from .detectors import Detector, categories_for_packs, detectors_for_categories, normalize_packs
+from .detectors_ast import detect_worm_shape, is_worm_shape_target
+from .detectors_fuzzy import FingerprintHit, load_corpus, match_fingerprints
+from .detectors_splittoken import SplitTokenMatch, collect_fragments, find_split_tokens
 from .models import Evidence, Finding, confidence_for_severity
-from .redaction import redact_snippet, redact_value
+from .privacy_filter import scrub_snippet as pii_scrub_snippet
+from .redaction import new_run_salt, redact_snippet, redact_value
 from .reporting import build_report
+from .sourcemaps import SourceMapError, reconstruct_originals
+
+
+# Lazy: cache the loaded fingerprint corpus across scans within one process.
+_FINGERPRINT_CORPUS_CACHE: Optional[List] = None
+
+
+def _get_fingerprint_corpus():
+    global _FINGERPRINT_CORPUS_CACHE
+    if _FINGERPRINT_CORPUS_CACHE is None:
+        try:
+            _FINGERPRINT_CORPUS_CACHE = load_corpus()
+        except ValueError:
+            _FINGERPRINT_CORPUS_CACHE = []
+    return _FINGERPRINT_CORPUS_CACHE
 
 
 DEFAULT_INCLUDES = ("env", "mcp", "ci", "docker", "sourcemaps", "logs")
@@ -26,19 +45,87 @@ SKIP_DIRS = {
     "node_modules",
     "venv",
 }
+SKIP_GENERATED_FILE_SUFFIXES = {
+    "extension/lib/patterns.js",
+}
 
 
-def scan_path(path: str, includes: Sequence[str] = DEFAULT_INCLUDES):
+def scan_path(
+    path: str,
+    includes: Sequence[str] = DEFAULT_INCLUDES,
+    profile: str = "launch-gate",
+    packs: Optional[Iterable[str]] = None,
+    *,
+    run_salt: Optional[bytes] = None,
+):
     target = Path(path).expanduser().resolve()
     findings: List[Finding] = []
+    active_packs = normalize_packs(packs, profile=profile)
+    active_includes = _effective_includes(includes, active_packs)
+    if run_salt is None:
+        run_salt = new_run_salt()
 
-    for file_path, categories in _iter_candidate_files(target, includes):
-        findings.extend(scan_file(file_path, detectors_for_categories(categories)))
+    code_files: List[Path] = []
+    for file_path, categories in _iter_candidate_files(target, active_includes):
+        findings.extend(
+            scan_file(file_path, detectors_for_categories(categories, active_packs), run_salt=run_salt)
+        )
+        if file_path.suffix.lower() in {".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py"}:
+            code_files.append(file_path)
 
-    return build_report(str(target), findings, scan_mode="local")
+    # Wave 3.4 — cross-file split-token reassembly. Opt-in via env var because
+    # the current algorithm is noisy on real-world corpora (any fragment that
+    # already starts with a key prefix produces N×M cross-file findings against
+    # every other-file fragment). The 313-repo dogfood scan surfaced this at
+    # 7M+ findings on cline/cline alone. Slated for redesign in v0.3 with a
+    # proper prefix-bridging gate; meanwhile, callers can opt in with
+    # ``KEYLEAK_ENABLE_SPLIT_TOKEN=1``.
+    if os.environ.get("KEYLEAK_ENABLE_SPLIT_TOKEN") == "1" and len(code_files) >= 2:
+        fragments_by_file = collect_fragments(code_files)
+        for match in find_split_tokens(fragments_by_file):
+            findings.append(_split_token_finding(match))
+
+    return build_report(str(target), findings, scan_mode="local", profile=profile, packs=active_packs)
 
 
-def scan_file(file_path: Path, detectors: Iterable[Detector]) -> List[Finding]:
+def _split_token_finding(match) -> Finding:
+    snippet = (
+        f"{match.fragment_a.file}:{match.fragment_a.line} + "
+        f"{match.fragment_b.file}:{match.fragment_b.line} = "
+        f"{match.prefix}..."
+    )
+    return Finding(
+        type="split_token_reassembly",
+        severity="critical",
+        confidence=0.75,
+        detector_id="leak.split_token_reassembly",
+        source=f"{match.fragment_a.file}+{match.fragment_b.file}",
+        evidence=Evidence(
+            source=match.fragment_a.file,
+            snippet=snippet[:600],
+            line=match.fragment_a.line,
+            redacted_value=f"{match.prefix}...[reassembled]",
+        ),
+        risk_reason=(
+            f"Two source files contain fragments that concatenate to a string starting with "
+            f"{match.prefix!r}. The bundle merges them at runtime; the regex pack sees only the "
+            "individual fragments."
+        ),
+        remediation=(
+            "Audit the call site. If the concatenation is intentional, restructure to fetch the "
+            "secret server-side. If unintentional, the splitting may be an evasion attempt."
+        ),
+        validation_status="lead",
+        category="leak",
+    )
+
+
+def scan_file(
+    file_path: Path,
+    detectors: Iterable[Detector],
+    *,
+    run_salt: Optional[bytes] = None,
+) -> List[Finding]:
     try:
         if file_path.stat().st_size > MAX_FILE_BYTES:
             return []
@@ -46,36 +133,185 @@ def scan_file(file_path: Path, detectors: Iterable[Detector]) -> List[Finding]:
     except OSError:
         return []
 
+    detectors_list = list(detectors)
+    findings = scan_text(content, str(file_path), detectors_list, run_salt=run_salt)
+    # Wave 2.1 — if this is a JS bundle with a sibling .map or inline source map,
+    # re-run detectors against the reconstructed *original* sources so the PR
+    # comment surfaces src/components/Auth.tsx:42 instead of a minified
+    # one-line bundle. Skip the deobfuscation step for non-JS files.
+    if file_path.suffix.lower() in {".js", ".mjs", ".cjs", ".html", ".htm"}:
+        try:
+            originals = reconstruct_originals(content, bundle_path=file_path)
+        except SourceMapError:
+            originals = []
+        for entry in originals:
+            # Tag the reconstructed source with both the original logical name
+            # (so the developer can find the line) and the bundle path (so
+            # they know which deploy artifact carried it).
+            source_id = f"{file_path}#{entry.source_path}"
+            findings.extend(scan_text(entry.content, source_id, detectors_list, run_salt=run_salt))
+    # Wave 2.2 — capability-triad worm-shape scan on install scripts and
+    # node_modules sources. Independent of the regex pack; pure behavioral.
+    if is_worm_shape_target(file_path):
+        match = detect_worm_shape(content, str(file_path))
+        if match is not None:
+            findings.append(_worm_shape_finding(match, run_salt=run_salt))
+        # Wave 2.3 — fuzzy-hash fingerprint scan on the same targets.
+        corpus = _get_fingerprint_corpus()
+        if corpus:
+            for hit in match_fingerprints(content, corpus):
+                findings.append(_fingerprint_finding(str(file_path), hit))
+    return findings
+
+
+def _worm_shape_finding(match, *, run_salt: Optional[bytes] = None) -> Finding:
+    summary = (
+        f"capability triad in {match.source}: "
+        f"env_read line {match.env_read_line}, "
+        f"net_egress line {match.net_egress_line}, "
+        f"persistence_write line {match.persistence_write_line}"
+    )
+    evidence = Evidence(
+        source=match.source,
+        snippet=match.excerpt_window[:600],
+        line=match.env_read_line,
+        redacted_value=summary[:200],
+    )
+    finding = Finding(
+        type="worm_shape_capability_triad",
+        severity="critical",
+        confidence=0.85,
+        detector_id="leak.worm_shape_capability_triad",
+        source=match.source,
+        evidence=evidence,
+        risk_reason=(
+            "A single source exhibits all three Mini Shai-Hulud capabilities: a credential-shaped "
+            "env-var read, network egress, and a write into a persistence-relevant directory. "
+            "This is the worm payload shape regardless of which strings or hostnames are used."
+        ),
+        remediation=(
+            "Remove the package or vendor the code in-tree. Rotate every credential the install "
+            "step could have read. Audit egress logs for the install timeframe."
+        ),
+        validation_status="lead",
+        category="leak",
+    )
+    return finding
+
+
+def _fingerprint_finding(source: str, hit: FingerprintHit) -> Finding:
+    snippet = (
+        f"matched worm fingerprint {hit.name!r} via {hit.matched} "
+        f"(score={hit.score:.2f}). References: {', '.join(hit.references) or 'n/a'}"
+    )
+    return Finding(
+        type="worm_fingerprint_match",
+        severity="critical",
+        confidence=hit.score if hit.matched == "fuzzy" else 0.95,
+        detector_id=f"leak.worm_fingerprint.{hit.name}",
+        source=source,
+        evidence=Evidence(
+            source=source,
+            snippet=snippet[:600],
+            redacted_value=snippet[:200],
+        ),
+        risk_reason=(
+            f"This file matches a known worm payload fingerprint ({hit.name}). "
+            f"{hit.description}"
+        ),
+        remediation=(
+            "Treat the host as compromised. Rotate every credential reachable from the affected "
+            "machine or CI runner: AWS, GCP, Kubernetes, Vault, GitHub, npm, SSH. Audit egress."
+        ),
+        validation_status="validated" if hit.matched == "exact" else "lead",
+        category="leak",
+        references=list(hit.references),
+    )
+
+
+def scan_text(
+    content: str,
+    source: str,
+    detectors: Iterable[Detector],
+    *,
+    run_salt: Optional[bytes] = None,
+) -> List[Finding]:
     findings: List[Finding] = []
     seen = set()
     for detector in detectors:
         regex = detector.compile()
         for match in regex.finditer(content):
-            raw_value = match.group(1) if match.groups() else match.group(0)
+            raw_value = match.group(detector.capture_group) if detector.capture_group and match.groups() else match.group(1) if match.groups() else match.group(0)
             if _is_placeholder(raw_value, min_length=detector.min_match_length):
+                continue
+            # L.3 — database_url placeholder-password gate (skip dev defaults).
+            if detector.id == "database_url" and _is_placeholder_db_url(raw_value):
+                continue
+            # L.4 — Local-dev URL guard: skip findings whose hostname is loopback / .local / .test.
+            if _is_local_dev_url(raw_value):
+                continue
+            # Q.1 — Shannon-entropy filter: dictionary-word matches like
+            # `sk-indigo-twilight-color-1` (Skeleton UI class names) shouldn't
+            # trip credential detectors.
+            min_entropy = getattr(detector, "min_entropy", None)
+            if min_entropy is not None and _shannon_entropy(raw_value) < min_entropy:
+                continue
+            # Q.7 — basic-auth localhost guard: the L.4 generic check misses
+            # `https://localhost:'...@` substrings in minified JS where the
+            # "port" isn't a clean number. Check the user portion directly.
+            if detector.id == "http_basic_auth" and _is_basic_auth_localhost(raw_value):
+                continue
+            # Q.11 — extend the template-string guard to http_basic_auth.
+            # Workflow YAML / install scripts often contain
+            # ``http://${USER}:${PASSWORD}@host`` shapes that are interpolated
+            # at runtime, not actual creds.
+            if detector.id == "http_basic_auth" and any(m in str(raw_value) for m in _TEMPLATE_MARKERS):
+                continue
+            # Q.8 — bearer/secret tokens that literally start with a "public"
+            # prefix are by definition public.
+            if detector.id in {"bearer_token", "openai_api_key", "stripe_secret_key"} and _has_public_prefix(raw_value):
                 continue
             line = content.count("\n", 0, match.start()) + 1
             snippet = _snippet_for(content, match.start(), match.end())
-            key = (detector.id, str(file_path), redact_value(raw_value), line)
+            # Q.6 + Q.9 — AIza referrer-restricted keys: Google's Firebase /
+            # Maps / Analytics keys are designed to live in client code.
+            # Downgrade severity if ANY client-side marker (firebaseConfig,
+            # gapi, googleapis Maps, gtag, fbq) appears in the *same file* —
+            # not just the ±80-char snippet (markers usually live elsewhere
+            # in the file).
+            effective_severity = detector.severity
+            if detector.id == "gemini_api_key" and _looks_like_client_side_aiza(content):
+                effective_severity = "medium"
+            redacted_value = redact_value(raw_value, run_salt=run_salt)
+            key = (detector.canonical_id, source, redacted_value, line)
             if key in seen:
                 continue
             seen.add(key)
+            # 1. Replace the raw secret with its redacted form in the snippet,
+            #    then 2. mask any *adjacent* PII so the report can't carry
+            #    third-party emails/phones/cards into auditor hands.
+            redacted_snippet = redact_snippet(snippet, raw_value, run_salt=run_salt)
+            redacted_snippet = pii_scrub_snippet(redacted_snippet, redacted_value)
             evidence = Evidence(
-                source=str(file_path),
-                snippet=redact_snippet(snippet, raw_value),
+                source=source,
+                snippet=redacted_snippet,
                 line=line,
-                redacted_value=redact_value(raw_value),
+                redacted_value=redacted_value,
             )
             findings.append(
                 Finding(
-                    type=detector.id,
-                    severity=detector.severity,
-                    confidence=confidence_for_severity(detector.severity, str(file_path)),
-                    detector_id=f"local:{detector.id}",
-                    source=str(file_path),
+                    type=detector.result_type,
+                    severity=effective_severity,
+                    confidence=confidence_for_severity(effective_severity, source),
+                    detector_id=detector.canonical_id,
+                    source=source,
                     evidence=evidence,
                     risk_reason=detector.description,
                     remediation=detector.remediation,
+                    validation_status=detector.validation_status,
+                    category=detector.pack,
+                    references=list(detector.references),
+                    remediation_v2=detector.get_remediation().to_dict(),
                 )
             )
     return findings
@@ -93,9 +329,16 @@ def _iter_candidate_files(target: Path, includes: Sequence[str]):
         root_path = Path(root)
         for filename in files:
             file_path = root_path / filename
+            if _is_generated_file(file_path):
+                continue
             categories = _categories_for_file(file_path, includes)
             if categories:
                 yield file_path, categories
+
+
+def _is_generated_file(path: Path) -> bool:
+    normalized = str(path).replace(os.sep, "/")
+    return any(normalized.endswith(suffix) for suffix in SKIP_GENERATED_FILE_SUFFIXES)
 
 
 def _matches_include(path: Path, includes: Sequence[str]) -> bool:
@@ -106,6 +349,7 @@ def _categories_for_file(path: Path, includes: Sequence[str]) -> List[str]:
     requested = {include.lower() for include in includes}
     name = path.name.lower()
     full = str(path).lower()
+    suffix = path.suffix.lower()
 
     checks = {
         "env": name.startswith(".env") or name.endswith(".env") or name in {"config.json", "secrets.json"},
@@ -114,9 +358,29 @@ def _categories_for_file(path: Path, includes: Sequence[str]) -> List[str]:
         "docker": name in {"dockerfile", "compose.yml", "docker-compose.yml"} or name.endswith(".dockerfile"),
         "sourcemaps": name.endswith((".map", ".js", ".html", ".htm")),
         "logs": name.endswith(".log") or name.endswith(".txt"),
+        "code": suffix in {
+            ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rb", ".php", ".cs",
+            ".rs", ".swift", ".kt", ".sql", ".graphql", ".html", ".htm",
+        },
+        "tests": (
+            "/test" in full
+            or "/tests" in full
+            or ".spec." in name
+            or ".test." in name
+            or name.startswith("test_")
+            or name.endswith("_test.py")
+        ),
+        "docs": "/docs/" in full or suffix in {".md", ".rst", ".adoc"},
+        "config": suffix in {".json", ".yml", ".yaml", ".toml", ".ini", ".cfg"} or name in {"package.json", "pyproject.toml"},
     }
 
     return [include for include in requested if checks.get(include, False)]
+
+
+def _effective_includes(includes: Sequence[str], packs: Tuple[str, ...]) -> Tuple[str, ...]:
+    requested = {include.lower() for include in includes}
+    requested.update(categories_for_packs(packs))
+    return tuple(sorted(requested))
 
 
 def _snippet_for(content: str, start: int, end: int, radius: int = 80) -> str:
@@ -130,8 +394,224 @@ def _snippet_for(content: str, start: int, end: int, radius: int = 80) -> str:
     return snippet
 
 
-def _is_placeholder(value: object, min_length: int = 8) -> bool:
+# L.3 — placeholder passwords that show up in `postgres://postgres:postgres@...`
+# style dev defaults. The 313-repo dogfood produced 323 critical database_url
+# findings, the vast majority of them in this dev-default shape. Q.3 expanded
+# this with project-name dev defaults the live-URL dogfood surfaced.
+_PLACEHOLDER_DB_PASSWORDS = {
+    "postgres", "postgresql", "root", "password", "pass", "passwd",
+    "hunter2", "changeme", "change-me", "dev", "test", "testing",
+    "admin", "default", "secret", "example", "placeholder",
+    # Q.3 — additional project-name dev defaults seen in the live dogfood.
+    "posthog", "prisma", "hatchet", "convex", "supabase", "redis",
+    "mysql", "mongodb", "mongo", "rabbitmq", "kafka", "minio",
+    "elastic", "elasticsearch", "clickhouse", "temporal", "appuser",
+    "app", "user", "service", "ci", "ci-user", "ci_user",
+}
+
+# Q.3 — password suffix patterns that are also placeholders.
+_PLACEHOLDER_DB_PASSWORD_SUFFIXES = (
+    "_password", "_pass", "_pwd", "_secret", "_credential",
+    "-password", "-pass", "-pwd", "-secret",
+)
+
+# Q.2 — template / format-string markers in the password component.
+# These never appear in a real credential; they always indicate
+# interpolation-at-runtime. Q.13 extended with capitalized-braced names.
+_TEMPLATE_MARKERS = ("${", "$(", "%s", "%d", "{0}", "{1}", "{{", "<value>", "<your_", "<replace", "{value}")
+_BRACED_PLACEHOLDER_RE = re.compile(r"\{[A-Z_][A-Z_0-9]*\}")
+
+# L.3 — database_url regex: postgres://user:pass@host:port/db
+_DB_URL_RE = re.compile(
+    r"^(?P<scheme>postgres(?:ql)?|mysql2?|mongodb(?:\+srv)?|redis)://"
+    r"(?P<user>[^:@/\s]+):"
+    r"(?P<password>[^@/\s]+)@"
+    r"(?P<host>[^:/?\s]+)",
+    re.IGNORECASE,
+)
+
+
+def _is_placeholder_db_url(value: object) -> bool:
+    text = str(value or "").strip()
+    match = _DB_URL_RE.search(text)
+    if not match:
+        return False
+    user = (match.group("user") or "").strip().lower()
+    password = (match.group("password") or "").strip()
+    password_lower = password.lower()
+    # Q.2 — template/format-string interpolation marker → never a real cred.
+    if any(marker in password for marker in _TEMPLATE_MARKERS):
+        return True
+    if any(marker in user for marker in _TEMPLATE_MARKERS):
+        return True
+    # Q.13 — capitalized braced placeholders like ``{POSTGRES_PASSWORD}``.
+    if _BRACED_PLACEHOLDER_RE.search(password) or _BRACED_PLACEHOLDER_RE.search(match.group("user") or ""):
+        return True
+    # Q.13 — ALL-CAPS user/password like ``USER``, ``PASSWORD``, ``HOST``.
+    raw_user = match.group("user") or ""
+    raw_pass = match.group("password") or ""
+    if raw_user.isupper() and raw_user.replace("_", "").isalpha():
+        return True
+    if raw_pass.isupper() and raw_pass.replace("_", "").isalpha():
+        return True
+    # L.3 — known placeholder password literal.
+    if password_lower in _PLACEHOLDER_DB_PASSWORDS:
+        return True
+    # Q.3 — placeholder password suffixes (`*_password`, `*_pass`, etc.).
+    if any(password_lower.endswith(s) for s in _PLACEHOLDER_DB_PASSWORD_SUFFIXES):
+        return True
+    # Q.4 — user == password is a near-universal dev default
+    # (`postgres:postgres@db`, `posthog:posthog@db`, `prisma:prisma@db`).
+    if user and user == password_lower:
+        return True
+    return False
+
+
+# L.4 — Local-dev URL host guard. Any matched value whose host portion is
+# loopback / .local / .test / .lan is almost certainly a dev/test artifact.
+# Applies to any detector that captures a URL-shaped value.
+_LOCAL_DEV_HOST_RE = re.compile(
+    r"://"
+    r"(?:[^@/\s]+@)?"
+    r"(?P<host>"
+    r"localhost|"
+    r"127\.\d{1,3}\.\d{1,3}\.\d{1,3}|"
+    r"::1|"
+    r"\[?::1\]?|"
+    r"0\.0\.0\.0|"
+    r"host\.docker\.internal|"
+    r"[A-Za-z0-9-]+\.(?:local|test|localhost|lan|invalid)"
+    r")"
+    r"(?::\d+)?"
+    r"(?:[/?#]|$)",
+    re.IGNORECASE,
+)
+
+
+def _is_local_dev_url(value: object) -> bool:
+    text = str(value or "")
+    if "://" not in text:
+        return False
+    return bool(_LOCAL_DEV_HOST_RE.search(text))
+
+
+# Q.7 — basic-auth-specific localhost guard. The L.4 generic regex requires a
+# clean port + path tail, which the minified-JS substrings on workos /
+# materialize / glean don't have (e.g., `https://localhost:'...@`). Check the
+# user portion of the matched ``http://USER:PASS@`` block directly.
+_BASIC_AUTH_USER_RE = re.compile(
+    r"https?://(?P<user>[^:@/\s]+):",
+    re.IGNORECASE,
+)
+_BASIC_AUTH_LOCAL_USERS = {
+    "localhost", "127.0.0.1", "0.0.0.0", "::1",
+    "host.docker.internal",
+}
+
+
+def _is_basic_auth_localhost(value: object) -> bool:
+    """Check whether the captured value (either the bare user portion captured
+    by the basic-auth regex, or the full ``http://...@`` URL) refers to a
+    loopback / local-dev host."""
+
     text = str(value or "").strip().lower()
+    # Case 1: scanner passed in the captured-user group directly.
+    if text in _BASIC_AUTH_LOCAL_USERS:
+        return True
+    if text.endswith((".local", ".test", ".localhost", ".lan", ".invalid")):
+        return True
+    # Case 2: scanner passed in the full ``http://USER:PASS@`` block.
+    match = _BASIC_AUTH_USER_RE.search(text)
+    if match:
+        user = (match.group("user") or "").strip().lower()
+        if user in _BASIC_AUTH_LOCAL_USERS:
+            return True
+        if user.endswith((".local", ".test", ".localhost", ".lan", ".invalid")):
+            return True
+    return False
+
+
+# Q.8 — values that announce themselves as public (``public_key_*``, ``pk_*``,
+# ``publishable_*``, ``client_id_*``) shouldn't trip critical secret detectors.
+_PUBLIC_PREFIXES = ("public_", "public-", "publishable_", "publishable-", "pk_", "client_id_", "client-id-")
+
+
+def _has_public_prefix(value: object) -> bool:
+    text = str(value or "").strip().lower()
+    # The basic_auth / bearer / openai regex may capture a "Bearer foo" or
+    # "Authorization: Bearer foo" lead-in; strip it before checking.
+    for prefix in ("bearer ", "authorization: bearer ", "bearer:"):
+        if text.startswith(prefix):
+            text = text[len(prefix):].lstrip()
+            break
+    return any(text.startswith(p) for p in _PUBLIC_PREFIXES)
+
+
+# Q.6 — Google's AIza-prefixed keys are often referrer-restricted client keys
+# (Firebase, Maps, Analytics, Custom Search). Surface a softer "medium"
+# severity when the surrounding snippet has any of these markers. We don't
+# fully suppress because un-restricted server keys *do* leak this way too.
+_CLIENT_SIDE_AIZA_MARKERS = (
+    "firebaseConfig",
+    "firebase_config",
+    "apiKey",
+    "api_key",
+    "google_api_key",
+    "googleapikey",
+    "gapi.client",
+    "maps.googleapis.com",
+    "googleapis.com/maps",
+    "google-analytics.com",
+    "googletagmanager.com",
+    "googletagservices",
+    "firebaseapp",
+    "appsforyourdomain",
+    "youtube.googleapis.com",
+    "GoogleAnalyticsObject",
+    "ga(",
+    "gtag(",
+    "fbq(",
+    # Q.12 — OAuth + GIS markers (Google Identity Services).
+    "apps.googleusercontent.com",
+    "google_client_id",
+    "google_project_id",
+    "drive_import",
+    "google_drive",
+    "googledrive",
+    "google.accounts.id",
+    "accounts.google.com",
+    "GIS_CLIENT_ID",
+)
+
+
+def _looks_like_client_side_aiza(snippet: object) -> bool:
+    text = str(snippet or "")
+    return any(marker.lower() in text.lower() for marker in _CLIENT_SIDE_AIZA_MARKERS)
+
+
+def _shannon_entropy(value: object) -> float:
+    """Shannon entropy in bits/character.
+
+    Dictionary-word matches like ``sk-indigo-twilight-color-1`` have entropy
+    around 3.0 bits/char. Real OpenAI / AWS / Stripe keys are ~5.0+ bits/char
+    (random alphanumeric). Threshold of 4.0 separates them cleanly.
+    """
+
+    text = str(value or "")
+    if not text:
+        return 0.0
+    counts: dict = {}
+    for ch in text:
+        counts[ch] = counts.get(ch, 0) + 1
+    import math
+
+    total = len(text)
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def _is_placeholder(value: object, min_length: int = 8) -> bool:
+    raw = str(value or "")
+    text = raw.strip().lower()
     if min_length > 0 and len(text) < min_length:
         return True
     exact = {"example", "placeholder", "changeme", "dummy", "fake", "test"}
@@ -158,4 +638,33 @@ def _is_placeholder(value: object, min_length: int = 8) -> bool:
     if text.startswith(prefixes):
         return True
     tokens = {token for token in re.split(r"[^a-z0-9]+", text) if token}
-    return bool(tokens) and tokens.issubset(exact)
+    if tokens and tokens.issubset(exact):
+        return True
+    # Q.13 — well-known placeholder words appearing as a substring of the
+    # captured value (``AKIAIOSFODNN7EXAMPLE``, ``ABCDPLACEHOLDER123``, etc.).
+    for word in ("example", "placeholder", "changeme", "dummy", "fake"):
+        if word in text and len(text) - len(word) < 20:
+            return True
+    # Q.13 — high single-character repetition is a docs / example placeholder.
+    # ``AKIAXXXXXXXXXXXXXXXX``, ``AAAAAAAAAAAAAAAAAAAAA``, etc.
+    alnum = re.sub(r"[^a-z0-9]", "", text)
+    if alnum and len(alnum) >= 8:
+        counts: dict = {}
+        for ch in alnum:
+            counts[ch] = counts.get(ch, 0) + 1
+        most_common_share = max(counts.values()) / len(alnum)
+        if most_common_share >= 0.5:
+            return True
+    # Q.13 — ALL-CAPS-LETTER-ONLY placeholders like ``USER``, ``PASSWORD``,
+    # ``POSTGRES_PASSWORD``. Real credentials almost always include digits;
+    # require letters-and-underscores only to keep AWS-shaped keys (which are
+    # uppercase letters + digits) from being false-positive-suppressed.
+    if raw and re.fullmatch(r"[A-Z][A-Z_]*", raw) and "_" in raw or raw in {
+        "USER", "USERNAME", "PASSWORD", "PASS", "HOST", "PORT", "DATABASE",
+        "DBNAME", "DB", "SECRET", "TOKEN", "API_KEY", "APIKEY",
+    }:
+        return True
+    # Q.13 — capitalized braced placeholder like ``{POSTGRES_PASSWORD}``.
+    if re.fullmatch(r"\{[A-Z_][A-Z_0-9]*\}", raw):
+        return True
+    return False

--- a/keyleak/models.py
+++ b/keyleak/models.py
@@ -22,6 +22,59 @@ VERDICT_REVIEW = "REVIEW"
 VERDICT_BLOCK = "BLOCK_SHIP"
 
 
+# Wave 1.6 — Structured Remediation contract.
+#
+# Every finding's emitter (Markdown, SARIF, the CLI `explain` subcommand, the
+# extension popup) renders the same four-field card so developers see
+# *what leaked*, *why it matters*, *what to do*, and *how to verify*.
+# Detectors can populate ``Remediation`` explicitly; if absent, an auto-derived
+# Remediation is built from the existing ``description`` / ``attack_scenario``
+# / ``remediation`` (single-line) fields so all 43 detectors satisfy the
+# contract by default.
+
+@dataclass
+class Remediation:
+    what_leaked: str
+    why_it_matters: str
+    fix_steps: List[str]
+    verify_command: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "what_leaked": self.what_leaked,
+            "why_it_matters": self.why_it_matters,
+            "fix_steps": list(self.fix_steps),
+            "verify_command": self.verify_command,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "Remediation":
+        return cls(
+            what_leaked=str(payload.get("what_leaked") or ""),
+            why_it_matters=str(payload.get("why_it_matters") or ""),
+            fix_steps=[str(step) for step in (payload.get("fix_steps") or [])],
+            verify_command=str(payload.get("verify_command") or ""),
+        )
+
+
+def derive_remediation(
+    description: str,
+    attack_scenario: Optional[str],
+    remediation_text: str,
+) -> Remediation:
+    """Build a structured Remediation from existing detector fields."""
+
+    fix_steps = [step.strip() for step in (remediation_text or "").split(". ") if step.strip()]
+    if not fix_steps and remediation_text:
+        fix_steps = [remediation_text.strip()]
+    return Remediation(
+        what_leaked=description.strip(),
+        why_it_matters=(attack_scenario or description).strip(),
+        fix_steps=fix_steps,
+        verify_command="",
+    )
+
+
 @dataclass
 class Evidence:
     source: str
@@ -63,9 +116,14 @@ class Finding:
     evidence: Evidence
     risk_reason: str
     remediation: str
-    validation_status: str = "not_validated"
+    validation_status: str = "lead"
+    category: str = ""
     references: List[str] = field(default_factory=list)
     id: str = ""
+    # Wave 1.6 — Structured Remediation card. Optional dict (kept dict-shaped
+    # for backward compat with from_dict consumers). Populated by ``scan_text``
+    # from the detector. Reporters render it if present.
+    remediation_v2: Optional[Dict[str, Any]] = None
 
     def __post_init__(self) -> None:
         self.severity = normalize_severity(self.severity)
@@ -80,7 +138,7 @@ class Finding:
             )
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        payload = {
             "id": self.id,
             "type": self.type,
             "severity": self.severity,
@@ -92,9 +150,13 @@ class Finding:
             "redacted_value": self.evidence.redacted_value,
             "risk_reason": self.risk_reason,
             "remediation": self.remediation,
+            "category": self.category,
             "references": self.references,
             "validation_status": self.validation_status,
         }
+        if self.remediation_v2:
+            payload["remediation_v2"] = dict(self.remediation_v2)
+        return payload
 
     @classmethod
     def from_dict(cls, payload: Dict[str, Any]) -> "Finding":
@@ -115,9 +177,11 @@ class Finding:
             evidence=evidence,
             risk_reason=str(payload.get("risk_reason") or ""),
             remediation=str(payload.get("remediation") or ""),
-            validation_status=str(payload.get("validation_status") or "not_validated"),
+            validation_status=str(payload.get("validation_status") or "lead"),
+            category=str(payload.get("category") or payload.get("pack") or ""),
             references=list(payload.get("references") or []),
             id=str(payload.get("id") or ""),
+            remediation_v2=payload.get("remediation_v2"),
         )
 
 
@@ -222,6 +286,12 @@ def finding_from_legacy(raw: Dict[str, Any], detector_prefix: str = "runtime") -
     finding_type = str(raw.get("type") or "unknown")
     severity = normalize_severity(raw.get("severity"))
     source = str(raw.get("source") or "unknown")
+    category = str(raw.get("category") or raw.get("pack") or "")
+    if not category:
+        if finding_type == "access_control_issue":
+            category = "access-control"
+        else:
+            category = "leak"
     raw_value = raw.get("value") if raw.get("value") is not None else raw.get("match", "")
     redacted_value = redact_value(raw_value)
     snippet = raw.get("context_lines") or raw.get("context") or raw.get("details") or ""
@@ -249,6 +319,7 @@ def finding_from_legacy(raw: Dict[str, Any], detector_prefix: str = "runtime") -
         evidence=evidence,
         risk_reason=str(raw.get("context") or raw.get("details") or f"{finding_type} detected in {source}"),
         remediation=str(raw.get("recommendation") or "Review this finding and remove exposed sensitive data."),
-        validation_status=str(raw.get("validation_status") or "not_validated"),
+        validation_status=str(raw.get("validation_status") or ("lead" if category != "leak" else "validated")),
+        category=category,
         references=list(raw.get("references") or []),
     )

--- a/keyleak/offline_guard.py
+++ b/keyleak/offline_guard.py
@@ -1,0 +1,104 @@
+"""``--offline`` mode: provable network isolation.
+
+A buyer in a regulated or air-gapped environment must be able to prove that
+KeyLeak makes zero outbound network calls. ``--offline`` monkey-patches
+``socket.socket.connect`` to allow only loopback connections (``127.0.0.1``,
+``::1``, ``localhost``) and raises ``OfflineViolation`` for anything else.
+
+The patch runs before any KeyLeak module that opens a socket. It does not
+block local IPC (mitmproxy and the Flask bridge listen on 127.0.0.1).
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from typing import List, Optional
+
+
+class OfflineViolation(RuntimeError):
+    """Raised when ``--offline`` mode rejects an outbound socket connection."""
+
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+_INSTALLED = False
+_ORIGINAL_CONNECT: Optional[callable] = None
+# 4-tuple addresses ((host, port, flowinfo, scopeid)) only have str/int in [0].
+# Pre-resolved IP families have str ports too. We accept any address whose
+# first element is loopback or '' (Unix socket).
+
+
+def _is_loopback(address) -> bool:
+    if address is None:
+        return False
+    if isinstance(address, (bytes, str)) and not address:
+        return True  # Unix socket path
+    if isinstance(address, str) and address.startswith("/"):
+        return True  # explicit Unix socket path
+    if isinstance(address, tuple) and address:
+        host = address[0]
+        if isinstance(host, bytes):
+            try:
+                host = host.decode("utf-8")
+            except UnicodeDecodeError:
+                return False
+        if not isinstance(host, str):
+            return False
+        if host in _LOOPBACK_HOSTS:
+            return True
+        # Treat private DNS like ``host.docker.internal`` resolving to 127.x as
+        # loopback — but a real DNS lookup may resolve elsewhere. Be strict and
+        # require literal loopback addresses or 'localhost'.
+    return False
+
+
+def install_socket_block() -> None:
+    """Patch ``socket.socket.connect`` to allow only loopback connections."""
+
+    global _INSTALLED, _ORIGINAL_CONNECT
+
+    if _INSTALLED:
+        return
+    _ORIGINAL_CONNECT = socket.socket.connect
+
+    def guarded_connect(self, address):  # type: ignore[no-redef]
+        if not _is_loopback(address):
+            raise OfflineViolation(
+                f"--offline blocked outbound socket to {address!r}. "
+                "Set KEYLEAK_OFFLINE_ALLOW_HOSTS to extend, or run without --offline."
+            )
+        return _ORIGINAL_CONNECT(self, address)
+
+    socket.socket.connect = guarded_connect  # type: ignore[assignment]
+    _INSTALLED = True
+
+
+def uninstall_socket_block() -> None:
+    """Restore the original ``socket.socket.connect`` (for tests)."""
+
+    global _INSTALLED, _ORIGINAL_CONNECT
+    if not _INSTALLED:
+        return
+    if _ORIGINAL_CONNECT is not None:
+        socket.socket.connect = _ORIGINAL_CONNECT
+    _INSTALLED = False
+    _ORIGINAL_CONNECT = None
+
+
+KNOWN_EGRESS_TARGETS: List[str] = [
+    "the URL passed to `keyleak scan` (only when `--offline` is OFF)",
+    "GitHub-token-revocation endpoint (Wave 3.3 `keyleak diff --revoke` only)",
+    "OSV.dev + OpenSSF malicious-packages feeds (Wave 3.2 `keyleak feed sync` only)",
+    "AWS / Stripe / OpenAI / Anthropic security contacts (Wave 1.7 `keyleak disclose` if invoked)",
+    "vendor sigstore registries (signature verification, if cosign is invoked)",
+]
+
+
+def print_egress_banner(stream=sys.stderr) -> None:
+    """Document the *known* outbound endpoints, off mode only."""
+
+    print("KeyLeak --offline ON. Without --offline, KeyLeak may contact:", file=stream)
+    for target in KNOWN_EGRESS_TARGETS:
+        print(f"  - {target}", file=stream)
+    print("Loopback (127.0.0.1, ::1, localhost) remains allowed.", file=stream)

--- a/keyleak/privacy_filter.py
+++ b/keyleak/privacy_filter.py
@@ -1,0 +1,80 @@
+"""PII pre-emission scrubber.
+
+KeyLeak scans authenticated traffic and local files — the snippet around a
+detector hit often includes adjacent PII (email addresses, phone numbers,
+payment data, user names) that has no business in a findings report. Without
+this filter, the same network capture that catches a Stripe key also leaks the
+customer's support-ticket thread.
+
+Ordering matters. The scrubber runs **after** detector match, when the
+``Evidence.snippet`` is built. Running it before would risk masking a real
+secret that happens to live inside a PII-shaped string. The scrubber's job is
+to keep adjacent PII out of the snippet, not to hide the matched secret.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+
+# Order matters: longer / more-specific patterns must apply before shorter ones.
+_PATTERNS: List[Tuple[re.Pattern[str], str]] = [
+    # Email addresses.
+    (re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"), "[email]"),
+    # US-style phone numbers like +1 555-123-4567 or (555) 123-4567.
+    (
+        re.compile(
+            r"(?:\+\d{1,3}[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b"
+        ),
+        "[phone]",
+    ),
+    # SSN-like 3-2-4 digit groups.
+    (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "[ssn]"),
+    # Card-like 16-digit numbers (with separators allowed).
+    (
+        re.compile(r"\b(?:\d[ -]?){13,19}\d\b"),
+        "[card-or-num]",
+    ),
+    # Street-address-ish patterns (number + words + STREET-TYPE).
+    (
+        re.compile(
+            r"\b\d{1,5}\s+[A-Za-z][A-Za-z0-9.\s]{2,40}\b(?:Street|St|Avenue|Ave|Boulevard|Blvd|Road|Rd|Drive|Dr|Lane|Ln|Way|Court|Ct)\b",
+            re.IGNORECASE,
+        ),
+        "[addr]",
+    ),
+]
+
+
+def scrub_text(text: str) -> str:
+    """Mask PII in ``text``. Used for free-form bodies."""
+
+    if not text:
+        return text
+    out = text
+    for pattern, replacement in _PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+def scrub_snippet(snippet: str, preserve: Optional[str] = None) -> str:
+    """Mask PII in a finding snippet while preserving the matched (already-redacted)
+    secret token.
+
+    ``preserve`` is the *already-redacted* secret value (e.g.
+    ``"[redacted:abc123]"`` or ``"AKIA...[redacted]...wxyz"``). It is replaced
+    with a sentinel before scrubbing and restored after — so a PII scrubber
+    that happens to overlap with the redacted shape doesn't double-mask the
+    finding itself.
+    """
+
+    if not snippet:
+        return snippet
+    if not preserve:
+        return scrub_text(snippet)
+
+    sentinel = "\x01KEYLEAK_FINDING\x01"
+    placeholder_snippet = snippet.replace(preserve, sentinel)
+    scrubbed = scrub_text(placeholder_snippet)
+    return scrubbed.replace(sentinel, preserve)

--- a/keyleak/redaction.py
+++ b/keyleak/redaction.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
+import os
 import re
 from typing import Optional
 
@@ -25,19 +27,61 @@ SECRET_QUERY_KEYS = {
 }
 
 
+# Env override for deterministic redaction in tests. Hex-encoded bytes.
+REDACTION_SALT_ENV = "KEYLEAK_REDACTION_SALT_HEX"
+
+
+def new_run_salt() -> bytes:
+    """Return per-scan HMAC salt.
+
+    Honors ``KEYLEAK_REDACTION_SALT_HEX`` for deterministic tests; otherwise
+    32 bytes from ``os.urandom``.
+    """
+
+    override = os.environ.get(REDACTION_SALT_ENV)
+    if override:
+        try:
+            return bytes.fromhex(override)
+        except ValueError:
+            pass  # fall through to urandom
+    return os.urandom(32)
+
+
 def stable_id(*parts: object, prefix: str = "finding") -> str:
     payload = "\n".join("" if part is None else str(part) for part in parts)
     digest = hashlib.sha256(payload.encode("utf-8", errors="replace")).hexdigest()[:16]
     return f"{prefix}_{digest}"
 
 
-def redact_value(value: object, keep_start: int = 6, keep_end: int = 4) -> str:
+def redact_value(
+    value: object,
+    keep_start: int = 6,
+    keep_end: int = 4,
+    *,
+    run_salt: Optional[bytes] = None,
+) -> str:
+    """Redact a value before it's emitted in a finding.
+
+    - If ``run_salt`` is supplied: emit ``[redacted:<8-hex>]`` where the 8 hex
+      chars are HMAC-SHA256(salt, value). This is the diff-resistant mode used
+      by the scanner — two reports of the same content scanned with different
+      salts produce different HMACs, so an analyst cannot diff them to recover
+      the secret. Within one scan (same salt), the same secret produces the
+      same HMAC, so dedup still works.
+    - Without ``run_salt``: legacy prefix/suffix masking ``aBcDeF...[redacted]...wxyz``.
+      Callers that haven't migrated still work.
+    """
+
     if value is None:
         return ""
 
     text = str(value).strip()
     if not text:
         return ""
+
+    if run_salt is not None:
+        digest = hmac.new(run_salt, text.encode("utf-8"), hashlib.sha256).hexdigest()[:8]
+        return f"[redacted:{digest}]"
 
     if len(text) <= keep_start + keep_end + 6:
         if len(text) <= 4:
@@ -64,7 +108,12 @@ def redact_url(url: object) -> str:
     return re.sub(r"([?&])([^=&]+)=([^&#]+)", replace_secret, text)
 
 
-def redact_snippet(snippet: object, raw_value: Optional[object] = None) -> str:
+def redact_snippet(
+    snippet: object,
+    raw_value: Optional[object] = None,
+    *,
+    run_salt: Optional[bytes] = None,
+) -> str:
     if snippet is None:
         return ""
 
@@ -72,5 +121,5 @@ def redact_snippet(snippet: object, raw_value: Optional[object] = None) -> str:
     if raw_value:
         raw_text = str(raw_value)
         if raw_text and raw_text in text:
-            return text.replace(raw_text, redact_value(raw_text))
+            return text.replace(raw_text, redact_value(raw_text, run_salt=run_salt))
     return text

--- a/keyleak/self_audit.py
+++ b/keyleak/self_audit.py
@@ -1,0 +1,437 @@
+"""KeyLeak self-supply-chain audit.
+
+Audits the KeyLeak repository for known supply-chain attack surfaces:
+
+- Tag-pinned GitHub Actions ``uses:`` references (must be full SHA pins).
+- Dangerous workflow triggers (``pull_request_target``, ``workflow_run``).
+- Risky ``extension/package.json`` shapes (``optionalDependencies`` git refs,
+  lifecycle scripts ``prepare`` / ``preinstall`` / ``postinstall``).
+- Missing ``poetry.lock`` (and drift, if poetry is installed).
+- Missing ``.github/CODEOWNERS`` covering ``.github/workflows/``.
+- Expired entries in a ``keyleak-allowlist.yaml`` (best-effort, forward-looking
+  for Wave 1.2).
+
+The audit returns a regular :class:`~keyleak.models.ScanReport` so the existing
+verdict + emit + fail-on logic reused by the CLI works without changes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .models import Evidence, Finding, ScanReport
+from .reporting import build_report
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def run_self_audit(repo_root: Path) -> ScanReport:
+    """Run every audit check against ``repo_root`` and return a ``ScanReport``."""
+
+    repo_root = Path(repo_root).resolve()
+    findings: List[Finding] = []
+
+    findings.extend(_audit_workflows(repo_root))
+    findings.extend(_audit_extension_package_json(repo_root))
+    findings.extend(_audit_poetry_lockfile(repo_root))
+    findings.extend(_audit_codeowners(repo_root))
+    findings.extend(_audit_allowlist_yaml(repo_root))
+
+    return build_report(
+        str(repo_root),
+        findings,
+        scan_mode="self-audit",
+        profile="self-audit",
+        packs=["self-audit"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workflow audit
+# ---------------------------------------------------------------------------
+
+# Match a `uses: owner/repo@ref` line. We only care about the ref.
+_USES_LINE_RE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)\s*(?:#.*)?$", re.MULTILINE)
+_SHA_RE = re.compile(r"^[a-f0-9]{40}$")
+# Top-level `on:` block may be inline (`on: [pull_request]`) or block-style.
+_ON_INLINE_RE = re.compile(r"^on:\s*(.+)$", re.MULTILINE)
+_ON_BLOCK_RE = re.compile(r"^on:\s*\n((?:[ \t]+.+\n?)+)", re.MULTILINE)
+_DANGEROUS_TRIGGERS = ("pull_request_target", "workflow_run")
+# Local actions like `./.github/actions/foo` don't need SHA pins.
+_LOCAL_REF_RE = re.compile(r"^\.{1,2}/")
+
+
+def _audit_workflows(repo_root: Path) -> List[Finding]:
+    findings: List[Finding] = []
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return findings
+
+    for workflow_path in sorted(workflows_dir.glob("*.y*ml")):
+        try:
+            content = workflow_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            findings.append(_finding(
+                detector_id="self_audit.workflow_unreadable",
+                finding_type="workflow_unreadable",
+                severity="medium",
+                source=str(workflow_path.relative_to(repo_root)),
+                snippet=str(exc),
+                risk_reason="Workflow file could not be read.",
+                remediation="Check file permissions and re-run self-audit.",
+            ))
+            continue
+
+        findings.extend(_audit_workflow_uses(workflow_path, repo_root, content))
+        findings.extend(_audit_workflow_triggers(workflow_path, repo_root, content))
+
+    return findings
+
+
+def _audit_workflow_uses(workflow_path: Path, repo_root: Path, content: str) -> List[Finding]:
+    findings: List[Finding] = []
+    rel = str(workflow_path.relative_to(repo_root))
+
+    for match in _USES_LINE_RE.finditer(content):
+        spec = match.group(1).strip().strip('"').strip("'")
+        if _LOCAL_REF_RE.match(spec):
+            continue  # local composite actions are not SHA-pinned
+        if "@" not in spec:
+            findings.append(_finding(
+                detector_id="self_audit.workflow_uses_unpinned",
+                finding_type="workflow_uses_unpinned",
+                severity="high",
+                source=rel,
+                line=content.count("\n", 0, match.start()) + 1,
+                snippet=match.group(0).strip(),
+                risk_reason=f"Action `{spec}` has no ref pin at all.",
+                remediation="Pin to a full 40-character commit SHA.",
+            ))
+            continue
+        ref = spec.rsplit("@", 1)[1]
+        if not _SHA_RE.match(ref):
+            findings.append(_finding(
+                detector_id="self_audit.workflow_uses_tag_pinned",
+                finding_type="workflow_uses_tag_pinned",
+                severity="high",
+                source=rel,
+                line=content.count("\n", 0, match.start()) + 1,
+                snippet=match.group(0).strip(),
+                risk_reason=(
+                    f"`{spec}` is tag-pinned. Tags can be moved by the action publisher; "
+                    "use a full 40-character commit SHA."
+                ),
+                remediation=(
+                    f"Replace `@{ref}` with the full commit SHA from "
+                    f"https://github.com/{spec.rsplit('@', 1)[0]}/commits"
+                ),
+            ))
+    return findings
+
+
+def _audit_workflow_triggers(workflow_path: Path, repo_root: Path, content: str) -> List[Finding]:
+    findings: List[Finding] = []
+    rel = str(workflow_path.relative_to(repo_root))
+
+    inline = _ON_INLINE_RE.search(content)
+    block = _ON_BLOCK_RE.search(content)
+    on_text = ""
+    if inline:
+        on_text = inline.group(1)
+    if block:
+        on_text += "\n" + block.group(1)
+
+    for trigger in _DANGEROUS_TRIGGERS:
+        if re.search(rf"\b{re.escape(trigger)}\b", on_text):
+            findings.append(_finding(
+                detector_id="self_audit.workflow_dangerous_trigger",
+                finding_type="workflow_dangerous_trigger",
+                severity="critical",
+                source=rel,
+                snippet=f"on: ... {trigger}",
+                risk_reason=(
+                    f"Workflow uses `{trigger}` trigger, which runs in the context of the base "
+                    "repo with write scope. This is the 'Pwn Request' pattern."
+                ),
+                remediation=(
+                    "Switch to `pull_request`. If you must inspect PR state with write scope, "
+                    "split into two workflows and pass artifacts between them."
+                ),
+            ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# extension/package.json audit
+# ---------------------------------------------------------------------------
+
+_GIT_REF_RE = re.compile(r"^(?:github:|git\+|git://|ssh://)", re.IGNORECASE)
+_LIFECYCLE_SCRIPTS = ("prepare", "preinstall", "postinstall")
+
+
+def _audit_extension_package_json(repo_root: Path) -> List[Finding]:
+    findings: List[Finding] = []
+    package_path = repo_root / "extension" / "package.json"
+    if not package_path.is_file():
+        return findings
+
+    try:
+        data = json.loads(package_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        findings.append(_finding(
+            detector_id="self_audit.package_json_unreadable",
+            finding_type="package_json_unreadable",
+            severity="medium",
+            source="extension/package.json",
+            snippet=str(exc),
+            risk_reason="extension/package.json could not be parsed.",
+            remediation="Restore valid JSON in extension/package.json.",
+        ))
+        return findings
+
+    optional_deps = data.get("optionalDependencies") or {}
+    for name, version in optional_deps.items():
+        if isinstance(version, str) and _GIT_REF_RE.match(version):
+            findings.append(_finding(
+                detector_id="self_audit.npm_optional_dep_git_ref",
+                finding_type="npm_optional_dep_git_ref",
+                severity="high",
+                source="extension/package.json",
+                snippet=f'"{name}": "{version}"',
+                risk_reason=(
+                    "optionalDependencies points to a git ref. This is the Mini Shai-Hulud "
+                    "vector that hit @tanstack on 2026-05-11."
+                ),
+                remediation=(
+                    "Remove the git-ref dependency. Pin to a published semver from the registry "
+                    "or vendor the code in-tree."
+                ),
+            ))
+
+    scripts = data.get("scripts") or {}
+    for hook in _LIFECYCLE_SCRIPTS:
+        if hook in scripts:
+            findings.append(_finding(
+                detector_id="self_audit.npm_lifecycle_script",
+                finding_type="npm_lifecycle_script",
+                severity="high",
+                source="extension/package.json",
+                snippet=f'"{hook}": {json.dumps(scripts[hook])}',
+                risk_reason=(
+                    f"`scripts.{hook}` runs arbitrary code at install time. This is the "
+                    "exfil-on-install vector the worm family uses."
+                ),
+                remediation=(
+                    f"Remove `scripts.{hook}`. If you genuinely need a build step, move it to a "
+                    "dev-time `build` script that contributors run explicitly."
+                ),
+            ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# poetry.lock audit
+# ---------------------------------------------------------------------------
+
+def _audit_poetry_lockfile(repo_root: Path) -> List[Finding]:
+    findings: List[Finding] = []
+    lock_path = repo_root / "poetry.lock"
+    pyproject_path = repo_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        return findings
+
+    if not lock_path.is_file():
+        findings.append(_finding(
+            detector_id="self_audit.poetry_lock_missing",
+            finding_type="poetry_lock_missing",
+            severity="medium",
+            source="poetry.lock",
+            snippet="missing",
+            risk_reason=(
+                "poetry.lock is not checked in. Production installs are not reproducible and "
+                "transitive deps can drift silently."
+            ),
+            remediation="Run `poetry lock --no-update` and commit poetry.lock.",
+        ))
+        return findings
+
+    poetry = shutil.which("poetry")
+    if poetry is None:
+        return findings  # best-effort: skip lock-drift check if poetry isn't installed
+
+    try:
+        result = subprocess.run(
+            [poetry, "check", "--lock"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return findings
+
+    if result.returncode != 0:
+        findings.append(_finding(
+            detector_id="self_audit.poetry_lock_drift",
+            finding_type="poetry_lock_drift",
+            severity="medium",
+            source="poetry.lock",
+            snippet=(result.stderr or result.stdout or "").strip()[:400] or "poetry check --lock failed",
+            risk_reason=(
+                "poetry.lock is out of sync with pyproject.toml. Reproducible installs may pick "
+                "up unexpected versions."
+            ),
+            remediation="Run `poetry lock --no-update` and commit the regenerated poetry.lock.",
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# CODEOWNERS audit
+# ---------------------------------------------------------------------------
+
+def _audit_codeowners(repo_root: Path) -> List[Finding]:
+    findings: List[Finding] = []
+    candidates = [
+        repo_root / ".github" / "CODEOWNERS",
+        repo_root / "CODEOWNERS",
+        repo_root / "docs" / "CODEOWNERS",
+    ]
+    existing = [path for path in candidates if path.is_file()]
+    if not existing:
+        findings.append(_finding(
+            detector_id="self_audit.codeowners_missing",
+            finding_type="codeowners_missing",
+            severity="medium",
+            source=".github/CODEOWNERS",
+            snippet="missing",
+            risk_reason=(
+                "CODEOWNERS is missing. Without it, branch protection cannot require human review "
+                "on sensitive paths like .github/workflows/."
+            ),
+            remediation=(
+                "Create .github/CODEOWNERS covering .github/workflows/, keyleak/, pyproject.toml, "
+                "poetry.lock, extension/package.json, and keyleak-allowlist.*"
+            ),
+        ))
+        return findings
+
+    content = existing[0].read_text(encoding="utf-8")
+    required_patterns = (
+        ".github/workflows",
+        "keyleak",
+        "pyproject.toml",
+    )
+    missing = [pattern for pattern in required_patterns if pattern not in content]
+    if missing:
+        findings.append(_finding(
+            detector_id="self_audit.codeowners_incomplete",
+            finding_type="codeowners_incomplete",
+            severity="low",
+            source=str(existing[0].relative_to(repo_root)),
+            snippet=f"missing patterns: {', '.join(missing)}",
+            risk_reason=(
+                "CODEOWNERS exists but does not cover all sensitive paths. Without coverage, those "
+                "paths can be edited without an owner review."
+            ),
+            remediation=(
+                "Add owner rules for: " + ", ".join(missing)
+            ),
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Allowlist YAML audit (forward-looking for Wave 1.2)
+# ---------------------------------------------------------------------------
+
+# Simple line-based date scan. We don't pull in PyYAML just for this.
+_EXPIRES_RE = re.compile(r"^\s*expires_at:\s*[\"']?(\d{4}-\d{2}-\d{2})[\"']?\s*$", re.MULTILINE)
+_TODAY_OVERRIDE_ENV = "KEYLEAK_SELF_AUDIT_TODAY"  # for tests
+
+
+def _today_iso() -> str:
+    import os
+    from datetime import date
+
+    override = os.environ.get(_TODAY_OVERRIDE_ENV)
+    if override:
+        return override
+    return date.today().isoformat()
+
+
+def _audit_allowlist_yaml(repo_root: Path) -> List[Finding]:
+    findings: List[Finding] = []
+    candidates = list(repo_root.glob("keyleak-allowlist.y*ml"))
+    if not candidates:
+        return findings
+
+    today = _today_iso()
+    for path in candidates:
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in _EXPIRES_RE.finditer(content):
+            expires = match.group(1)
+            if expires < today:
+                findings.append(_finding(
+                    detector_id="self_audit.allowlist_entry_expired",
+                    finding_type="allowlist_entry_expired",
+                    severity="medium",
+                    source=str(path.relative_to(repo_root)),
+                    line=content.count("\n", 0, match.start()) + 1,
+                    snippet=match.group(0).strip(),
+                    risk_reason=(
+                        f"Allowlist entry expired on {expires} (today is {today}). Expired entries "
+                        "should be removed or renewed to keep the gate honest."
+                    ),
+                    remediation=(
+                        "Remove the expired allowlist entry, or extend `expires_at` after a "
+                        "fresh review."
+                    ),
+                ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _finding(
+    *,
+    detector_id: str,
+    finding_type: str,
+    severity: str,
+    source: str,
+    snippet: str = "",
+    risk_reason: str,
+    remediation: str,
+    line: Optional[int] = None,
+) -> Finding:
+    evidence = Evidence(
+        source=source,
+        snippet=snippet,
+        line=line,
+        redacted_value=snippet[:120],
+    )
+    return Finding(
+        type=finding_type,
+        severity=severity,
+        confidence=0.95,
+        detector_id=detector_id,
+        source=source,
+        evidence=evidence,
+        risk_reason=risk_reason,
+        remediation=remediation,
+        validation_status="validated",
+        category="self-audit",
+    )

--- a/keyleak/sourcemaps.py
+++ b/keyleak/sourcemaps.py
@@ -1,0 +1,189 @@
+"""Source-map deobfuscation (Wave 2.1).
+
+Reconstructs original sources from a JavaScript source-map (v3) so detectors
+run against ``src/components/Auth.tsx:42`` instead of a minified
+``a.js:1:42``. The PR-comment screenshot shows the *original* line.
+
+Safety
+------
+``fetch_sourcemap_for`` enforces a strict sandbox:
+
+- Size cap (default 8 MiB).
+- Same-origin: the .map URL must share scheme + host with the bundle URL.
+- No follow-redirects: anything HTTP 3xx is treated as failure.
+- No chained .map references: we deobfuscate the immediate sources, not their
+  own source maps.
+
+Without these guards, a malicious PR could point ``//# sourceMappingURL=...``
+at attacker-controlled hosts that return giant payloads or SSRF targets while
+KeyLeak's CI runs with ``GITHUB_TOKEN`` write scope.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+from urllib.parse import urljoin, urlparse
+
+
+MAX_SOURCEMAP_BYTES = 8 * 1024 * 1024  # 8 MiB
+SOURCE_MAPPING_RE = re.compile(
+    r"(?://[#@]|/\*[#@])\s*sourceMappingURL=([^\s'\"<>*]+)\s*\*?/?\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class SourceMapEntry:
+    """One reconstructed source from a v3 source map."""
+
+    source_path: str  # logical name from the map's "sources" array
+    content: str      # original source text
+
+
+class SourceMapError(RuntimeError):
+    """Recoverable failure parsing or fetching a source map."""
+
+
+def find_sourcemap_url(bundle_text: str) -> Optional[str]:
+    """Return the trailing ``sourceMappingURL`` directive, if present."""
+
+    matches = list(SOURCE_MAPPING_RE.finditer(bundle_text))
+    if not matches:
+        return None
+    return matches[-1].group(1).strip()
+
+
+def parse_sourcemap_payload(text: str) -> List[SourceMapEntry]:
+    """Parse a v3 source map JSON and yield ``SourceMapEntry`` per source.
+
+    Drops sources without ``sourcesContent`` (those would require a second
+    fetch which is forbidden by the sandbox).
+    """
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SourceMapError(f"invalid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SourceMapError("source map root must be an object")
+    if data.get("version") not in (3, "3"):
+        # Be permissive — Vite/webpack/esbuild all emit v3 but some emit no version.
+        if data.get("version") is not None:
+            raise SourceMapError(f"unsupported source map version: {data.get('version')!r}")
+
+    sources = data.get("sources") or []
+    contents = data.get("sourcesContent") or []
+    entries: List[SourceMapEntry] = []
+    for index, source in enumerate(sources):
+        if not isinstance(source, str):
+            continue
+        if index >= len(contents):
+            continue
+        content = contents[index]
+        if not isinstance(content, str):
+            continue
+        entries.append(SourceMapEntry(source_path=source, content=content))
+    return entries
+
+
+def load_sourcemap_from_disk(bundle_path: Path) -> List[SourceMapEntry]:
+    """For ``keyleak local`` — locate the sibling ``.map`` file next to ``bundle_path``.
+
+    A bundle file ``dist/app.js`` is typically accompanied by
+    ``dist/app.js.map``. Returns an empty list if no sibling map exists.
+    """
+
+    map_path = bundle_path.with_suffix(bundle_path.suffix + ".map")
+    if not map_path.is_file():
+        # Some bundlers emit "app.js.map" alongside "app.js" — that's the
+        # default; some emit "app.map" — check that too.
+        alt = bundle_path.with_suffix(".map")
+        if not alt.is_file():
+            return []
+        map_path = alt
+
+    if map_path.stat().st_size > MAX_SOURCEMAP_BYTES:
+        raise SourceMapError(f"source map exceeds {MAX_SOURCEMAP_BYTES} bytes: {map_path}")
+
+    try:
+        text = map_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise SourceMapError(f"could not read {map_path}: {exc}") from exc
+    return parse_sourcemap_payload(text)
+
+
+def is_safe_remote_url(map_url: str, bundle_url: str) -> bool:
+    """Enforce same-origin + non-redirect rules on a remote ``.map`` URL.
+
+    Returns False if the URL is not safe to fetch. The caller refuses the
+    network fetch when this is False.
+    """
+
+    if not map_url or not bundle_url:
+        return False
+
+    # Inline data URLs are inline-sourceMap; the caller handles them.
+    if map_url.startswith("data:"):
+        return False
+
+    resolved = urljoin(bundle_url, map_url)
+    parsed_bundle = urlparse(bundle_url)
+    parsed_map = urlparse(resolved)
+    if parsed_bundle.scheme != parsed_map.scheme:
+        return False
+    if parsed_bundle.netloc != parsed_map.netloc:
+        return False
+    return True
+
+
+def extract_inline_sourcemap(map_url: str) -> Optional[List[SourceMapEntry]]:
+    """Decode an inline ``data:application/json;base64,...`` source map.
+
+    Returns None if the URL is not an inline data URL.
+    """
+
+    if not map_url.startswith("data:"):
+        return None
+    import base64
+
+    head, _, body = map_url.partition(",")
+    if not body:
+        return None
+    if "base64" in head:
+        try:
+            payload = base64.b64decode(body).decode("utf-8", errors="replace")
+        except Exception:
+            return None
+    else:
+        payload = body
+    return parse_sourcemap_payload(payload)
+
+
+def reconstruct_originals(
+    bundle_text: str,
+    bundle_path: Optional[Path] = None,
+) -> List[SourceMapEntry]:
+    """Best-effort: return original sources reconstructed from ``bundle_text``.
+
+    Tries inline-data URLs first; falls back to a sibling ``.map`` file when
+    ``bundle_path`` is provided. Returns ``[]`` if no usable source map is
+    found. Does NOT perform any network IO; remote URLs are skipped here. The
+    web-scan path (Wave 2.1c) wires in network fetching with the sandbox above.
+    """
+
+    url = find_sourcemap_url(bundle_text)
+    if url:
+        inline = extract_inline_sourcemap(url)
+        if inline is not None:
+            return inline
+    if bundle_path is not None:
+        try:
+            return load_sourcemap_from_disk(bundle_path)
+        except SourceMapError:
+            return []
+    return []

--- a/keyleak/suppressions.py
+++ b/keyleak/suppressions.py
@@ -2,12 +2,140 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
+import os
+import shutil
+import subprocess
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set
 
 from .models import Finding, ScanReport
+
+
+class AllowlistSignatureError(ValueError):
+    """Raised when a signed allowlist fails verification."""
+
+
+class AllowlistExpiredError(ValueError):
+    """Raised when an allowlist entry has expired (strict mode only)."""
+
+
+# Maximum allowlist entry expiry, in days from signed_at.
+MAX_EXPIRY_DAYS = 90
+TODAY_OVERRIDE_ENV = "KEYLEAK_ALLOWLIST_TODAY"
+ALLOWLIST_HMAC_KEY_ENV = "KEYLEAK_ALLOWLIST_KEY"
+ALLOWLIST_REQUIRE_SIG_ENV = "KEYLEAK_REQUIRE_ALLOWLIST_SIGNATURE"
+DISABLE_DEFAULTS_ENV = "KEYLEAK_NO_DEFAULT_SUPPRESSIONS"
+
+
+# L.1 — Default fixture-path suppressions (added 2026-05-20 post-dogfood).
+#
+# The 313-repo OSS dogfood produced 371 critical findings, 82% of which were
+# in obvious fixture / example / docker-compose paths. Users' first scan now
+# hides those by default so the real signal isn't drowned out. Opt out via
+# ``KEYLEAK_NO_DEFAULT_SUPPRESSIONS=1`` or the ``--no-default-suppressions``
+# CLI flag.
+#
+# Each entry is a ``source_contains`` substring (case-insensitive). Match
+# semantics are the same as the user-supplied ``--allowlist``.
+DEFAULT_FIXTURE_SUPPRESSIONS: List[str] = [
+    # Template / example envs.
+    ".env.example",
+    ".env.template",
+    ".env.sample",
+    ".env.dist",
+    ".env.docker",
+    ".env.default",
+    ".env.dev",
+    ".env.development",
+    ".env.local",
+    ".env.test",
+    ".env.testing",
+    ".env.e2e",
+    ".envrc",
+    "example.env",
+    "example.docker.env",
+    ".example",
+    ".template",
+    # Fixtures / tests / examples (any path segment).
+    "/fixtures/",
+    "/fixture/",
+    "/__tests__/",
+    "/__fixtures__/",
+    "/test_data/",
+    "/testdata/",
+    "/test-data/",
+    "/testfixtures/",
+    "/test-fixtures/",
+    "/tests/",
+    "/test/",
+    "/spec/",
+    "/specs/",
+    "/examples/",
+    "/example/",
+    "/demo/",
+    "/demos/",
+    "/sample/",
+    "/samples/",
+    "/playground/",
+    "/playgrounds/",
+    "/private-demos/",
+    "/private_demos/",
+    # Q.5 — path patterns the live-URL dogfood revealed slip past the L.1 set.
+    "/test-files/",
+    "/testfiles/",
+    "/test_files/",
+    "/fixture_data/",
+    "/fixturedata/",
+    "/fixture-data/",
+    "/sandbox/",
+    "/scratch/",
+    "/internal-demos/",
+    "/golden-files/",
+    "/snapshots/",
+    "/__snapshots__/",
+    "/cypress/",
+    "/e2e/",
+    "/e2e-tests/",
+    "/integration-tests/",
+    "/integration_tests/",
+    # Q.10 — OIDC / OAuth / TLS conformance test corpora.
+    "/certification/",
+    "/conformance/",
+    "/conformance-tests/",
+    "/test-vectors/",
+    "/test_vectors/",
+    "/golden/",
+    # Q.10 — auto-generated TypeScript / OpenAPI schema files. These often
+    # define type names like ``McpServerConfigInputSecretToken`` that match
+    # secret-shape detectors but contain no actual secrets.
+    "/serialization/types/",
+    "/openapi-generated/",
+    "/generated/types/",
+    "/generated-types/",
+    # File-name patterns for tests.
+    "_test.py",
+    "_tests.py",
+    "test_",  # matches test_foo.py
+    ".test.",
+    ".spec.",
+    # Docker compose / dev orchestration.
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "compose.yml",
+    "compose.yaml",
+    "compose.test.",
+    "compose.dev.",
+    # Docs.
+    "/docs/",
+    "README.md",
+    "README.rst",
+    "CHANGELOG.md",
+]
 
 
 @dataclass
@@ -19,12 +147,23 @@ class SuppressionSet:
     source_contains: List[str] = field(default_factory=list)
 
 
+def default_fixture_suppressions() -> SuppressionSet:
+    """Built-in fixture-aware suppression set applied by default."""
+
+    return SuppressionSet(source_contains=list(DEFAULT_FIXTURE_SUPPRESSIONS))
+
+
 def apply_suppressions(
     report: ScanReport,
     baseline_path: str = "",
     allowlist_path: str = "",
+    *,
+    apply_defaults: bool = True,
 ) -> ScanReport:
     suppressions = SuppressionSet()
+    # L.1 — apply built-in fixture suppressions unless explicitly disabled.
+    if apply_defaults and os.environ.get(DISABLE_DEFAULTS_ENV) != "1":
+        suppressions = merge_suppressions(suppressions, default_fixture_suppressions())
     if baseline_path:
         suppressions = merge_suppressions(suppressions, load_suppressions(baseline_path, baseline_mode=True))
     if allowlist_path:
@@ -65,9 +204,179 @@ def merge_suppressions(left: SuppressionSet, right: SuppressionSet) -> Suppressi
 def load_suppressions(path: str, baseline_mode: bool = False) -> SuppressionSet:
     file_path = Path(path).expanduser()
     text = file_path.read_text(encoding="utf-8")
-    if file_path.suffix.lower() == ".json":
+    suffix = file_path.suffix.lower()
+    if suffix == ".json":
         return _from_json(json.loads(text), baseline_mode=baseline_mode)
+    if suffix in (".yaml", ".yml"):
+        return _from_yaml(text)
     return _from_lines(text.splitlines())
+
+
+def _today_iso() -> str:
+    override = os.environ.get(TODAY_OVERRIDE_ENV)
+    if override:
+        return override
+    return date.today().isoformat()
+
+
+def _from_yaml(text: str) -> SuppressionSet:
+    """Parse the KeyLeak allowlist YAML schema.
+
+    Schema::
+
+        schema_version: 1
+        signed_at: "<ISO8601>"
+        signature_mode: "none" | "hmac-sha256" | "cosign"
+        signature: "<hex or base64 or cosign bundle>"
+        entries:
+          - id: "..."                 # optional; derived if absent
+            detector: "leak.<id>"     # Detector.canonical_id; required if no source_contains
+            source_contains: "..."    # optional
+            reason: "..."             # required
+            owner: "@user"            # required
+            expires_at: "YYYY-MM-DD"  # required (≤ 90 days from signed_at)
+
+    Behavior:
+      - Verifies signature if signature_mode != 'none'.
+      - Honors KEYLEAK_REQUIRE_ALLOWLIST_SIGNATURE=1 to fail closed on missing sig.
+      - Drops entries past expires_at (warns).
+    """
+
+    import yaml  # PyYAML
+
+    data = yaml.safe_load(text) or {}
+    if not isinstance(data, dict):
+        raise ValueError("allowlist YAML must be a mapping")
+
+    schema_version = data.get("schema_version")
+    if schema_version not in (None, 1):
+        raise ValueError(f"unsupported allowlist schema_version: {schema_version!r}")
+
+    signature_mode = (data.get("signature_mode") or "none").lower()
+    signature = data.get("signature") or ""
+
+    if os.environ.get(ALLOWLIST_REQUIRE_SIG_ENV) == "1" and signature_mode == "none":
+        raise AllowlistSignatureError(
+            "Allowlist requires a signature (KEYLEAK_REQUIRE_ALLOWLIST_SIGNATURE=1) "
+            "but signature_mode is 'none'."
+        )
+
+    if signature_mode != "none":
+        _verify_signature(data, signature_mode, signature)
+
+    entries = data.get("entries") or []
+    if not isinstance(entries, list):
+        raise ValueError("allowlist YAML 'entries' must be a list")
+
+    today = _today_iso()
+    suppressions = SuppressionSet()
+    for raw_entry in entries:
+        if not isinstance(raw_entry, dict):
+            raise ValueError(f"allowlist entry must be a mapping, got {type(raw_entry).__name__}")
+
+        expires_at = str(raw_entry.get("expires_at") or "").strip()
+        if not expires_at:
+            raise ValueError(
+                f"allowlist entry missing required field 'expires_at': {raw_entry!r}"
+            )
+        if expires_at < today:
+            # Drop expired entries silently (self-audit surfaces them separately).
+            continue
+
+        if not raw_entry.get("reason"):
+            raise ValueError(f"allowlist entry missing required field 'reason': {raw_entry!r}")
+        if not raw_entry.get("owner"):
+            raise ValueError(f"allowlist entry missing required field 'owner': {raw_entry!r}")
+
+        if raw_entry.get("id"):
+            suppressions.ids.add(str(raw_entry["id"]).strip())
+        if raw_entry.get("detector"):
+            suppressions.detector_ids.add(str(raw_entry["detector"]).strip())
+        if raw_entry.get("type"):
+            suppressions.types.add(str(raw_entry["type"]).strip())
+        if raw_entry.get("source_contains"):
+            suppressions.source_contains.append(str(raw_entry["source_contains"]).strip())
+        if raw_entry.get("signature"):
+            suppressions.signatures.add(str(raw_entry["signature"]).strip())
+
+        if not (
+            raw_entry.get("id")
+            or raw_entry.get("detector")
+            or raw_entry.get("type")
+            or raw_entry.get("source_contains")
+        ):
+            raise ValueError(
+                f"allowlist entry must set one of id/detector/type/source_contains: {raw_entry!r}"
+            )
+
+    return suppressions
+
+
+def _verify_signature(data: Dict[str, Any], mode: str, signature: str) -> None:
+    """Verify the allowlist signature according to ``signature_mode``."""
+
+    if not signature:
+        raise AllowlistSignatureError(f"signature_mode={mode!r} but no signature provided")
+
+    payload = canonical_entries_bytes(data.get("entries") or [])
+
+    if mode == "hmac-sha256":
+        key = os.environ.get(ALLOWLIST_HMAC_KEY_ENV)
+        if not key:
+            raise AllowlistSignatureError(
+                f"signature_mode='hmac-sha256' requires {ALLOWLIST_HMAC_KEY_ENV} env var"
+            )
+        expected = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, signature.strip().lower()):
+            raise AllowlistSignatureError("HMAC signature mismatch on allowlist YAML")
+        return
+
+    if mode == "cosign":
+        cosign = shutil.which("cosign")
+        if not cosign:
+            raise AllowlistSignatureError(
+                "signature_mode='cosign' but cosign is not installed on PATH"
+            )
+        # Best-effort: write payload + signature to temp and invoke cosign verify-blob.
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("wb", delete=False, suffix=".payload") as payload_file:
+            payload_file.write(payload)
+            payload_path = payload_file.name
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".sig") as sig_file:
+            sig_file.write(signature)
+            sig_path = sig_file.name
+        try:
+            result = subprocess.run(
+                [cosign, "verify-blob", "--signature", sig_path, payload_path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        finally:
+            Path(payload_path).unlink(missing_ok=True)
+            Path(sig_path).unlink(missing_ok=True)
+        if result.returncode != 0:
+            raise AllowlistSignatureError(
+                f"cosign verify-blob failed: {result.stderr.strip() or result.stdout.strip()}"
+            )
+        return
+
+    raise AllowlistSignatureError(f"unknown signature_mode: {mode!r}")
+
+
+def canonical_entries_bytes(entries: List[Any]) -> bytes:
+    """Return a deterministic byte representation of allowlist entries for signing."""
+
+    return json.dumps(entries, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sign_entries_hmac(entries: List[Any], key: str) -> str:
+    """Helper used by tests + the future ``keyleak allowlist sign`` subcommand."""
+
+    payload = canonical_entries_bytes(entries)
+    return hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()
 
 
 def is_suppressed(finding: Finding, suppressions: SuppressionSet) -> bool:
@@ -75,6 +384,21 @@ def is_suppressed(finding: Finding, suppressions: SuppressionSet) -> bool:
         return True
     if finding.detector_id in suppressions.detector_ids:
         return True
+    # Honor detector id_aliases: a suppression that references an old detector
+    # ID still matches after a rename. Lazy import to avoid a circular dep.
+    if suppressions.detector_ids:
+        try:
+            from .detectors import DETECTORS  # local import
+
+            for detector in DETECTORS:
+                if finding.detector_id != detector.canonical_id:
+                    continue
+                for alias in detector.canonical_id_aliases:
+                    if alias in suppressions.detector_ids:
+                        return True
+                break
+        except Exception:  # pragma: no cover — defensive
+            pass
     if finding.type in suppressions.types:
         return True
     if finding_signature(finding) in suppressions.signatures:

--- a/keyleak/watch.py
+++ b/keyleak/watch.py
@@ -1,0 +1,105 @@
+"""`keyleak watch` — debounced incremental scan on file save (Wave 3.8).
+
+Polls the filesystem (stdlib only — no watchdog dep) every ``poll_interval``
+seconds. When any file's ``mtime`` changes, the watched path is re-scanned
+and the SARIF report at ``.keyleak/findings.sarif`` is updated. VS Code's
+built-in SARIF Problems panel picks it up automatically.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+from .local_scanner import scan_path
+from .reporting import format_sarif
+
+
+DEFAULT_POLL_INTERVAL = 0.5  # seconds
+DEFAULT_OUTPUT_PATH = ".keyleak/findings.sarif"
+WATCHED_SUFFIXES = (".py", ".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs", ".json", ".yml", ".yaml", ".env", ".html", ".tf")
+
+
+def snapshot_mtimes(root: Path) -> Dict[str, float]:
+    """Return ``{path: mtime}`` for every file under ``root`` with a watched suffix."""
+
+    mtimes: Dict[str, float] = {}
+    skip = {".git", "node_modules", ".keyleak", "__pycache__", "dist", "build"}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in skip]
+        for name in filenames:
+            if not name.endswith(WATCHED_SUFFIXES) and not name.startswith(".env"):
+                continue
+            full = Path(dirpath) / name
+            try:
+                mtimes[str(full)] = full.stat().st_mtime
+            except OSError:
+                continue
+    return mtimes
+
+
+def detect_changes(prev: Dict[str, float], curr: Dict[str, float]) -> Tuple[bool, Iterable[str]]:
+    """Return (changed?, changed_paths)."""
+
+    changed = []
+    for path, mtime in curr.items():
+        if prev.get(path) != mtime:
+            changed.append(path)
+    for path in prev:
+        if path not in curr:
+            changed.append(path)
+    return bool(changed), changed
+
+
+def run_watch(
+    root: Path,
+    *,
+    output_path: Path,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    iterations: Optional[int] = None,
+) -> int:
+    """Watch ``root`` and refresh ``output_path`` on every change.
+
+    ``iterations`` caps the loop count (for tests). ``None`` runs forever.
+    """
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    prev = snapshot_mtimes(root)
+    _write_scan(root, output_path)  # initial scan
+
+    count = 0
+    while iterations is None or count < iterations:
+        time.sleep(poll_interval)
+        curr = snapshot_mtimes(root)
+        changed, paths = detect_changes(prev, curr)
+        if changed:
+            _write_scan(root, output_path)
+            prev = curr
+            print(f"[keyleak watch] re-scanned ({len(list(paths))} files changed)", file=sys.stderr)
+        count += 1
+    return 0
+
+
+def _write_scan(root: Path, output_path: Path) -> None:
+    report = scan_path(str(root), profile="ci")
+    output_path.write_text(format_sarif(report), encoding="utf-8")
+
+
+def cli_main(args) -> int:
+    root = Path(args.path).expanduser().resolve()
+    if not root.is_dir():
+        print(f"path is not a directory: {root}", file=sys.stderr)
+        return 1
+    output_path = Path(args.out) if args.out else (root / DEFAULT_OUTPUT_PATH)
+    try:
+        return run_watch(
+            root,
+            output_path=output_path,
+            poll_interval=float(args.interval),
+            iterations=int(args.iterations) if args.iterations else None,
+        )
+    except KeyboardInterrupt:
+        return 0


### PR DESCRIPTION
## Why
`origin/main` does not import on a fresh clone. Committed `detectors.py` does `from .models import Remediation, derive_remediation`, but committed `models.py` has neither — so `import keyleak` (and therefore the CLI) fails on a clean checkout. On top of that, **19 `keyleak` modules existed only as untracked local files** and four tracked files were stale relative to the shipped code.

The published **PyPI 0.5.2 is unaffected** — it was built from a complete working tree, so end users are fine. Only the git repo was behind, which means a `git clone && pip install -e .` was broken and PR diffs couldn't be reviewed against reality.

## What
Brings the repo to its real, shipped state — **proxy excluded** (that's a separate PR on `feat/scan-proxy`):

- **Adds 19 modules:** `access_control, allowlist_diff, archive_scanner, chain_of_custody, demo, detectors_ast, detectors_dynamic, detectors_fuzzy, detectors_splittoken, diff, disclose, doctor, extension_bundle, feeds, offline_guard, privacy_filter, self_audit, sourcemaps, watch`.
- **Syncs 4 proxy-free stale files** to shipped state: `models` (restores `Remediation`/`derive_remediation`), `local_scanner`, `suppressions`, `redaction`.
- `feeds.py` is committed **proxy-free** (its `proxy` param/import belong to the proxy PR).

## Deferred to the proxy PR (`feat/scan-proxy`)
`proxy.py`, and the proxy edits in `cli.py`, `browser_scanner.py`, `site_scanner.py`, `baas_validator.py`, `feeds.py`. Those files are intentionally left at `main`'s non-proxy state here.

## Verification
- `import keyleak.*` (cli, detectors, local_scanner, site_scanner, browser_scanner, doctor, feeds, self_audit, …) now succeeds.
- `python -m unittest tests.test_site_scanner` → 9/9 pass.
- `keyleak self-audit .` → exit 0.

## Known / out of scope
- The launch-gate workflow also references `keyleak-allowlist.txt`, which is **also untracked** on main, and flags pre-existing findings in `extension/lib/key-tester.js` and `app.py` (not introduced here). Tracking the allowlist + tuning those is a follow-up.
- Untracked **test files** for some of these modules also still need committing — recommended as a next step so CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/keyleak-detector/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-wave secret detection including IDOR, worm-shape patterns, fuzzy fingerprints, and cross-file split tokens
  * Archive scanning and source-map deobfuscation
  * Responsible disclosure workflow
  * Offline scanning mode and continuous file watching
  * Repository supply-chain self-audit
  * Demo onboarding flow

* **Security Improvements**
  * Enhanced redaction with HMAC salts for diff-resistant reports
  * Signed and expiring allowlists
  * PII scrubbing in findings
  * Report integrity verification

* **Tooling & UX**
  * Environment checker tool
  * Report diffing and comparison
  * Chrome extension detector support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->