### PR TITLE
Full Site Scan: multi-source subdomain enumeration (amass + auto-install subfinder + source attribution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Static scanners find hardcoded secrets in source code. KeyLeak finds the ones th
 
 - **BaaS vulnerability scanner**: Detects Supabase/Firebase/Appwrite config in minified JS bundles, extracts table names, and actively probes whether Row-Level Security is enforced. A Supabase anon key is harmless if RLS works. KeyLeak tests whether it does.
 - **Chrome extension**: Detects leaked keys in real-time as you browse. TEST button validates whether a found key is still active (supports 14 providers). JWT decoder surfaces suspicious claims (service_role, admin flags, broad scopes).
-- **Full Site Scan**: Enumerates subdomains (crt.sh certificate transparency + DNS — no external tools needed), crawls every page of the domain, and scans them all, reporting which subdomains/pages each leak appeared on. One command (or one click in the web UI) for a full domain audit. Authorized targets only.
+- **Full Site Scan**: Enumerates subdomains (crt.sh certificate transparency + DNS, and a deep scan auto-installs **subfinder** — pinned, opt-out — for far richer discovery; **amass** is used too if present), crawls every page of the domain, and scans them all, reporting which subdomains/pages each leak appeared on plus a per-source discovery breakdown. One command (or one click in the web UI) for a full domain audit. Authorized targets only.
 - **200+ first-party domain suppression**: No false positives when browsing Google, AWS, Azure, GitHub, Stripe, etc.
 
 ## Install
@@ -93,8 +93,11 @@ keyleak browser-scan https://your-app.vercel.app --html > report.html
 # Scan with BaaS validation (tests Supabase RLS, Firebase rules)
 keyleak browser-scan https://your-app.vercel.app --baas-validate --html > report.html
 
-# Full Site Scan — subdomain enumeration (crt.sh + DNS) + multi-page crawl, all pages scanned
-keyleak site-scan example.com --depth 3 --max-pages 100 --max-subdomains 25 --baas-validate --html > report.html
+# Full Site Scan — subdomain enumeration (subfinder/amass if installed + crt.sh + DNS) + multi-page crawl
+keyleak site-scan example.com --depth 3 --max-pages 100 --max-subdomains 50 --baas-validate --html > report.html
+# A deep scan auto-installs subfinder if it's missing (brew → pinned `go install`), then uses it;
+# pass --no-auto-install (or set KEYLEAK_NO_AUTO_INSTALL=1) to stay on crt.sh + DNS only.
+# amass is also auto-used if present. `keyleak doctor` reports which enumerators are active.
 
 # Scan local files for secrets
 keyleak local . --fail-on high

--- a/app.py
+++ b/app.py
@@ -1421,8 +1421,9 @@ async def _run_full_site_scan(url, parsed_url, scan_id):
             domain,
             depth=3,
             max_pages=100,
-            max_subdomains=25,
+            max_subdomains=50,
             baas_validate=True,
+            auto_install=False,  # never install binaries from the web request path
             on_progress=_progress,
         )
 

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -406,7 +406,7 @@ def build_parser() -> argparse.ArgumentParser:
     site_scan.add_argument("--depth", default="3", help="Link crawl depth per host (default: 3).")
     site_scan.add_argument("--max-pages", default="100", help="Maximum pages to scan (default: 100).")
     site_scan.add_argument("--max-subdomains", default="50", help="Maximum subdomains to scan (default: 50).")
-    site_scan.add_argument("--no-auto-install", action="store_true", help="Don't auto-install subfinder for deeper discovery; use crt.sh + DNS only (also via KEYLEAK_NO_AUTO_INSTALL=1).")
+    site_scan.add_argument("--no-auto-install", action="store_true", help="Don't auto-install subfinder; still use amass if already on PATH, otherwise fall back to crt.sh + DNS (also via KEYLEAK_NO_AUTO_INSTALL=1).")
     site_scan.add_argument("--launch-profile", default="launch-gate", choices=["launch-gate", "local-dev", "bug-bounty", "ci", "full"])
     site_scan.add_argument("--scan-budget", default="30", help="Per-page timeout in seconds.")
     site_scan.add_argument("--headed", action="store_true", help="Show browser windows.")

