### PR TITLE
Detect outdated JS libraries (CVEs), SQL connection strings, and dangerous URL params

### DIFF
--- a/extension/lib/detector-info.js
+++ b/extension/lib/detector-info.js
@@ -792,7 +792,7 @@ export const DETECTOR_INFO = {
     "validation_status": "validated"
   },
   "otp_in_response": {
-    "attack_scenario": "The server sends the OTP value in the API response. An attacker reads it from the network tab and enters it \u2014 bypassing two-factor authentication entirely. This was exploited in the CBSE exam portal breach (2026).",
+    "attack_scenario": "The server sends the OTP value in the API response. An attacker reads it from the network tab and enters it \u2014 bypassing two-factor authentication entirely. This is a recurring cause of real-world authentication breaches.",
     "categories": [
       "sourcemaps",
       "code",

--- a/fixtures/vulnerable-demo/.env.leaky
+++ b/fixtures/vulnerable-demo/.env.leaky
@@ -1,3 +1,3 @@
 OPENAI_API_KEY=sk-proj-THISISNOTAREALKEY012345678901234567890
-DATABASE_URL=postgres://runtime_user:runtime_password@db.internal:5432/app
+DATABASE_URL=postgres://runtime_user:8fK3pWmZqL7tRv2N@db.internal:5432/app
 MCP_SERVER_TOKEN=mcp-runtime-token-ABCDEFGHIJKLMNOPQRSTUVWX

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -175,6 +175,50 @@ _INIT_SCRIPT_TEMPLATE = r"""
     return window.__keyleak_findings;
   };
 
+  // Frontend dependency hygiene — report the versions of well-known libraries
+  // the page actually loaded, so Python can flag known-vulnerable releases.
+  // Reads runtime version globals first, then falls back to parsing the version
+  // out of <script src> filenames for libraries not exposed as globals.
+  window.__keyleak_library_scan = function () {
+    var libs = [];
+    try {
+      if (window.jQuery && window.jQuery.fn && window.jQuery.fn.jquery) {
+        libs.push({name: 'jquery', version: window.jQuery.fn.jquery, source: 'global'});
+      } else if (window.$ && window.$.fn && window.$.fn.jquery) {
+        libs.push({name: 'jquery', version: window.$.fn.jquery, source: 'global'});
+      }
+      if (window.bootstrap && (window.bootstrap.Tooltip || window.bootstrap.Alert)) {
+        libs.push({name: 'bootstrap', version: (window.bootstrap.Tooltip || window.bootstrap.Alert).VERSION, source: 'global'});
+      } else if (window.jQuery && window.jQuery.fn && window.jQuery.fn.tooltip && window.jQuery.fn.tooltip.Constructor) {
+        // Bootstrap 4 registers as a jQuery plugin exposing Constructor.VERSION.
+        libs.push({name: 'bootstrap', version: window.jQuery.fn.tooltip.Constructor.VERSION, source: 'global'});
+      }
+      if (window.React && window.React.version) {
+        libs.push({name: 'react', version: window.React.version, source: 'global'});
+      }
+      if (window.Vue && window.Vue.version) {
+        libs.push({name: 'vue', version: window.Vue.version, source: 'global'});
+      }
+      if (window.angular && typeof window.angular.version === 'object' && window.angular.version.full) {
+        libs.push({name: 'angular', version: window.angular.version.full, source: 'global'});
+      }
+      var SRC_RE = [
+        ['jquery', /jquery[-.]?(\d+\.\d+\.\d+)/i],
+        ['bootstrap', /bootstrap[-.]?(\d+\.\d+\.\d+)/i],
+        ['angular', /angular[-.]?(\d+\.\d+\.\d+)/i]
+      ];
+      var srcs = document.querySelectorAll('script[src]');
+      for (var i = 0; i < srcs.length; i++) {
+        var src = srcs[i].src || '';
+        for (var j = 0; j < SRC_RE.length; j++) {
+          var m = SRC_RE[j][1].exec(src);
+          if (m) libs.push({name: SRC_RE[j][0], version: m[1], source: 'script-url', url: src});
+        }
+      }
+    } catch (_err) { /* swallow — best-effort enumeration */ }
+    return libs;
+  };
+
   // Wave 4.1 — BaaS config extraction.
   // Fetches all JS bundles loaded by the page and extracts Supabase/Firebase
   // configuration: project URL, anon key, table names, RPC functions, and
@@ -362,6 +406,15 @@ def run_browser_scan(
         except Exception:
             pass
 
+        # Enumerate loaded frontend libraries + versions for CVE matching.
+        libraries = []
+        try:
+            libraries = page.evaluate(
+                "() => window.__keyleak_library_scan ? window.__keyleak_library_scan() : []"
+            )
+        except Exception:
+            pass
+
         browser.close()
 
     # Merge extra --baas-tables into extraction
@@ -376,6 +429,9 @@ def run_browser_scan(
     findings = [_to_finding(entry, url) for entry in raw or []]
     baas_findings = _run_baas_validation(raw, baas_extraction, baas_validate, baas_prober, proxy)
     findings.extend(baas_findings)
+
+    from .js_library_cves import _library_cve_findings
+    findings.extend(_library_cve_findings(libraries or [], url))
 
     return build_report(
         url,

--- a/keyleak/detectors.py
+++ b/keyleak/detectors.py
@@ -342,6 +342,20 @@ DETECTORS = [
         attack_scenario="The embedded credentials grant whatever role the DB user has — typically full read of every row. Attackers pull customer PII, payment records, and password hashes for credential stuffing elsewhere; if the DB is internet-reachable it's game over.",
     ),
     Detector(
+        "dotnet_sql_connection_string",
+        r"(?:(?:Server|Data Source)\s*=\s*[^;'\"]+;[\s\S]{0,200}?(?:Password|Pwd)\s*=\s*[^;'\"\s]{3,}|jdbc:(?:sqlserver|postgresql|mysql|oracle:thin)://[^\s'\"]+[?;&](?:password|pwd)\s*=\s*[^\s'\"&;]{3,})",
+        "critical",
+        "ADO.NET / ODBC / JDBC database connection string with an embedded password.",
+        "Rotate the database password, move connection strings to a server-side secret store, and never ship them in client bundles, config files, or logs.",
+        ["env", "ci", "docker", "config", "code", "sourcemaps", "logs"],
+        validation_status="validated",
+        references=(
+            "https://cwe.mitre.org/data/definitions/798.html",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+        ),
+        attack_scenario="A connection string with a high-privilege account (e.g. the SQL Server `sa` login) hands an attacker direct read/write to every database on that instance. On shared/multi-tenant hosting, one exposed string compromises every co-located tenant's data at once.",
+    ),
+    Detector(
         "private_key",
         r"-----BEGIN (?:(?:RSA|DSA|EC|OPENSSH) )?PRIVATE KEY-----[\s\S]+?-----END (?:(?:RSA|DSA|EC|OPENSSH) )?PRIVATE KEY-----",
         "critical",
@@ -977,7 +991,7 @@ DETECTORS = [
         "validated",
         ("https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/",),
         True,
-        attack_scenario="The server sends the OTP value in the API response. An attacker reads it from the network tab and enters it — bypassing two-factor authentication entirely. This was exploited in the CBSE exam portal breach (2026).",
+        attack_scenario="The server sends the OTP value in the API response. An attacker reads it from the network tab and enters it — bypassing two-factor authentication entirely. This is a recurring cause of real-world authentication breaches.",
     ),
     Detector(
         "hardcoded_credential_in_bundle",

--- a/keyleak/js_library_cves.py
+++ b/keyleak/js_library_cves.py
@@ -1,0 +1,205 @@
+"""Known-vulnerable frontend JavaScript library detection (retire.js-style).
+
+The browser scanner reads the versions of libraries a page actually loads
+(see ``__keyleak_library_scan`` in ``browser_scanner.py``). This module maps a
+``(library, version)`` pair to publicly documented CVEs and builds ``appsec``
+findings.
+
+Detection is version-based, so findings are reported as ``lead``: a vulnerable
+version is present, but whether the specific sink is reachable depends on how
+the app uses the library. The signal is still high-value — shipping a decade-old
+jQuery or an unpatched Bootstrap is a real, common exposure.
+
+Only well-established, widely-cited CVEs for popular libraries are encoded. The
+table is deliberately small and easy to extend; library/version come from the
+page at runtime, CVE IDs are public, so nothing target-specific lives here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from .models import Evidence, Finding, confidence_for_severity
+
+Version = Tuple[int, int, int]
+
+NVD_URL = "https://nvd.nist.gov/vuln/detail/{}"
+
+# Severity rank for picking the worst across multiple matched rules.
+_SEVERITY_RANK = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
+# Each library maps to a list of rules. A rule matches when the parsed version
+# is >= ``introduced`` (inclusive, default 0.0.0) and < ``below`` (exclusive).
+# A single version may match several rules; findings aggregate them.
+VULN_TABLE: Dict[str, List[Dict[str, Any]]] = {
+    "jquery": [
+        {
+            "below": (1, 9, 0),
+            "severity": "high",
+            "cves": ["CVE-2012-6708"],
+            "summary": "jQuery < 1.9 cannot reliably tell a CSS selector from HTML, so $() on attacker-controlled input executes scripts (DOM XSS).",
+        },
+        {
+            "below": (3, 0, 0),
+            "severity": "high",
+            "cves": ["CVE-2015-9251"],
+            "summary": "jQuery < 3.0 auto-executes cross-domain AJAX responses served as text/javascript, enabling XSS.",
+        },
+        {
+            "below": (3, 4, 0),
+            "severity": "high",
+            "cves": ["CVE-2019-11358"],
+            "summary": "jQuery < 3.4 jQuery.extend(true, ...) is vulnerable to Object.prototype pollution.",
+        },
+        {
+            "below": (3, 5, 0),
+            "severity": "high",
+            "cves": ["CVE-2020-11022", "CVE-2020-11023"],
+            "summary": "jQuery < 3.5 htmlPrefilter regex can be bypassed, so .html()/.append() on untrusted HTML executes scripts (XSS).",
+        },
+    ],
+    "bootstrap": [
+        {
+            "below": (3, 4, 1),
+            "severity": "medium",
+            "cves": ["CVE-2018-14041", "CVE-2019-8331"],
+            "summary": "Bootstrap < 3.4.1 has XSS in data-target and tooltip/popover templates.",
+        },
+        {
+            "introduced": (4, 0, 0),
+            "below": (4, 1, 2),
+            "severity": "medium",
+            "cves": ["CVE-2018-14041"],
+            "summary": "Bootstrap 4 < 4.1.2 has XSS in the scrollspy data-target attribute.",
+        },
+        {
+            "introduced": (4, 0, 0),
+            "below": (4, 3, 1),
+            "severity": "medium",
+            "cves": ["CVE-2019-8331"],
+            "summary": "Bootstrap 4 < 4.3.1 has XSS in tooltip/popover data-template.",
+        },
+        {
+            "introduced": (4, 0, 0),
+            "below": (4, 6, 3),
+            "severity": "medium",
+            "cves": ["CVE-2024-6531"],
+            "summary": "Bootstrap 4 (4.0.0–4.6.2) has XSS in the carousel data-slide / data-slide-to attributes.",
+        },
+    ],
+}
+
+# Latest safe major line per library, for remediation guidance.
+_SAFE_TARGET = {"jquery": "3.7.1 or later", "bootstrap": "5.3.x or later"}
+
+
+def parse_version(raw: Optional[str]) -> Optional[Version]:
+    """Parse a loose version string into a (major, minor, patch) tuple.
+
+    Tolerates a leading ``v``, pre-release/build suffixes (``3.5.0-beta``), and
+    missing patch/minor (``2`` -> ``(2, 0, 0)``). Returns None when no numeric
+    version can be recovered, so callers simply skip the library.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    text = raw.strip().lstrip("vV")
+    # Take the leading dotted-numeric run, ignoring any -beta/+build suffix.
+    head = ""
+    for ch in text:
+        if ch.isdigit() or ch == ".":
+            head += ch
+        else:
+            break
+    parts = [p for p in head.split(".") if p != ""]
+    if not parts:
+        return None
+    nums: List[int] = []
+    for p in parts[:3]:
+        try:
+            nums.append(int(p))
+        except ValueError:
+            return None
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2])
+
+
+def match_library_cves(name: str, version: Optional[str]) -> List[Dict[str, Any]]:
+    """Return the vulnerability rules that apply to ``name``@``version``.
+
+    Empty list when the library is unknown or the version is safe/unparseable.
+    """
+    rules = VULN_TABLE.get((name or "").strip().lower())
+    if not rules:
+        return []
+    parsed = parse_version(version)
+    if parsed is None:
+        return []
+    matched: List[Dict[str, Any]] = []
+    for rule in rules:
+        introduced = rule.get("introduced", (0, 0, 0))
+        below = rule["below"]
+        if introduced <= parsed < below:
+            matched.append(rule)
+    return matched
+
+
+def _library_cve_findings(libraries: List[Dict[str, Any]], page_url: str) -> List[Finding]:
+    """Build one ``appsec`` Finding per distinct vulnerable (library, version).
+
+    ``libraries`` is the raw payload from ``__keyleak_library_scan``: dicts with
+    ``name``, ``version``, ``source`` ('global'|'script-url'), and optional
+    ``url``.
+    """
+    findings: List[Finding] = []
+    seen: set = set()
+    for lib in libraries or []:
+        name = str((lib or {}).get("name") or "").strip().lower()
+        version = (lib or {}).get("version")
+        if not name or not version:
+            continue
+        key = (name, str(version))
+        if key in seen:
+            continue
+        seen.add(key)
+
+        matched = match_library_cves(name, version)
+        if not matched:
+            continue
+
+        cves: List[str] = []
+        for rule in matched:
+            for cve in rule["cves"]:
+                if cve not in cves:
+                    cves.append(cve)
+        severity = max((r["severity"] for r in matched), key=lambda s: _SEVERITY_RANK.get(s, 0))
+        summary = " ".join(r["summary"] for r in matched)
+        source = str(lib.get("url") or page_url or "")
+        target = _SAFE_TARGET.get(name, "a current, supported release")
+
+        findings.append(
+            Finding(
+                type="vulnerable_js_library",
+                severity=severity,
+                confidence=confidence_for_severity(severity),
+                detector_id="appsec.vulnerable_js_library",
+                source=source,
+                evidence=Evidence(
+                    source=source,
+                    snippet=f"{name} {version} — {', '.join(cves)}",
+                    redacted_value=f"{name} {version}",
+                    request_url=page_url or "",
+                ),
+                risk_reason=(
+                    f"{name} {version} is loaded and has known vulnerabilities ({', '.join(cves)}). {summary}"
+                ),
+                remediation=(
+                    f"Upgrade {name} to {target} and re-test. Pin the dependency and "
+                    "track advisories so vulnerable versions are not reintroduced."
+                ),
+                validation_status="lead",
+                category="appsec",
+                references=[NVD_URL.format(c) for c in cves],
+            )
+        )
+    return findings

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -442,6 +442,23 @@ def scan_site(
     if not subdomains:
         subdomains = [domain]
 
+    # Subdomain-takeover check runs in parallel with the crawl/scan below. It
+    # only uses ``requests`` (no Playwright), so a single worker thread safely
+    # overlaps the main-thread browser work and adds almost no wall-clock time.
+    takeover_pool = None
+    takeover_future = None
+    if not offline:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from .subdomain_takeover import check_subdomain_takeovers
+
+        _emit(on_progress, "takeover",
+              f"Checking {len(subdomains)} subdomain(s) for takeover in parallel")
+        takeover_pool = ThreadPoolExecutor(max_workers=1)
+        takeover_future = takeover_pool.submit(
+            check_subdomain_takeovers, subdomains, proxy=proxy
+        )
+
     raw_query_urls: Set[str] = set()
     urls = crawl_pages(
         subdomains, depth=depth, max_pages=max_pages,
@@ -471,6 +488,23 @@ def scan_site(
             print(f"[keyleak]   Error scanning {url}: {exc}", file=sys.stderr)
             continue
 
+    # Join the parallel subdomain-takeover check and fold its findings in.
+    takeover_count = 0
+    if takeover_future is not None:
+        try:
+            takeover_findings = takeover_future.result()
+        except Exception:
+            takeover_findings = []
+        finally:
+            takeover_pool.shutdown(wait=False)
+        for f in takeover_findings:
+            pairs.append((f, f.source))
+        takeover_count = len(takeover_findings)
+        if takeover_count:
+            _emit(on_progress, "takeover",
+                  f"Subdomain-takeover check flagged {takeover_count} host(s)",
+                  takeover_count, takeover_count)
+
     findings, provenance = _merge_findings(pairs)
     _emit(on_progress, "done",
           f"Full site scan complete: {len(findings)} unique finding(s) from {total} page(s)",
@@ -489,5 +523,6 @@ def scan_site(
         "pages_scanned": total,
         "scanned_urls": urls,
         "provenance": provenance,
+        "subdomain_takeovers": takeover_count,
     })
     return report

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -18,15 +18,25 @@ import subprocess
 import sys
 from collections import deque
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse, urlsplit
 
 import requests
 import tldextract
 
 from .browser_scanner import run_browser_scan
-from .models import Finding, ScanReport
+from .models import Evidence, Finding, ScanReport, confidence_for_severity
 from .proxy import playwright_proxy, requests_proxies
 from .reporting import build_report
+
+
+# Query parameter names that commonly feed OS command / code execution sinks.
+DANGEROUS_PARAMS = {
+    "cmd", "command", "exec", "execute", "shell", "system", "run",
+    "code", "func", "function", "ping",
+}
+# Server-executed endpoints (vs. static assets); a dangerous param here is worse.
+_SERVER_EXEC_EXT = (".aspx", ".asp", ".jsp", ".php", ".cgi", ".do", ".action")
+_EXEC_FAMILY = {"cmd", "command", "exec", "execute", "shell", "system", "run"}
 
 
 COMMON_SUBDOMAINS = [
@@ -220,12 +230,16 @@ def crawl_pages(
     max_pages: int = MAX_PAGES_DEFAULT,
     headless: bool = True,
     proxy: Optional[str] = None,
+    collect_raw: Optional[Set[str]] = None,
     on_progress: ProgressFn = None,
 ) -> List[str]:
     """Breadth-first crawl across ``hosts`` up to ``depth`` link levels.
 
     Same-registrable-domain scope, normalized dedup, global ``max_pages`` cap.
-    Falls back to host roots only when Playwright is unavailable.
+    Falls back to host roots only when Playwright is unavailable. When
+    ``collect_raw`` is given, in-scope hrefs that carry a query string are added
+    to it verbatim (before normalization strips the query) so callers can scan
+    them for dangerous parameters.
     """
     seen: Set[str] = set()
     roots = []
@@ -272,6 +286,14 @@ def crawl_pages(
                         except Exception:
                             pass
                 registrable = registrable_domain(urlparse(url).netloc)
+                if collect_raw is not None:
+                    for link in links:
+                        if "?" not in link:
+                            continue
+                        lp = urlparse(link)
+                        if lp.scheme in ("http", "https") and lp.netloc \
+                                and registrable_domain(lp.netloc) == registrable:
+                            collect_raw.add(link)
                 remaining = max_pages - (len(results) + len(queue))
                 for nu in _filter_links(links, registrable, seen, remaining):
                     queue.append((nu, level + 1))
@@ -318,6 +340,71 @@ def _deduplicate_findings(findings: List[Finding]) -> List[Finding]:
     return merged
 
 
+def _dangerous_param_findings(urls: Set[str]) -> List[Finding]:
+    """Flag crawled URLs whose query string carries a command-injection-shaped
+    parameter (``?cmd=``, ``?exec=``, …). Deduplicated by (host, path, params).
+
+    These are leads: the parameter name is suggestive, not proof of a sink.
+    Query *values* are never echoed (they may themselves be attacker payloads).
+    """
+    findings: List[Finding] = []
+    seen: Set[Tuple[str, str, Tuple[str, ...]]] = set()
+    for url in urls or set():
+        try:
+            parts = urlsplit(url)
+        except ValueError:
+            continue
+        if not parts.query:
+            continue
+        params = parse_qs(parts.query, keep_blank_values=True)
+        hits = tuple(sorted(p for p in params if p.lower() in DANGEROUS_PARAMS))
+        if not hits:
+            continue
+        path = parts.path or "/"
+        key = (parts.netloc, path, hits)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        server_exec = path.lower().endswith(_SERVER_EXEC_EXT)
+        exec_family = any(h.lower() in _EXEC_FAMILY for h in hits)
+        severity = "high" if (server_exec and exec_family) else "medium"
+        loc = f"{parts.scheme}://{parts.netloc}{path}"
+        names = ", ".join(hits)
+        findings.append(
+            Finding(
+                type="dangerous_url_parameter",
+                severity=severity,
+                confidence=confidence_for_severity(severity),
+                detector_id="appsec.dangerous_url_param",
+                source=loc,
+                evidence=Evidence(
+                    source=loc,
+                    snippet=f"{path}?{names}=…",
+                    redacted_value=names,
+                    request_url=loc,
+                ),
+                risk_reason=(
+                    f"A crawled link exposes the query parameter(s) {names} on "
+                    f"{'a server-executed endpoint ' if server_exec else ''}{path} — "
+                    "a common command-injection / RCE vector."
+                ),
+                remediation=(
+                    "Treat this parameter as untrusted input: never pass it to a shell, "
+                    "OS command, or eval; validate against a strict allowlist and re-test "
+                    "the endpoint."
+                ),
+                validation_status="lead",
+                category="appsec",
+                references=[
+                    "https://cwe.mitre.org/data/definitions/78.html",
+                    "https://owasp.org/www-community/attacks/Command_Injection",
+                ],
+            )
+        )
+    return findings
+
+
 def scan_site(
     domain: str,
     *,
@@ -355,12 +442,16 @@ def scan_site(
     if not subdomains:
         subdomains = [domain]
 
+    raw_query_urls: Set[str] = set()
     urls = crawl_pages(
         subdomains, depth=depth, max_pages=max_pages,
-        headless=headless, proxy=proxy, on_progress=on_progress,
+        headless=headless, proxy=proxy, collect_raw=raw_query_urls,
+        on_progress=on_progress,
     )
 
     pairs: List[Tuple[Finding, str]] = []
+    for finding in _dangerous_param_findings(raw_query_urls):
+        pairs.append((finding, finding.evidence.request_url))
     total = len(urls)
     for i, url in enumerate(urls):
         _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {url}", i + 1, total)

--- a/keyleak/subdomain_takeover.py
+++ b/keyleak/subdomain_takeover.py
@@ -1,0 +1,138 @@
+"""Subdomain-takeover detection.
+
+A subdomain that still points (via DNS/CNAME) at a third-party service which no
+longer claims it can be re-registered by an attacker, who then serves content
+from your domain — phishing, cookie theft, CSP bypass, etc.
+
+We detect the most reliable, low-false-positive signal: the *fingerprint* the
+abandoned provider returns for an unclaimed host (e.g. S3's "NoSuchBucket",
+GitHub Pages' "There isn't a GitHub Pages site here"). Fingerprints come from the
+community ``can-i-take-over-xyz`` project. No DNS library is required — we fetch
+the host and match the response body — and probes run concurrently so checking
+many subdomains adds little wall-clock time.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Optional
+
+from .models import Evidence, Finding, confidence_for_severity
+from .proxy import requests_proxies
+
+ProgressFn = Optional[Callable[[Dict[str, Any]], None]]
+
+# service -> response-body signatures that indicate an unclaimed/danging target.
+# Conservative subset chosen for low false positives; easy to extend.
+TAKEOVER_FINGERPRINTS: Dict[str, List[str]] = {
+    "AWS/S3": ["The specified bucket does not exist", "NoSuchBucket"],
+    "GitHub Pages": [
+        "There isn't a GitHub Pages site here.",
+        "For root URLs (like http://example.com/) you must provide an index.html file",
+    ],
+    "Heroku": ["No such app", "herokucdn.com/error-pages/no-such-app.html"],
+    "Fastly": ["Fastly error: unknown domain"],
+    "Shopify": ["Sorry, this shop is currently unavailable"],
+    "Bitbucket": ["Repository not found"],
+    "Ghost": ["The thing you were looking for is no longer here, or never was"],
+    "Surge.sh": ["project not found"],
+    "Tilda": ["Please renew your subscription"],
+    "Pantheon": ["The gods are wise, but do not know of the site which you seek"],
+    "Cargo": ["If you're moving your domain away from Cargo"],
+    "Help Scout": ["No settings were found for this company"],
+    "Unbounce": ["The requested URL was not found on this server"],
+    "Azure": ["404 Web Site not found"],
+    "Netlify": ["Not Found - Request ID"],
+}
+
+_REFERENCES = [
+    "https://github.com/EdOverflow/can-i-take-over-xyz",
+    "https://owasp.org/www-community/attacks/Subdomain_Takeover",
+]
+
+DEFAULT_WORKERS = 16
+
+
+def _probe_host(host: str, proxy: Optional[str], timeout: int) -> Optional[Finding]:
+    """Fetch ``host`` and return a Finding if its body matches a takeover
+    fingerprint, else None. Network/TLS errors are treated as "no signal"."""
+    import requests
+
+    proxies = requests_proxies(proxy)
+    body = None
+    for scheme in ("https", "http"):
+        try:
+            resp = requests.get(
+                f"{scheme}://{host}",
+                timeout=timeout,
+                proxies=proxies,
+                allow_redirects=True,
+                headers={"User-Agent": "keyleak-detector/subdomain-takeover"},
+            )
+            body = resp.text or ""
+            break
+        except requests.RequestException:
+            continue
+    if not body:
+        return None
+
+    for service, signatures in TAKEOVER_FINGERPRINTS.items():
+        for sig in signatures:
+            if sig in body:
+                loc = f"https://{host}"
+                return Finding(
+                    type="subdomain_takeover",
+                    severity="high",
+                    confidence=confidence_for_severity("high"),
+                    detector_id="appsec.subdomain_takeover",
+                    source=loc,
+                    evidence=Evidence(
+                        source=loc,
+                        snippet=f"{host} returns an unclaimed-{service} fingerprint",
+                        redacted_value=f"{host} -> {service}",
+                        request_url=loc,
+                    ),
+                    risk_reason=(
+                        f"{host} still resolves to {service} but the target is unclaimed "
+                        f"(\"{sig}\"). An attacker can register it and serve content from your "
+                        "domain — phishing, cookie/session theft, and CSP/SSO bypass."
+                    ),
+                    remediation=(
+                        f"Remove the dangling DNS record for {host}, or re-claim the {service} "
+                        "resource it points to. Audit all CNAMEs for retired services."
+                    ),
+                    validation_status="lead",
+                    category="appsec",
+                    references=list(_REFERENCES),
+                )
+    return None
+
+
+def check_subdomain_takeovers(
+    hosts: List[str],
+    *,
+    proxy: Optional[str] = None,
+    timeout: int = 8,
+    max_workers: int = DEFAULT_WORKERS,
+) -> List[Finding]:
+    """Probe ``hosts`` concurrently for subdomain-takeover fingerprints.
+
+    Returns one Finding per vulnerable host. Safe to run from a background
+    thread alongside the Playwright crawl (uses ``requests`` only).
+    """
+    findings: List[Finding] = []
+    unique = [h for h in dict.fromkeys(hosts) if h]
+    if not unique:
+        return findings
+    workers = max(1, min(max_workers, len(unique)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_probe_host, h, proxy, timeout): h for h in unique}
+        for fut in as_completed(futures):
+            try:
+                finding = fut.result()
+            except Exception:
+                finding = None
+            if finding is not None:
+                findings.append(finding)
+    findings.sort(key=lambda f: f.source)
+    return findings

--- a/tests/test_browser_library_scan.py
+++ b/tests/test_browser_library_scan.py
@@ -1,0 +1,57 @@
+"""run_browser_scan emits vulnerable-library findings from the page probe."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from typing import Any, Dict
+from unittest import mock
+
+HAS_PLAYWRIGHT = importlib.util.find_spec("playwright") is not None
+
+
+@unittest.skipUnless(HAS_PLAYWRIGHT, "Playwright not installed; integration test skipped.")
+class BrowserLibraryScanTests(unittest.TestCase):
+    def _run_with_evaluate_results(self, results):
+        """Drive run_browser_scan with a fully-mocked Playwright; page.evaluate
+        returns ``results`` in call order: __keyleak_run, baas_extract, library_scan.
+        """
+        from keyleak.browser_scanner import run_browser_scan
+
+        page = mock.MagicMock()
+        page.evaluate.side_effect = list(results)
+        context = mock.MagicMock()
+        context.new_page.return_value = page
+        browser = mock.MagicMock()
+        browser.new_context.return_value = context
+        p = mock.MagicMock()
+        p.chromium.launch.return_value = browser
+        cm = mock.MagicMock()
+        cm.__enter__.return_value = p
+
+        with mock.patch("playwright.sync_api.sync_playwright", return_value=cm):
+            return run_browser_scan("https://app.example.test/")
+
+    def test_old_jquery_produces_vulnerable_library_finding(self):
+        report = self._run_with_evaluate_results([
+            [],                                                  # __keyleak_run
+            None,                                                # __keyleak_baas_extract
+            [{"name": "jquery", "version": "1.10.2", "source": "global"}],  # library scan
+        ])
+        types = [f.type for f in report.findings]
+        self.assertIn("vulnerable_js_library", types)
+        f = next(f for f in report.findings if f.type == "vulnerable_js_library")
+        self.assertEqual(f.detector_id, "appsec.vulnerable_js_library")
+        self.assertTrue(any("CVE-" in r for r in f.references))
+
+    def test_modern_library_produces_no_finding(self):
+        report = self._run_with_evaluate_results([
+            [],
+            None,
+            [{"name": "jquery", "version": "3.7.1", "source": "global"}],
+        ])
+        self.assertNotIn("vulnerable_js_library", [f.type for f in report.findings])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dangerous_url_params.py
+++ b/tests/test_dangerous_url_params.py
@@ -1,0 +1,67 @@
+"""Tests for crawl-time dangerous-URL-parameter detection (site_scanner)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import keyleak.site_scanner as ss
+from keyleak.models import ScanReport
+
+
+class DangerousParamFindingTests(unittest.TestCase):
+    def _by_loc(self, urls):
+        return {f.source: f for f in ss._dangerous_param_findings(set(urls))}
+
+    def test_flags_cmd_on_server_endpoint_as_high(self):
+        found = self._by_loc(["https://h.example.test/Eval/QP.aspx?cmd=whoami"])
+        f = found["https://h.example.test/Eval/QP.aspx"]
+        self.assertEqual(f.type, "dangerous_url_parameter")
+        self.assertEqual(f.detector_id, "appsec.dangerous_url_param")
+        self.assertEqual(f.severity, "high")
+        self.assertEqual(f.validation_status, "lead")
+        self.assertEqual(f.evidence.redacted_value, "cmd")
+
+    def test_non_exec_endpoint_is_medium(self):
+        found = self._by_loc(["https://h.example.test/api?exec=ls&token=abc"])
+        self.assertEqual(found["https://h.example.test/api"].severity, "medium")
+
+    def test_ignores_benign_params(self):
+        self.assertEqual(ss._dangerous_param_findings({"https://h.example.test/p?id=5"}), [])
+        self.assertEqual(ss._dangerous_param_findings({"https://h.example.test/s?q=hi"}), [])
+
+    def test_does_not_echo_param_values(self):
+        # The query value (a possible payload) must not appear in the finding.
+        found = self._by_loc(["https://h.example.test/x.php?command=rm%20-rf%20%2F"])
+        f = found["https://h.example.test/x.php"]
+        self.assertNotIn("rm", f.evidence.snippet)
+        self.assertNotIn("rm", f.evidence.redacted_value)
+
+    def test_dedupes_same_endpoint_and_params(self):
+        urls = [
+            "https://h.example.test/x.aspx?cmd=a",
+            "https://h.example.test/x.aspx?cmd=b",  # same host/path/param
+        ]
+        self.assertEqual(len(ss._dangerous_param_findings(set(urls))), 1)
+
+
+class ScanSiteWiringTests(unittest.TestCase):
+    def test_dangerous_params_reach_the_report(self):
+        def fake_crawl(hosts, **kwargs):
+            collect = kwargs.get("collect_raw")
+            if collect is not None:
+                collect.add("https://h.example.test/Eval/QP.aspx?cmd=whoami")
+            return ["https://h.example.test/"]
+
+        with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["h.example.test"]), \
+             mock.patch.object(ss, "crawl_pages", fake_crawl), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda url, **k: ScanReport(target=url, scan_mode="browser", findings=[])):
+            report = ss.scan_site("example.test")
+
+        types = [f.type for f in report.findings]
+        self.assertIn("dangerous_url_parameter", types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dotnet_conn_string.py
+++ b/tests/test_dotnet_conn_string.py
@@ -1,0 +1,47 @@
+"""Tests for the ADO.NET / JDBC SQL connection-string detector."""
+
+from __future__ import annotations
+
+import unittest
+
+from keyleak.detectors import find_detector
+from keyleak.local_scanner import scan_text
+
+
+class DotnetSqlConnectionStringTests(unittest.TestCase):
+    def setUp(self):
+        self.detector = find_detector("leak.dotnet_sql_connection_string")
+        self.assertIsNotNone(self.detector)
+
+    def _types(self, text):
+        return [f.type for f in scan_text(text, "appsettings.config", [self.detector])]
+
+    def test_flags_ado_net_sa_string(self):
+        text = "Server=tcp:mssql.example.net,1433;Initial Catalog=prod;User ID=sa;Password=S3cr3tP@ss!;"
+        self.assertIn("dotnet_sql_connection_string", self._types(text))
+
+    def test_flags_data_source_pwd_string(self):
+        text = "Data Source=db1;Initial Catalog=app;User Id=svc;Pwd=Hk29Wq7mZ4;"
+        self.assertIn("dotnet_sql_connection_string", self._types(text))
+
+    def test_flags_jdbc_sqlserver_string(self):
+        text = "jdbc:sqlserver://db.example.net:1433;databaseName=app;user=sa;password=Adm1n2026X"
+        self.assertIn("dotnet_sql_connection_string", self._types(text))
+
+    def test_ignores_connection_string_without_password(self):
+        text = "Server=tcp:db.example.net,1433;Initial Catalog=app;Integrated Security=true;"
+        self.assertEqual(self._types(text), [])
+
+    def test_ignores_plain_env_password(self):
+        # A bare password assignment is not a connection string.
+        text = "DB_PASSWORD=hunter2hunter2"
+        self.assertEqual(self._types(text), [])
+
+    def test_severity_and_pack(self):
+        self.assertEqual(self.detector.severity, "critical")
+        self.assertEqual(self.detector.pack, "leak")
+        self.assertEqual(self.detector.validation_status, "validated")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_js_library_cves.py
+++ b/tests/test_js_library_cves.py
@@ -1,0 +1,92 @@
+"""Tests for known-vulnerable JS library detection (keyleak/js_library_cves.py)."""
+
+from __future__ import annotations
+
+import unittest
+
+from keyleak.js_library_cves import (
+    _library_cve_findings,
+    match_library_cves,
+    parse_version,
+)
+
+
+class ParseVersionTests(unittest.TestCase):
+    def test_parses_common_shapes(self):
+        self.assertEqual(parse_version("1.10.2"), (1, 10, 2))
+        self.assertEqual(parse_version("v3.7.1"), (3, 7, 1))
+        self.assertEqual(parse_version("3.5.0-beta"), (3, 5, 0))
+        self.assertEqual(parse_version("2"), (2, 0, 0))
+        self.assertEqual(parse_version("4.6"), (4, 6, 0))
+
+    def test_rejects_garbage(self):
+        self.assertIsNone(parse_version(""))
+        self.assertIsNone(parse_version(None))
+        self.assertIsNone(parse_version("not-a-version"))
+
+
+class MatchLibraryCvesTests(unittest.TestCase):
+    def _cves(self, name, version):
+        return sorted({c for r in match_library_cves(name, version) for c in r["cves"]})
+
+    def test_old_jquery_flags_the_expected_cves(self):
+        # jQuery 1.10.2 is >= 1.9 so CVE-2012-6708 does not apply, but the
+        # cross-domain AJAX, prototype-pollution, and htmlPrefilter XSS CVEs do.
+        self.assertEqual(
+            self._cves("jquery", "1.10.2"),
+            ["CVE-2015-9251", "CVE-2019-11358", "CVE-2020-11022", "CVE-2020-11023"],
+        )
+
+    def test_ancient_jquery_includes_selector_cve(self):
+        self.assertIn("CVE-2012-6708", self._cves("jquery", "1.8.3"))
+
+    def test_current_jquery_is_clean(self):
+        self.assertEqual(match_library_cves("jquery", "3.7.1"), [])
+
+    def test_bootstrap4_flags_xss_and_carousel(self):
+        cves = self._cves("bootstrap", "4.0.0")
+        self.assertIn("CVE-2019-8331", cves)
+        self.assertIn("CVE-2024-6531", cves)
+
+    def test_modern_bootstrap_is_clean(self):
+        self.assertEqual(match_library_cves("bootstrap", "5.3.2"), [])
+
+    def test_unknown_library_and_bad_version_are_safe(self):
+        self.assertEqual(match_library_cves("leftpad", "1.0.0"), [])
+        self.assertEqual(match_library_cves("jquery", "garbage"), [])
+
+
+class LibraryFindingTests(unittest.TestCase):
+    def test_builds_appsec_lead_finding(self):
+        findings = _library_cve_findings(
+            [{"name": "jquery", "version": "1.10.2", "source": "global"}],
+            "https://app.example.test/",
+        )
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(f.type, "vulnerable_js_library")
+        self.assertEqual(f.detector_id, "appsec.vulnerable_js_library")
+        self.assertEqual(f.category, "appsec")
+        self.assertEqual(f.validation_status, "lead")
+        self.assertEqual(f.severity, "high")
+        self.assertEqual(f.evidence.redacted_value, "jquery 1.10.2")
+        self.assertTrue(any("CVE-2020-11022" in r for r in f.references))
+
+    def test_dedupes_and_skips_safe_libraries(self):
+        findings = _library_cve_findings(
+            [
+                {"name": "jquery", "version": "1.10.2"},
+                {"name": "jquery", "version": "1.10.2"},  # duplicate
+                {"name": "react", "version": "18.2.0"},   # safe
+            ],
+            "u",
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_empty_input_is_safe(self):
+        self.assertEqual(_library_cve_findings([], "u"), [])
+        self.assertEqual(_library_cve_findings([{"name": "jquery"}], "u"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subdomain_takeover.py
+++ b/tests/test_subdomain_takeover.py
@@ -1,0 +1,97 @@
+"""Tests for parallel subdomain-takeover detection."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import requests
+
+import keyleak.subdomain_takeover as st
+import keyleak.site_scanner as ss
+from keyleak.models import ScanReport
+
+
+class _Resp:
+    def __init__(self, text):
+        self.text = text
+
+
+class ProbeHostTests(unittest.TestCase):
+    # _probe_host does a local ``import requests``, so patch the real global.
+    def test_flags_known_fingerprint(self):
+        body = "<html><body>There isn't a GitHub Pages site here.</body></html>"
+        with mock.patch("requests.get", return_value=_Resp(body)):
+            finding = st._probe_host("app.example.test", None, 8)
+        self.assertIsNotNone(finding)
+        self.assertEqual(finding.type, "subdomain_takeover")
+        self.assertEqual(finding.severity, "high")
+        self.assertEqual(finding.detector_id, "appsec.subdomain_takeover")
+        self.assertIn("GitHub Pages", finding.evidence.redacted_value)
+
+    def test_benign_body_yields_nothing(self):
+        with mock.patch("requests.get", return_value=_Resp("<html>Welcome to our app</html>")):
+            self.assertIsNone(st._probe_host("ok.example.test", None, 8))
+
+    def test_network_error_is_no_signal(self):
+        with mock.patch("requests.get", side_effect=requests.RequestException("boom")):
+            self.assertIsNone(st._probe_host("dead.example.test", None, 8))
+
+
+class CheckSubdomainTakeoversTests(unittest.TestCase):
+    def test_runs_over_all_hosts_and_collects(self):
+        def fake_probe(host, proxy, timeout):
+            from keyleak.models import Evidence, Finding
+            if host == "vuln.example.test":
+                return Finding(
+                    type="subdomain_takeover", severity="high", confidence=0.9,
+                    detector_id="appsec.subdomain_takeover", source=f"https://{host}",
+                    evidence=Evidence(source=f"https://{host}", redacted_value=f"{host} -> AWS/S3"),
+                    risk_reason="x", remediation="y", validation_status="lead", category="appsec",
+                )
+            return None
+
+        with mock.patch.object(st, "_probe_host", side_effect=fake_probe):
+            findings = st.check_subdomain_takeovers(
+                ["ok.example.test", "vuln.example.test", "ok.example.test"], max_workers=4
+            )
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].source, "https://vuln.example.test")
+
+    def test_empty_hosts(self):
+        self.assertEqual(st.check_subdomain_takeovers([]), [])
+
+
+class ScanSiteWiringTests(unittest.TestCase):
+    def test_takeover_findings_reach_the_report(self):
+        from keyleak.models import Evidence, Finding
+        fake_finding = Finding(
+            type="subdomain_takeover", severity="high", confidence=0.9,
+            detector_id="appsec.subdomain_takeover", source="https://t.example.test",
+            evidence=Evidence(source="https://t.example.test", redacted_value="t.example.test -> Heroku"),
+            risk_reason="x", remediation="y", validation_status="lead", category="appsec",
+        )
+        with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["t.example.test"]), \
+             mock.patch.object(ss, "crawl_pages", lambda hosts, **k: ["https://t.example.test/"]), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda url, **k: ScanReport(target=url, scan_mode="browser", findings=[])), \
+             mock.patch("keyleak.subdomain_takeover.check_subdomain_takeovers",
+                        return_value=[fake_finding]):
+            report = ss.scan_site("example.test")
+
+        self.assertIn("subdomain_takeover", [f.type for f in report.findings])
+        self.assertEqual(report.extra["subdomain_takeovers"], 1)
+
+    def test_offline_skips_takeover(self):
+        with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["x.example.test"]), \
+             mock.patch.object(ss, "crawl_pages", lambda hosts, **k: []), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda url, **k: ScanReport(target=url, scan_mode="browser", findings=[])), \
+             mock.patch("keyleak.subdomain_takeover.check_subdomain_takeovers") as chk:
+            report = ss.scan_site("example.test", offline=True)
+        chk.assert_not_called()
+        self.assertEqual(report.extra["subdomain_takeovers"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds detections for common, high-impact web exposures that KeyLeak previously missed — most notably **known-vulnerable frontend libraries** (the analyzer never read loaded library versions) and **subdomain takeover**.

## What's new

### 1. Vulnerable JS libraries → CVEs (retire.js-style)
- New page-side probe `__keyleak_library_scan` reads versions of jQuery, Bootstrap, React, Vue, Angular from runtime globals **and** `<script src>` filenames.
- `keyleak/js_library_cves.py` maps `(library, version)` to CVEs and emits `appsec` `vulnerable_js_library` findings. Covers jQuery `CVE-2015-9251 / 2019-11358 / 2020-11022 / 2020-11023 / 2012-6708` and Bootstrap `CVE-2018-14041 / 2019-8331 / 2024-6531`. Runs in `browser-scan` and `site-scan`.

### 2. ADO.NET / ODBC / JDBC SQL connection strings
- New `leak`-pack regex detector `dotnet_sql_connection_string` (`Server=…;Password=…`, `Data Source=…;Pwd=…`, `jdbc:sqlserver://…`). Complements `database_url`; JS-compatible so it ships to the extension bundle.

### 3. Dangerous URL parameters (command-injection / RCE leads)
- The crawl preserves query-bearing hrefs (previously stripped) and flags links carrying `cmd`/`exec`/`shell`/… params, elevated to **high** on server-executed endpoints (`.aspx`/`.jsp`/`.php`). Query values are never echoed.

### 4. Parallel subdomain-takeover check
- After subdomains are discovered, `scan_site` probes them for **subdomain takeover** (dangling DNS pointing at an unclaimed service) using a community fingerprint table (`can-i-take-over-xyz`) matched against each host's response body — no DNS library needed.
- Runs **concurrently** (ThreadPoolExecutor) and **in parallel with the Playwright crawl/scan** (it uses only `requests`), so it adds almost no wall-clock time. Emits high-severity `appsec` `subdomain_takeover` leads; skipped under `--offline`.

## Incidental fixes
- **Fixture fix:** `fixtures/vulnerable-demo/.env.leaky` used a placeholder-shaped DB password that the dev-credential gate correctly suppresses, so a `test_core_reporting` assertion failed on a clean `main` checkout. Swapped in a realistic secret. (Pre-existing failure, now green.)
- Generalized one detector's `attack_scenario` wording (removed an incident-specific reference).

## Tests / verification
- Standalone `unittest` suites for every detection + a Playwright-mocked browser-scan test. **Full suite green (123 passed).** Extension pattern bundle still builds.
- **Real end-to-end:** a deep direct site scan flagged **jQuery 1.10.2 (high, with CVEs)** on a live subdomain that previously returned **0 findings** → verdict **BLOCK SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)