--- a/keyleak/cli.py
+++ b/keyleak/cli.py
@@ -239,6 +239,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 launch_profile=args.launch_profile,
                 offline=offline,
                 proxy=proxy,
+                auto_install=not args.no_auto_install,
             )
         except Exception as exc:
             print(f"site-scan failed: {exc}", file=sys.stderr)
@@ -404,7 +405,8 @@ def build_parser() -> argparse.ArgumentParser:
     site_scan.add_argument("domain", help="Domain or URL to scan (e.g., example.com)")
     site_scan.add_argument("--depth", default="3", help="Link crawl depth per host (default: 3).")
     site_scan.add_argument("--max-pages", default="100", help="Maximum pages to scan (default: 100).")
-    site_scan.add_argument("--max-subdomains", default="25", help="Maximum subdomains to scan (default: 25).")
+    site_scan.add_argument("--max-subdomains", default="50", help="Maximum subdomains to scan (default: 50).")
+    site_scan.add_argument("--no-auto-install", action="store_true", help="Don't auto-install subfinder for deeper discovery; use crt.sh + DNS only (also via KEYLEAK_NO_AUTO_INSTALL=1).")
     site_scan.add_argument("--launch-profile", default="launch-gate", choices=["launch-gate", "local-dev", "bug-bounty", "ci", "full"])
     site_scan.add_argument("--scan-budget", default="30", help="Per-page timeout in seconds.")
     site_scan.add_argument("--headed", action="store_true", help="Show browser windows.")

--- a/keyleak/doctor.py
+++ b/keyleak/doctor.py
@@ -106,6 +106,22 @@ def check_node() -> CheckResult:
     return _ok("node", "node is available.")
 
 
+def check_subdomain_tools() -> CheckResult:
+    """Optional enumerators that enrich Full Site Scan subdomain discovery."""
+
+    present = [t for t in ("subfinder", "amass") if shutil.which(t)]
+    if present:
+        return _ok(
+            "subdomain-tools",
+            f"{', '.join(present)} on PATH — richer Full Site Scan discovery.",
+        )
+    return _warn(
+        "subdomain-tools",
+        "subfinder/amass not found; Full Site Scan uses crt.sh + DNS only.",
+        fix="Optional: `brew install subfinder` (or amass) for deeper subdomain enumeration.",
+    )
+
+
 def check_poetry() -> CheckResult:
     if shutil.which("poetry") is None:
         return _warn(
@@ -152,6 +168,7 @@ CHECKS = (
     check_playwright,
     check_mitmproxy_cert,
     check_node,
+    check_subdomain_tools,
     check_poetry,
     check_network_egress,
     check_allowlist_sanity,

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -169,7 +169,9 @@ def _ensure_subfinder(*, auto_install: bool, on_progress: ProgressFn = None) -> 
     """
     if shutil.which("subfinder"):
         return True
-    if not auto_install or os.environ.get("KEYLEAK_NO_AUTO_INSTALL"):
+    no_auto_install = (os.environ.get("KEYLEAK_NO_AUTO_INSTALL", "").strip().lower()
+                       in {"1", "true", "yes", "on"})
+    if not auto_install or no_auto_install:
         return False
 
     if shutil.which("brew"):
@@ -191,7 +193,8 @@ def _ensure_subfinder(*, auto_install: bool, on_progress: ProgressFn = None) -> 
                 check=True, capture_output=True, text=True, timeout=900,
             )
             gobin = _go_bin_dir()
-            if gobin and os.path.isfile(os.path.join(gobin, "subfinder")):
+            exe_name = "subfinder.exe" if os.name == "nt" else "subfinder"
+            if gobin and os.path.isfile(os.path.join(gobin, exe_name)):
                 os.environ["PATH"] = gobin + os.pathsep + os.environ.get("PATH", "")
         except (subprocess.SubprocessError, OSError) as exc:
             _emit(on_progress, "install", f"go install subfinder failed: {exc}")
@@ -228,6 +231,12 @@ def discover_subdomains(
 
     if offline:
         _emit(on_progress, "subdomains", "Offline mode — skipping subdomain discovery", 1, 1)
+        if sources_out is not None:
+            sources_out.update({
+                "candidates": {"subfinder": 0, "amass": 0, "crt.sh": 0, "dns-brute": 0},
+                "kept": {"apex": 1},
+                "by_host": {domain: "apex"},
+            })
         return [domain]
 
     _ensure_subfinder(auto_install=auto_install, on_progress=on_progress)

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -13,6 +13,8 @@ number of subdomains and pages. Read-only: crawl + passive scan only.
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import socket
 import subprocess
 import sys
@@ -41,7 +43,7 @@ COMMON_SUBDOMAINS = [
 ]
 
 # Hard caps to keep a scan bounded and polite.
-MAX_SUBDOMAINS_DEFAULT = 25
+MAX_SUBDOMAINS_DEFAULT = 50
 MAX_PAGES_DEFAULT = 100
 
 ProgressFn = Optional[Callable[[Dict[str, Any]], None]]
@@ -122,20 +124,105 @@ def _subfinder_subdomains(domain: str) -> List[str]:
     return []
 
 
+def _amass_subdomains(domain: str) -> List[str]:
+    """Use the optional amass binary (passive mode) if present, else empty."""
+    try:
+        result = subprocess.run(
+            ["amass", "enum", "-passive", "-norecursive", "-d", domain, "-timeout", "2"],
+            capture_output=True, text=True, timeout=180,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            out = {
+                line.strip().lower()
+                for line in result.stdout.splitlines()
+                if line.strip()
+            }
+            return sorted(h for h in out if h == domain or h.endswith("." + domain))
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return []
+
+
+SUBFINDER_VERSION = "v2.14.0"
+
+
+def _go_bin_dir() -> Optional[str]:
+    """Best-effort location of the Go install bin dir (GOBIN or GOPATH/bin)."""
+    for var in ("GOBIN", "GOPATH"):
+        try:
+            out = subprocess.run(["go", "env", var], capture_output=True,
+                                 text=True, timeout=10).stdout.strip()
+        except (subprocess.SubprocessError, OSError):
+            continue
+        if out:
+            return out if var == "GOBIN" else os.path.join(out, "bin")
+    return os.path.join(os.path.expanduser("~"), "go", "bin")
+
+
+def _ensure_subfinder(*, auto_install: bool, on_progress: ProgressFn = None) -> bool:
+    """Make subfinder available for a deep scan, installing it if needed.
+
+    If subfinder is missing and ``auto_install`` is set (and the env var
+    ``KEYLEAK_NO_AUTO_INSTALL`` is unset), try Homebrew first, then a pinned
+    ``go install``. Never raises — a failed install just means discovery
+    falls back to crt.sh + DNS. Returns True if subfinder is usable.
+    """
+    if shutil.which("subfinder"):
+        return True
+    if not auto_install or os.environ.get("KEYLEAK_NO_AUTO_INSTALL"):
+        return False
+
+    if shutil.which("brew"):
+        _emit(on_progress, "install",
+              "subfinder not found — installing via Homebrew (brew install subfinder)...")
+        try:
+            subprocess.run(["brew", "install", "subfinder"],
+                           check=True, capture_output=True, text=True, timeout=900)
+        except (subprocess.SubprocessError, OSError) as exc:
+            _emit(on_progress, "install", f"brew install subfinder failed: {exc}")
+
+    if not shutil.which("subfinder") and shutil.which("go"):
+        _emit(on_progress, "install",
+              f"Installing subfinder via go install (pinned {SUBFINDER_VERSION})...")
+        try:
+            subprocess.run(
+                ["go", "install",
+                 f"github.com/projectdiscovery/subfinder/v2/cmd/subfinder@{SUBFINDER_VERSION}"],
+                check=True, capture_output=True, text=True, timeout=900,
+            )
+            gobin = _go_bin_dir()
+            if gobin and os.path.isfile(os.path.join(gobin, "subfinder")):
+                os.environ["PATH"] = gobin + os.pathsep + os.environ.get("PATH", "")
+        except (subprocess.SubprocessError, OSError) as exc:
+            _emit(on_progress, "install", f"go install subfinder failed: {exc}")
+
+    ok = shutil.which("subfinder") is not None
+    _emit(on_progress, "install",
+          "subfinder ready." if ok else "Could not install subfinder; using crt.sh + DNS only.")
+    return ok
+
+
 def discover_subdomains(
     domain: str,
     *,
     max_subdomains: int = MAX_SUBDOMAINS_DEFAULT,
     offline: bool = False,
     proxy: Optional[str] = None,
+    auto_install: bool = False,
+    sources_out: Optional[Dict[str, Any]] = None,
     on_progress: ProgressFn = None,
 ) -> List[str]:
     """Discover subdomains within ``domain``, scoped and capped.
 
-    Sources (union): subfinder (if installed) + crt.sh + DNS brute-force of
-    common names. Each candidate is DNS-resolved to drop dead names, then the
-    list is capped at ``max_subdomains``. With ``offline=True`` no network is
-    used and only the bare domain is returned.
+    Sources (union, in priority order): subfinder + amass (if installed) +
+    crt.sh certificate transparency + DNS brute-force of common names. Each
+    candidate is DNS-resolved to drop dead names, then the list is capped at
+    ``max_subdomains``. With ``offline=True`` no network is used and only the
+    bare domain is returned.
+
+    If ``sources_out`` is provided, it is populated with a per-source
+    breakdown: ``candidates`` (counts found per source), ``kept`` (counts of
+    resolved hosts attributed to each source), and ``by_host`` (host -> source).
     """
     domain = domain.strip().lower().split(":")[0]
 
@@ -143,36 +230,60 @@ def discover_subdomains(
         _emit(on_progress, "subdomains", "Offline mode — skipping subdomain discovery", 1, 1)
         return [domain]
 
+    _ensure_subfinder(auto_install=auto_install, on_progress=on_progress)
     subfinder = set(_subfinder_subdomains(domain))
+    amass = set(_amass_subdomains(domain))
     crt = set(_crt_sh_subdomains(domain, proxy=proxy))
-    if crt:
-        _emit(on_progress, "subdomains", f"crt.sh returned {len(crt)} candidate names")
     brute_force = {f"{sub}.{domain}" for sub in COMMON_SUBDOMAINS}
+    _emit(on_progress, "subdomains",
+          f"Candidates — subfinder {len(subfinder)}, amass {len(amass)}, "
+          f"crt.sh {len(crt)}, dns-brute {len(brute_force)}")
 
     # Build the candidate list in source-priority order — bare domain, then
-    # passive discovery (subfinder, crt.sh), then guessed names last — so a
-    # small cap never drops a real hit in favour of a brute-force guess that
-    # merely sorts earlier alphabetically.
+    # passive discovery (subfinder, amass, crt.sh), then guessed names last —
+    # so a small cap never drops a real hit in favour of a brute-force guess
+    # that merely sorts earlier alphabetically. Attribute each host to the
+    # first (highest-priority) source that surfaced it.
+    source_of: Dict[str, str] = {domain: "apex"}
     ordered: List[str] = [domain]
     seen = {domain}
-    for bucket in (sorted(subfinder), sorted(crt), sorted(brute_force)):
-        for host in bucket:
+    for label, bucket in (("subfinder", subfinder), ("amass", amass),
+                          ("crt.sh", crt), ("dns-brute", brute_force)):
+        for host in sorted(bucket):
             if host not in seen:
                 seen.add(host)
+                source_of[host] = label
                 ordered.append(host)
 
     # Keep only names that actually resolve, capped at max_subdomains.
     resolved: List[str] = []
+    kept_counts: Dict[str, int] = {}
     for host in ordered:
         if len(resolved) >= max_subdomains:
             break
         if _resolves(host):
             resolved.append(host)
+            src = source_of.get(host, "dns-brute")
+            kept_counts[src] = kept_counts.get(src, 0) + 1
 
     if not resolved:
         resolved = [domain]
+        kept_counts = {"apex": 1}
+
+    if sources_out is not None:
+        sources_out.update({
+            "candidates": {
+                "subfinder": len(subfinder), "amass": len(amass),
+                "crt.sh": len(crt), "dns-brute": len(brute_force),
+            },
+            "kept": kept_counts,
+            "by_host": {h: source_of.get(h, "dns-brute") for h in resolved},
+        })
+
+    kept_summary = ", ".join(f"{k} {v}" for k, v in sorted(kept_counts.items()))
     _emit(on_progress, "subdomains",
-          f"Discovered {len(resolved)} live host(s)", len(resolved), len(resolved))
+          f"Discovered {len(resolved)} live host(s) [{kept_summary}]",
+          len(resolved), len(resolved))
     return resolved
 
 
@@ -332,6 +443,7 @@ def scan_site(
     launch_profile: str = "launch-gate",
     offline: bool = False,
     proxy: Optional[str] = None,
+    auto_install: bool = True,
     on_progress: ProgressFn = None,
 ) -> ScanReport:
     """Full Site Scan: discover subdomains, crawl pages, scan each for secrets.
@@ -348,9 +460,11 @@ def scan_site(
 
     _emit(on_progress, "start", f"Starting full site scan for {domain}")
 
+    discovery_sources: Dict[str, Any] = {}
     subdomains = discover_subdomains(
         domain, max_subdomains=max_subdomains, offline=offline,
-        proxy=proxy, on_progress=on_progress,
+        proxy=proxy, auto_install=auto_install,
+        sources_out=discovery_sources, on_progress=on_progress,
     )
     if not subdomains:
         subdomains = [domain]
@@ -398,5 +512,6 @@ def scan_site(
         "pages_scanned": total,
         "scanned_urls": urls,
         "provenance": provenance,
+        "discovery_sources": discovery_sources,
     })
     return report

--- a/tests/test_site_scanner.py
+++ b/tests/test_site_scanner.py
@@ -98,12 +98,32 @@ class DiscoverTests(unittest.TestCase):
 
     def test_caps_and_requires_resolution(self):
         with mock.patch.object(ss, "_subfinder_subdomains", lambda d: []), \
+             mock.patch.object(ss, "_amass_subdomains", lambda d: []), \
              mock.patch.object(ss, "_crt_sh_subdomains",
                                lambda d, **k: [f"s{i}.example.com" for i in range(50)]), \
              mock.patch.object(ss, "_resolves", lambda h: True):
             out = ss.discover_subdomains("example.com", max_subdomains=5)
         self.assertEqual(len(out), 5)
         self.assertEqual(out[0], "example.com")     # apex leads
+
+    def test_amass_unioned_with_source_attribution(self):
+        with mock.patch.object(ss, "_subfinder_subdomains", lambda d: []), \
+             mock.patch.object(ss, "_amass_subdomains", lambda d: ["a.example.com"]), \
+             mock.patch.object(ss, "_crt_sh_subdomains", lambda d, **k: ["b.example.com"]), \
+             mock.patch.object(ss, "_resolves", lambda h: True):
+            sources = {}
+            out = ss.discover_subdomains("example.com", sources_out=sources)
+        # amass hits are unioned alongside crt.sh
+        self.assertIn("a.example.com", out)
+        self.assertIn("b.example.com", out)
+        # each kept host is attributed to the source that surfaced it
+        self.assertEqual(sources["by_host"]["a.example.com"], "amass")
+        self.assertEqual(sources["by_host"]["b.example.com"], "crt.sh")
+        self.assertEqual(sources["by_host"]["example.com"], "apex")
+        # per-source candidate + kept counts are reported
+        self.assertEqual(sources["candidates"]["amass"], 1)
+        self.assertEqual(sources["candidates"]["crt.sh"], 1)
+        self.assertGreaterEqual(sources["kept"].get("amass", 0), 1)
 
 
 class FilterLinksTests(unittest.TestCase):
@@ -210,6 +230,43 @@ class ScanSiteTests(unittest.TestCase):
         # Credentials/port stripped, reduced to the registrable domain (eTLD+1).
         self.assertEqual(captured["domain"], "example.com")
         self.assertEqual(report.target, "example.com")
+
+
+class AutoInstallTests(unittest.TestCase):
+    def test_present_subfinder_skips_install(self):
+        with mock.patch.object(ss.shutil, "which",
+                               side_effect=lambda n: "/usr/bin/subfinder" if n == "subfinder" else None), \
+             mock.patch.object(ss.subprocess, "run",
+                               side_effect=AssertionError("must not install when present")):
+            self.assertTrue(ss._ensure_subfinder(auto_install=True))
+
+    def test_no_install_when_opted_out(self):
+        with mock.patch.object(ss.shutil, "which", lambda n: None), \
+             mock.patch.object(ss.subprocess, "run",
+                               side_effect=AssertionError("must not install when opted out")):
+            self.assertFalse(ss._ensure_subfinder(auto_install=False))
+
+    def test_env_opt_out_blocks_install(self):
+        with mock.patch.object(ss.shutil, "which", lambda n: None), \
+             mock.patch.dict(ss.os.environ, {"KEYLEAK_NO_AUTO_INSTALL": "1"}), \
+             mock.patch.object(ss.subprocess, "run",
+                               side_effect=AssertionError("env opt-out must block install")):
+            self.assertFalse(ss._ensure_subfinder(auto_install=True))
+
+    def test_discover_threads_auto_install_flag(self):
+        captured = {}
+
+        def fake_ensure(*, auto_install, on_progress=None):
+            captured["auto_install"] = auto_install
+            return False
+
+        with mock.patch.object(ss, "_ensure_subfinder", fake_ensure), \
+             mock.patch.object(ss, "_subfinder_subdomains", lambda d: []), \
+             mock.patch.object(ss, "_amass_subdomains", lambda d: []), \
+             mock.patch.object(ss, "_crt_sh_subdomains", lambda d, **k: []), \
+             mock.patch.object(ss, "_resolves", lambda h: True):
+            ss.discover_subdomains("example.com", auto_install=True)
+        self.assertTrue(captured["auto_install"])
 
 
 if __name__ == "__main__":

--- a/tests/test_site_scanner.py
+++ b/tests/test_site_scanner.py
@@ -87,14 +87,20 @@ class CrtShTests(unittest.TestCase):
 
 
 class DiscoverTests(unittest.TestCase):
-    def test_offline_uses_no_network(self):
+    def test_offline_uses_no_network_and_fills_sources(self):
         def fail(*a, **k):
-            raise AssertionError("network must not be touched in offline mode")
+            raise AssertionError("offline mode must not touch network or install")
         with mock.patch.object(ss, "_crt_sh_subdomains", fail), \
              mock.patch.object(ss, "_subfinder_subdomains", fail), \
+             mock.patch.object(ss, "_amass_subdomains", fail), \
+             mock.patch.object(ss, "_ensure_subfinder", fail), \
              mock.patch.object(ss, "_resolves", fail):
-            self.assertEqual(ss.discover_subdomains("example.com", offline=True),
-                             ["example.com"])
+            sources = {}
+            out = ss.discover_subdomains("example.com", offline=True, sources_out=sources)
+        self.assertEqual(out, ["example.com"])
+        # offline still returns a consistent discovery_sources structure
+        self.assertEqual(sources["by_host"], {"example.com": "apex"})
+        self.assertEqual(sources["kept"], {"apex": 1})
 
     def test_caps_and_requires_resolution(self):
         with mock.patch.object(ss, "_subfinder_subdomains", lambda d: []), \
@@ -252,6 +258,26 @@ class AutoInstallTests(unittest.TestCase):
              mock.patch.object(ss.subprocess, "run",
                                side_effect=AssertionError("env opt-out must block install")):
             self.assertFalse(ss._ensure_subfinder(auto_install=True))
+
+    def test_env_value_zero_does_not_block(self):
+        # Only explicit truthy values opt out; "0"/"false" must NOT block install.
+        calls = []
+
+        def fake_run(cmd, *a, **k):
+            calls.append(cmd)
+
+            class _R:
+                returncode, stdout, stderr = 0, "", ""
+
+            return _R()
+
+        with mock.patch.object(ss.shutil, "which",
+                               lambda n: "/opt/homebrew/bin/brew" if n == "brew" else None), \
+             mock.patch.dict(ss.os.environ, {"KEYLEAK_NO_AUTO_INSTALL": "0"}), \
+             mock.patch.object(ss.subprocess, "run", fake_run):
+            ss._ensure_subfinder(auto_install=True)
+        self.assertTrue(any("brew" in c for c in calls),
+                        "KEYLEAK_NO_AUTO_INSTALL=0 must not block auto-install")
 
     def test_discover_threads_auto_install_flag(self):
         captured = {}


### PR DESCRIPTION
Builds on the now-complete `main` (#9 full-site, #10 proxy, #11 repo-completeness). Strengthens Full Site Scan subdomain discovery per the agreed scope.

## Changes
- **amass as a 3rd source** — `_amass_subdomains` (passive mode) unioned with subfinder + crt.sh + DNS, in priority order.
- **Auto-install subfinder on a deep scan** — when missing, `site-scan` installs it: **Homebrew → pinned `go install` (`v2.14.0`) → graceful fallback** to crt.sh + DNS. Opt out with `--no-auto-install` or `KEYLEAK_NO_AUTO_INSTALL=1`. The **web path never installs** (`auto_install=False`) — no binary installs from a request handler.
- **Source attribution + counts** — `discover_subdomains(sources_out=…)` reports per-source candidate counts, kept counts, and a host→source map; `scan_site` surfaces it as `report.extra["discovery_sources"]`, and progress logs `Candidates — subfinder N, amass M, crt.sh K, dns-brute B` / `Discovered X live host(s) [subfinder x, crt.sh z, …]`.
- **Raised cap** — default `--max-subdomains` 25 → 50 (engine constant, CLI, web helper), so richer enumeration isn't clipped.
- **doctor** — `check_subdomain_tools` reports whether subfinder/amass are active.
- README updated.

## Supply-chain note
Auto-installing a binary is done deliberately and conservatively given this repo's hygiene rules: **version-pinned** `go install` (no `@latest`), Homebrew as the primary path, clear progress logging of exactly what's installing, an opt-out, and a safe fallback. It only triggers on an explicit deep scan, never on the web request path.

## Tests
`tests/test_site_scanner.py` — 17 pass, including amass union + source attribution, and auto-install gating (present → no install; opt-out flag and env var both block install; flag threaded through `discover_subdomains`). Verified locally (subfinder installed → `_ensure_subfinder` no-ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/keyleak-detector/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Site Scan supports deeper subdomain enumeration with optional auto-install of tooling (enabled by default, opt-out available).
  * CLI adds a --no-auto-install flag and KEYLEAK_NO_AUTO_INSTALL env var to limit enumeration.
  * Diagnostic tool reports availability of subdomain enumeration tools.

* **Improvements**
  * Default max subdomains increased from 25 to 50.
  * Scan results include per-source discovery breakdown and per-page provenance.

* **Documentation**
  * README updated with usage examples and behavioral details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->