### PR TITLE
Release 0.5.4 — version bump + pre-release security hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,10 @@ EXPOSE 5002
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PORT=5002
+# Inside the container the app must listen on all interfaces to be reachable
+# through the published port mapping. The host (`python app.py`) defaults to
+# loopback; this opt-in is container-only.
+ENV KEYLEAK_HOST=0.0.0.0
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \

--- a/action.yml
+++ b/action.yml
@@ -60,10 +60,13 @@ runs:
 
     - name: Install KeyLeak
       shell: bash
+      env:
+        KL_MODE: ${{ inputs.mode }}
+        KL_ACTION_PATH: ${{ github.action_path }}
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e "${{ github.action_path }}"
-        if [ "${{ inputs.mode }}" = "browser" ] || [ "${{ inputs.mode }}" = "both" ]; then
+        python -m pip install -e "$KL_ACTION_PATH"
+        if [ "$KL_MODE" = "browser" ] || [ "$KL_MODE" = "both" ]; then
           python -m pip install playwright
           python -m playwright install chromium --with-deps
         fi
@@ -73,51 +76,59 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ''
+        # All user-controlled inputs flow through env vars — never interpolate
+        # ${{ inputs.* }} directly into the shell (GitHub Actions script injection).
+        KL_MODE: ${{ inputs.mode }}
+        KL_URL: ${{ inputs.url }}
+        KL_FORMAT: ${{ inputs.output-format }}
+        KL_FAILON: ${{ inputs.fail-on }}
+        KL_PROFILE: ${{ inputs.launch-profile }}
+        KL_ALLOWLIST: ${{ inputs.allowlist }}
+        KL_BAAS: ${{ inputs.baas-validate }}
       run: |
         FORMAT_FLAG="--json"
-        [ "${{ inputs.output-format }}" = "sarif" ] && FORMAT_FLAG="--sarif"
-        [ "${{ inputs.output-format }}" = "markdown" ] && FORMAT_FLAG="--markdown"
-        [ "${{ inputs.output-format }}" = "html" ] && FORMAT_FLAG="--html"
+        [ "$KL_FORMAT" = "sarif" ] && FORMAT_FLAG="--sarif"
+        [ "$KL_FORMAT" = "markdown" ] && FORMAT_FLAG="--markdown"
+        [ "$KL_FORMAT" = "html" ] && FORMAT_FLAG="--html"
 
         VERDICT="SAFE_TO_SHIP"
         FINDINGS=0
-        REPORT="keyleak-report.${{ inputs.output-format }}"
+        REPORT="keyleak-report.$KL_FORMAT"
 
         # Local scan
-        if [ "${{ inputs.mode }}" = "local" ] || [ "${{ inputs.mode }}" = "both" ]; then
+        if [ "$KL_MODE" = "local" ] || [ "$KL_MODE" = "both" ]; then
           ALLOWLIST_FLAG=""
-          [ -f "${{ inputs.allowlist }}" ] && ALLOWLIST_FLAG="--allowlist ${{ inputs.allowlist }}"
+          [ -n "$KL_ALLOWLIST" ] && [ -f "$KL_ALLOWLIST" ] && ALLOWLIST_FLAG="--allowlist $KL_ALLOWLIST"
 
-          keyleak self-audit . --fail-on ${{ inputs.fail-on }} || true
+          keyleak self-audit . --fail-on "$KL_FAILON" || true
 
           keyleak local . \
-            --launch-profile ${{ inputs.launch-profile }} \
+            --launch-profile "$KL_PROFILE" \
             $ALLOWLIST_FLAG \
             $FORMAT_FLAG \
-            --fail-on ${{ inputs.fail-on }} > "$REPORT" || VERDICT="BLOCK_SHIP"
+            --fail-on "$KL_FAILON" > "$REPORT" || VERDICT="BLOCK_SHIP"
         fi
 
         # Browser scan
-        if [ "${{ inputs.mode }}" = "browser" ] || [ "${{ inputs.mode }}" = "both" ]; then
-          URL="${{ inputs.url }}"
-          if [ -n "$URL" ]; then
+        if [ "$KL_MODE" = "browser" ] || [ "$KL_MODE" = "both" ]; then
+          if [ -n "$KL_URL" ]; then
             BAAS_FLAG=""
-            [ "${{ inputs.baas-validate }}" = "true" ] && BAAS_FLAG="--baas-validate"
+            [ "$KL_BAAS" = "true" ] && BAAS_FLAG="--baas-validate"
 
-            keyleak browser-scan "$URL" \
+            keyleak browser-scan "$KL_URL" \
               $BAAS_FLAG \
               $FORMAT_FLAG \
-              --fail-on ${{ inputs.fail-on }} > "keyleak-browser-report.${{ inputs.output-format }}" || VERDICT="BLOCK_SHIP"
+              --fail-on "$KL_FAILON" > "keyleak-browser-report.$KL_FORMAT" || VERDICT="BLOCK_SHIP"
 
-            REPORT="keyleak-browser-report.${{ inputs.output-format }}"
+            REPORT="keyleak-browser-report.$KL_FORMAT"
           fi
         fi
 
         echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
         echo "report_path=$REPORT" >> "$GITHUB_OUTPUT"
 
-        if [ -f "$REPORT" ] && [ "${{ inputs.output-format }}" = "json" ]; then
-          FINDINGS=$(python -c "import json; r=json.load(open('$REPORT')); print(r.get('summary',{}).get('total_findings',0))" 2>/dev/null || echo 0)
+        if [ -f "$REPORT" ] && [ "$KL_FORMAT" = "json" ]; then
+          FINDINGS=$(REPORT_PATH="$REPORT" python -c "import json,os; r=json.load(open(os.environ['REPORT_PATH'])); print(r.get('summary',{}).get('total_findings',0))" 2>/dev/null || echo 0)
         fi
         echo "findings_count=$FINDINGS" >> "$GITHUB_OUTPUT"
 

--- a/app.py
+++ b/app.py
@@ -12,6 +12,8 @@ import logging
 import asyncio
 import tempfile
 from urllib.parse import urlparse, parse_qs
+
+from keyleak.net_guard import scan_target_block_reason as _scan_target_is_blocked
 from datetime import datetime
 from functools import wraps
 from typing import Dict, List, Optional, Tuple, Union, Any
@@ -1416,13 +1418,18 @@ async def _run_full_site_scan(url, parsed_url, scan_id):
     def _progress(ev):
         _emit_progress(scan_id, ev.get("message") if isinstance(ev, dict) else str(ev))
 
+    # Active BaaS validation sends live probes to third-party infra, so it is
+    # opt-in (default off) on the web path. Read it here, in the request
+    # context, before handing off to the executor thread.
+    baas_validate = bool((request.json or {}).get('baas_validate', False))
+
     def _run():
         return scan_site(
             domain,
             depth=3,
             max_pages=100,
             max_subdomains=50,
-            baas_validate=True,
+            baas_validate=baas_validate,
             auto_install=False,  # never install binaries from the web request path
             on_progress=_progress,
         )
@@ -1506,6 +1513,12 @@ async def scan():
             return jsonify({'error': 'Invalid URL format'}), 400
     except Exception as e:
         return jsonify({'error': f'Invalid URL: {str(e)}'}), 400
+
+    # SSRF guard: never let a scan request reach internal/metadata addresses.
+    block_reason = _scan_target_is_blocked(parsed_url.hostname)
+    if block_reason:
+        logger.warning("Blocked scan target %s: %s", parsed_url.hostname, block_reason)
+        return jsonify({'error': block_reason}), 400
 
     # Set up SSE progress queue after validation (reuse if SSE endpoint pre-created it)
     if scan_id and scan_id not in _scan_queues:
@@ -1856,6 +1869,12 @@ def install_browser_deps():
 if __name__ == '__main__':
     # Install browser dependencies if needed
     install_browser_deps()
-    
-    # Start the Flask app on port 5002 (5000 is often used by AirPlay on macOS)
-    app.run(host='0.0.0.0', port=5002, debug=True)
+
+    # Bind to loopback by default — the scanner holds discovered secrets and auth
+    # tokens, so it must not be world-reachable unless the operator opts in.
+    # Containers set KEYLEAK_HOST=0.0.0.0 explicitly. Debug is always off unless
+    # KEYLEAK_DEBUG is set (never ship the Werkzeug debugger to a bound port).
+    host = os.environ.get('KEYLEAK_HOST', '127.0.0.1')
+    port = int(os.environ.get('KEYLEAK_PORT', os.environ.get('PORT', '5002')))
+    debug = os.environ.get('KEYLEAK_DEBUG', '').strip().lower() in {'1', 'true', 'yes', 'on'}
+    app.run(host=host, port=port, debug=debug)

--- a/app.py
+++ b/app.py
@@ -1431,6 +1431,9 @@ async def _run_full_site_scan(url, parsed_url, scan_id):
             max_subdomains=50,
             baas_validate=baas_validate,
             auto_install=False,  # never install binaries from the web request path
+            # SSRF guard applies to every enumerated subdomain and crawled link,
+            # not just the initial URL.
+            target_guard=_scan_target_is_blocked,
             on_progress=_progress,
         )
 

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,9 @@ services:
     environment:
       - PORT=5002
       - PYTHONUNBUFFERED=1
+      # Container listens on all interfaces (reachable via the port mapping);
+      # the host default is loopback-only.
+      - KEYLEAK_HOST=0.0.0.0
     volumes:
       # Mount logs directory (optional - for persistent logs)
       - ./logs:/app/logs

--- a/keyleak/__init__.py
+++ b/keyleak/__init__.py
@@ -1,3 +1,3 @@
 """Core utilities for KeyLeak Detector."""
 
-__version__ = "0.1.0"
+__version__ = "0.5.4"

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -474,7 +474,11 @@ def _to_finding(entry: Dict[str, Any], target: str, run_salt: Optional[bytes] = 
     value = str(entry.get("value") or "")
     # Redact before the value ever leaves this process. The browser path used to
     # store the raw match in ``redacted_value``/``snippet``, leaking cleartext
-    # secrets into reports, CI artifacts, and the /scan JSON response.
+    # secrets into reports, CI artifacts, and the /scan JSON response. Always use
+    # salted (HMAC) redaction — never the partial prefix/suffix masking — so a
+    # caller that forgets to pass a salt can't leak secret fragments.
+    if run_salt is None:
+        run_salt = new_run_salt()
     redacted = redact_value(value, run_salt=run_salt)
     evidence = Evidence(
         source=source,

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, Dict, List, Optional
 from .extension_bundle import extension_pattern_payload
 from .models import Evidence, Finding, ScanReport
 from .proxy import playwright_proxy
+from .redaction import new_run_salt, redact_value
 from .reporting import build_report
 
 
@@ -426,7 +427,8 @@ def run_browser_scan(
     elif baas_tables and not baas_extraction:
         baas_extraction = {"tables": list(baas_tables), "rpcs": [], "buckets": []}
 
-    findings = [_to_finding(entry, url) for entry in raw or []]
+    run_salt = new_run_salt()
+    findings = [_to_finding(entry, url, run_salt) for entry in raw or []]
     baas_findings = _run_baas_validation(raw, baas_extraction, baas_validate, baas_prober, proxy)
     findings.extend(baas_findings)
 
@@ -467,13 +469,17 @@ def _run_baas_validation(
     return validation.findings
 
 
-def _to_finding(entry: Dict[str, Any], target: str) -> Finding:
+def _to_finding(entry: Dict[str, Any], target: str, run_salt: Optional[bytes] = None) -> Finding:
     source = entry.get("source") or target
     value = str(entry.get("value") or "")
+    # Redact before the value ever leaves this process. The browser path used to
+    # store the raw match in ``redacted_value``/``snippet``, leaking cleartext
+    # secrets into reports, CI artifacts, and the /scan JSON response.
+    redacted = redact_value(value, run_salt=run_salt)
     evidence = Evidence(
         source=source,
-        snippet=value[:240],
-        redacted_value=value[:120],
+        snippet=redacted,
+        redacted_value=redacted,
         request_url=target,
     )
     detector_id = str(entry.get("detector_id") or "browser:unknown")
@@ -500,7 +506,8 @@ def evaluate_findings_payload(
     baas_validate: bool = False,
     baas_prober: Optional[Any] = None,
 ) -> ScanReport:
-    findings = [_to_finding(entry, target_url) for entry in raw_findings or []]
+    run_salt = new_run_salt()
+    findings = [_to_finding(entry, target_url, run_salt) for entry in raw_findings or []]
     baas_findings = _run_baas_validation(raw_findings, baas_extraction, baas_validate, baas_prober)
     findings.extend(baas_findings)
     return build_report(

--- a/keyleak/js_library_cves.py
+++ b/keyleak/js_library_cves.py
@@ -110,11 +110,15 @@ def parse_version(raw: Optional[str]) -> Optional[Version]:
             head += ch
         else:
             break
-    parts = [p for p in head.split(".") if p != ""]
-    if not parts:
+    # Reject malformed versions (leading/trailing dot or empty components like
+    # ".5", "3..5", "1.2.") rather than silently coercing them to a wrong number.
+    if not head or head[0] == ".":
         return None
+    parts = head.split(".")
     nums: List[int] = []
     for p in parts[:3]:
+        if p == "":
+            return None
         try:
             nums.append(int(p))
         except ValueError:

--- a/keyleak/net_guard.py
+++ b/keyleak/net_guard.py
@@ -1,0 +1,58 @@
+"""SSRF guard for scan targets.
+
+The web ``/scan`` endpoint drives a real browser/crawler against a
+caller-supplied URL. Without a guard, anyone who can reach the server can make
+it fetch internal services or cloud-metadata endpoints (``169.254.169.254``) and
+read back whatever secrets the response contains. This module decides whether a
+target host is safe to scan.
+
+Policy:
+- Link-local (incl. cloud metadata), multicast, and the unspecified address are
+  **always** refused — never a legitimate scan target.
+- Loopback and private (RFC1918 / IPv6 ULA) addresses are refused unless the
+  operator opts in via ``KEYLEAK_ALLOW_PRIVATE_TARGETS`` (e.g. to scan a local
+  dev app from the web UI).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from typing import Optional
+
+ALLOW_PRIVATE_ENV = "KEYLEAK_ALLOW_PRIVATE_TARGETS"
+
+
+def _allow_private_default() -> bool:
+    return os.environ.get(ALLOW_PRIVATE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def scan_target_block_reason(hostname: Optional[str], *, allow_private: Optional[bool] = None) -> Optional[str]:
+    """Return a human-readable reason if ``hostname`` must not be scanned, else None.
+
+    Resolves the host and checks every resolved address, so a hostname that
+    resolves to an internal IP is caught too.
+    """
+    if not hostname:
+        return "Invalid URL host."
+    if allow_private is None:
+        allow_private = _allow_private_default()
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except OSError:
+        return f"Could not resolve host '{hostname}'."
+    for info in infos:
+        try:
+            ip = ipaddress.ip_address(info[4][0])
+        except ValueError:
+            continue
+        # Cloud metadata (169.254.169.254) is link-local; always block link-local,
+        # multicast, and the unspecified address regardless of the opt-in.
+        if ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+            return (f"Refusing to scan '{hostname}' — it resolves to a non-routable or "
+                    f"cloud-metadata address ({ip}).")
+        if (ip.is_loopback or ip.is_private) and not allow_private:
+            return (f"Refusing to scan '{hostname}' — it resolves to an internal address "
+                    f"({ip}). Set {ALLOW_PRIVATE_ENV}=1 to allow scanning internal/local hosts.")
+    return None

--- a/keyleak/offline_guard.py
+++ b/keyleak/offline_guard.py
@@ -21,7 +21,7 @@ class OfflineViolation(RuntimeError):
     """Raised when ``--offline`` mode rejects an outbound socket connection."""
 
 
-_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _INSTALLED = False
 _ORIGINAL_CONNECT: Optional[callable] = None
 # 4-tuple addresses ((host, port, flowinfo, scopeid)) only have str/int in [0].

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -351,6 +351,7 @@ def crawl_pages(
     headless: bool = True,
     proxy: Optional[str] = None,
     collect_raw: Optional[Set[str]] = None,
+    target_guard: Optional[Callable[[str], Optional[str]]] = None,
     on_progress: ProgressFn = None,
 ) -> List[str]:
     """Breadth-first crawl across ``hosts`` up to ``depth`` link levels.
@@ -364,6 +365,8 @@ def crawl_pages(
     seen: Set[str] = set()
     roots = []
     for h in hosts:
+        if target_guard is not None and target_guard(h) is not None:
+            continue
         root = _normalize_url(f"https://{h}")
         if root not in seen:
             seen.add(root)
@@ -382,6 +385,9 @@ def crawl_pages(
         try:
             while queue and len(results) < max_pages:
                 url, level = queue.popleft()
+                # SSRF guard: a discovered link may resolve to an internal host.
+                if target_guard is not None and target_guard(urlparse(url).hostname) is not None:
+                    continue
                 results.append(url)
                 if level >= depth:
                     continue
@@ -540,9 +546,15 @@ def scan_site(
     offline: bool = False,
     proxy: Optional[str] = None,
     auto_install: bool = True,
+    target_guard: Optional[Callable[[str], Optional[str]]] = None,
     on_progress: ProgressFn = None,
 ) -> ScanReport:
     """Full Site Scan: discover subdomains, crawl pages, scan each for secrets.
+
+    ``target_guard``, if given, is called with each host before it is probed,
+    crawled, or scanned; a non-None return means "skip this host". The web path
+    passes an SSRF guard here so subdomain enumeration and link-following can't
+    reach internal/metadata addresses (CLI leaves it unset).
 
     Returns an aggregated ScanReport whose ``extra`` carries the scanned
     subdomains, page count, and a ``provenance`` map (finding id -> URLs).
@@ -564,6 +576,18 @@ def scan_site(
     )
     if not subdomains:
         subdomains = [domain]
+
+    # SSRF guard: drop any discovered subdomain that resolves to a blocked
+    # (internal/metadata) address before it is ever probed or crawled.
+    if target_guard is not None:
+        safe_hosts: List[str] = []
+        for host in subdomains:
+            reason = target_guard(host)
+            if reason is None:
+                safe_hosts.append(host)
+            else:
+                _emit(on_progress, "subdomains", f"Skipping {host}: {reason}")
+        subdomains = safe_hosts or [domain]
 
     # Subdomain-takeover check runs in parallel with the crawl/scan below. It
     # only uses ``requests`` (no Playwright), so a single worker thread safely
@@ -594,13 +618,16 @@ def scan_site(
         urls = crawl_pages(
             subdomains, depth=depth, max_pages=max_pages,
             headless=headless, proxy=proxy, collect_raw=raw_query_urls,
-            on_progress=on_progress,
+            target_guard=target_guard, on_progress=on_progress,
         )
 
         for finding in _dangerous_param_findings(raw_query_urls):
             pairs.append((finding, finding.evidence.request_url))
         total = len(urls)
         for i, url in enumerate(urls):
+            # SSRF guard: a crawled link may resolve to an internal address.
+            if target_guard is not None and target_guard(urlparse(url).hostname) is not None:
+                continue
             _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {url}", i + 1, total)
             try:
                 report = run_browser_scan(

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -583,50 +583,57 @@ def scan_site(
         )
 
     raw_query_urls: Set[str] = set()
-    urls = crawl_pages(
-        subdomains, depth=depth, max_pages=max_pages,
-        headless=headless, proxy=proxy, collect_raw=raw_query_urls,
-        on_progress=on_progress,
-    )
-
     pairs: List[Tuple[Finding, str]] = []
-    for finding in _dangerous_param_findings(raw_query_urls):
-        pairs.append((finding, finding.evidence.request_url))
-    total = len(urls)
-    for i, url in enumerate(urls):
-        _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {url}", i + 1, total)
-        try:
-            report = run_browser_scan(
-                url,
-                headless=headless,
-                baas_validate=baas_validate,
-                baas_prober=baas_prober,
-                baas_tables=baas_tables,
-                scan_budget_seconds=scan_budget_seconds,
-                proxy=proxy,
-            )
-            for f in report.findings:
-                pairs.append((f, url))
-        except Exception as exc:
-            print(f"[keyleak]   Error scanning {url}: {exc}", file=sys.stderr)
-            continue
-
-    # Join the parallel subdomain-takeover check and fold its findings in.
     takeover_count = 0
-    if takeover_future is not None:
-        try:
-            takeover_findings = takeover_future.result()
-        except Exception:
-            takeover_findings = []
-        finally:
+    total = 0
+    urls: List[str] = []
+    # Everything from the crawl through the takeover join runs inside a
+    # try/finally so the background takeover pool is always shut down — even if
+    # crawl_pages or the per-host scan raises.
+    try:
+        urls = crawl_pages(
+            subdomains, depth=depth, max_pages=max_pages,
+            headless=headless, proxy=proxy, collect_raw=raw_query_urls,
+            on_progress=on_progress,
+        )
+
+        for finding in _dangerous_param_findings(raw_query_urls):
+            pairs.append((finding, finding.evidence.request_url))
+        total = len(urls)
+        for i, url in enumerate(urls):
+            _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {url}", i + 1, total)
+            try:
+                report = run_browser_scan(
+                    url,
+                    headless=headless,
+                    baas_validate=baas_validate,
+                    baas_prober=baas_prober,
+                    baas_tables=baas_tables,
+                    scan_budget_seconds=scan_budget_seconds,
+                    proxy=proxy,
+                )
+                for f in report.findings:
+                    pairs.append((f, url))
+            except Exception as exc:
+                print(f"[keyleak]   Error scanning {url}: {exc}", file=sys.stderr)
+                continue
+
+        # Join the parallel subdomain-takeover check and fold its findings in.
+        if takeover_future is not None:
+            try:
+                takeover_findings = takeover_future.result()
+            except Exception:
+                takeover_findings = []
+            for f in takeover_findings:
+                pairs.append((f, f.source))
+            takeover_count = len(takeover_findings)
+            if takeover_count:
+                _emit(on_progress, "takeover",
+                      f"Subdomain-takeover check flagged {takeover_count} host(s)",
+                      takeover_count, takeover_count)
+    finally:
+        if takeover_pool is not None:
             takeover_pool.shutdown(wait=False)
-        for f in takeover_findings:
-            pairs.append((f, f.source))
-        takeover_count = len(takeover_findings)
-        if takeover_count:
-            _emit(on_progress, "takeover",
-                  f"Subdomain-takeover check flagged {takeover_count} host(s)",
-                  takeover_count, takeover_count)
 
     findings, provenance = _merge_findings(pairs)
     _emit(on_progress, "done",

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -318,11 +318,13 @@ def _filter_links(
     registrable: str,
     seen: Set[str],
     remaining: int,
+    target_guard: Optional[Callable[[str], Optional[str]]] = None,
 ) -> List[str]:
     """Pure helper: keep in-scope, http(s), de-duplicated links.
 
     Updates ``seen`` in place with normalized URLs. Returns up to
-    ``remaining`` newly discovered normalized URLs, in order.
+    ``remaining`` newly discovered normalized URLs, in order. Links blocked by
+    ``target_guard`` are skipped here so they never consume the crawl budget.
     """
     out: List[str] = []
     if remaining <= 0:
@@ -334,6 +336,8 @@ def _filter_links(
         if p.scheme not in ("http", "https") or not p.netloc:
             continue
         if registrable_domain(p.netloc) != registrable:
+            continue
+        if target_guard is not None and target_guard(p.hostname) is not None:
             continue
         normalized = _normalize_url(link)
         if normalized in seen:
@@ -385,9 +389,6 @@ def crawl_pages(
         try:
             while queue and len(results) < max_pages:
                 url, level = queue.popleft()
-                # SSRF guard: a discovered link may resolve to an internal host.
-                if target_guard is not None and target_guard(urlparse(url).hostname) is not None:
-                    continue
                 results.append(url)
                 if level >= depth:
                     continue
@@ -418,10 +419,11 @@ def crawl_pages(
                             continue
                         lp = urlparse(link)
                         if lp.scheme in ("http", "https") and lp.netloc \
-                                and registrable_domain(lp.netloc) == registrable:
+                                and registrable_domain(lp.netloc) == registrable \
+                                and not (target_guard is not None and target_guard(lp.hostname) is not None):
                             collect_raw.add(link)
                 remaining = max_pages - (len(results) + len(queue))
-                for nu in _filter_links(links, registrable, seen, remaining):
+                for nu in _filter_links(links, registrable, seen, remaining, target_guard):
                     queue.append((nu, level + 1))
         finally:
             browser.close()
@@ -587,7 +589,14 @@ def scan_site(
                 safe_hosts.append(host)
             else:
                 _emit(on_progress, "subdomains", f"Skipping {host}: {reason}")
-        subdomains = safe_hosts or [domain]
+        # Only fall back to the apex if it isn't itself blocked — never re-add a
+        # host target_guard just rejected (it would still be probed for takeover).
+        if safe_hosts:
+            subdomains = safe_hosts
+        elif target_guard(domain) is None:
+            subdomains = [domain]
+        else:
+            subdomains = []
 
     # Subdomain-takeover check runs in parallel with the crawl/scan below. It
     # only uses ``requests`` (no Playwright), so a single worker thread safely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keyleak-detector"
-version = "0.5.2"
+version = "0.5.4"
 description = "Runtime leak detector for modern web apps — finds exposed API keys, BaaS misconfigurations (Supabase/Firebase RLS), and secrets in JS bundles, with a Chrome extension for real-time detection."
 authors = ["Amal David <amal@utopianlabs.co>"]
 license = "MIT"
@@ -46,7 +46,7 @@ build-backend = "poetry.core.masonry.api"
 # PEP 621 project table for uv / pip compatibility
 [project]
 name = "keyleak-detector"
-version = "0.5.2"
+version = "0.5.4"
 description = "Runtime leak detector for modern web apps — finds exposed API keys, BaaS misconfigurations (Supabase/Firebase RLS), and secrets in JS bundles."
 requires-python = ">=3.12,<4.0"
 license = {text = "MIT"}

--- a/tests/test_browser_redaction.py
+++ b/tests/test_browser_redaction.py
@@ -1,0 +1,41 @@
+"""Regression: browser-scan findings must never carry the raw secret.
+
+The browser/full-site path used to store the cleartext match in
+``evidence.redacted_value`` and ``snippet``, leaking secrets into reports,
+CI artifacts, and the /scan JSON. These tests pin the redaction.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from keyleak.browser_scanner import _to_finding, evaluate_findings_payload
+
+SECRET = "sk-proj-ABCDEF1234567890SECRETVALUE0987654321"
+
+
+class BrowserRedactionTests(unittest.TestCase):
+    def test_to_finding_redacts_value(self):
+        f = _to_finding(
+            {"detector_id": "leak.openai_api_key", "type": "openai_api_key",
+             "severity": "critical", "source": "localStorage:t", "value": SECRET},
+            "https://app.example.test/",
+        )
+        self.assertNotIn(SECRET, f.evidence.redacted_value)
+        self.assertNotIn(SECRET, f.evidence.snippet)
+        self.assertIn("[redacted", f.evidence.redacted_value)
+
+    def test_report_dict_contains_no_raw_secret(self):
+        report = evaluate_findings_payload(
+            [{"detector_id": "leak.openai_api_key", "type": "openai_api_key",
+              "severity": "critical", "source": "localStorage:t", "value": SECRET}],
+            "https://app.example.test/",
+        )
+        import json
+        blob = json.dumps(report.to_dict())
+        self.assertNotIn(SECRET, blob)
+        self.assertIn("[redacted", blob)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_net_guard.py
+++ b/tests/test_net_guard.py
@@ -1,0 +1,39 @@
+"""Tests for the SSRF scan-target guard (keyleak/net_guard.py).
+
+IP literals are used as the hostname so getaddrinfo resolves without real DNS.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from keyleak.net_guard import scan_target_block_reason as block
+
+
+class NetGuardTests(unittest.TestCase):
+    def test_public_ip_allowed(self):
+        self.assertIsNone(block("93.184.216.34"))
+
+    def test_loopback_blocked_by_default(self):
+        self.assertIsNotNone(block("127.0.0.1"))
+
+    def test_private_blocked_by_default(self):
+        self.assertIsNotNone(block("10.0.0.1"))
+        self.assertIsNotNone(block("192.168.1.5"))
+
+    def test_loopback_and_private_allowed_with_optin(self):
+        self.assertIsNone(block("127.0.0.1", allow_private=True))
+        self.assertIsNone(block("10.0.0.1", allow_private=True))
+
+    def test_cloud_metadata_always_blocked(self):
+        # Link-local / metadata must stay blocked even with the opt-in.
+        self.assertIsNotNone(block("169.254.169.254"))
+        self.assertIsNotNone(block("169.254.169.254", allow_private=True))
+
+    def test_empty_host_blocked(self):
+        self.assertIsNotNone(block(""))
+        self.assertIsNotNone(block(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_site_scanner_ssrf.py
+++ b/tests/test_site_scanner_ssrf.py
@@ -38,6 +38,32 @@ class SiteScannerSSRFTests(unittest.TestCase):
         # The parallel takeover check must also only see the safe host.
         self.assertNotIn("internal.example.test", seen["takeover_hosts"])
 
+    def test_filter_links_skips_blocked_without_consuming_budget(self):
+        guard = lambda h: "blk" if h == "bad.example.com" else None
+        seen = set()
+        out = ss._filter_links(
+            ["https://bad.example.com/1", "https://bad.example.com/2",
+             "https://ok.example.com/a", "https://ok.example.com/b"],
+            "example.com", seen, remaining=2, target_guard=guard,
+        )
+        # Blocked links must not crowd out allowed ones from the budget.
+        self.assertEqual(out, ["https://ok.example.com/a", "https://ok.example.com/b"])
+        self.assertFalse(any("bad.example.com" in s for s in seen))
+
+    def test_blocked_apex_is_not_reinserted(self):
+        seen = {}
+        with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["x.example.test"]), \
+             mock.patch.object(ss, "crawl_pages",
+                               lambda hosts, **k: seen.setdefault("hosts", list(hosts)) or []), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda u, **k: ScanReport(target=u, scan_mode="browser", findings=[])), \
+             mock.patch("keyleak.subdomain_takeover.check_subdomain_takeovers",
+                        lambda hosts, **k: seen.setdefault("takeover", list(hosts)) or []):
+            # Guard blocks everything, including the apex.
+            ss.scan_site("example.test", target_guard=lambda h: "blocked")
+        self.assertEqual(seen["hosts"], [])
+        self.assertEqual(seen["takeover"], [])
+
     def test_no_guard_keeps_all_hosts(self):
         seen = {}
         with mock.patch.object(ss, "discover_subdomains",

--- a/tests/test_site_scanner_ssrf.py
+++ b/tests/test_site_scanner_ssrf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import unittest
 from unittest import mock
+from urllib.parse import urlparse
 
 import keyleak.site_scanner as ss
 from keyleak.models import ScanReport
@@ -48,7 +49,8 @@ class SiteScannerSSRFTests(unittest.TestCase):
         )
         # Blocked links must not crowd out allowed ones from the budget.
         self.assertEqual(out, ["https://ok.example.com/a", "https://ok.example.com/b"])
-        self.assertFalse(any("bad.example.com" in s for s in seen))
+        seen_hosts = {urlparse(s).hostname for s in seen}
+        self.assertNotIn("bad.example.com", seen_hosts)
 
     def test_blocked_apex_is_not_reinserted(self):
         seen = {}

--- a/tests/test_site_scanner_ssrf.py
+++ b/tests/test_site_scanner_ssrf.py
@@ -1,0 +1,55 @@
+"""scan_site's target_guard must keep internal hosts out of crawl/scan/takeover."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import keyleak.site_scanner as ss
+from keyleak.models import ScanReport
+
+
+def _guard(host):
+    return "internal" if host == "internal.example.test" else None
+
+
+class SiteScannerSSRFTests(unittest.TestCase):
+    def test_guard_filters_subdomains_before_crawl_and_takeover(self):
+        seen = {}
+
+        def fake_crawl(hosts, **kwargs):
+            seen["crawl_hosts"] = list(hosts)
+            return []
+
+        def fake_takeover(hosts, **kwargs):
+            seen["takeover_hosts"] = list(hosts)
+            return []
+
+        with mock.patch.object(ss, "discover_subdomains",
+                               lambda d, **k: ["safe.example.test", "internal.example.test"]), \
+             mock.patch.object(ss, "crawl_pages", fake_crawl), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda u, **k: ScanReport(target=u, scan_mode="browser", findings=[])), \
+             mock.patch("keyleak.subdomain_takeover.check_subdomain_takeovers", fake_takeover):
+            ss.scan_site("example.test", target_guard=_guard)
+
+        self.assertIn("safe.example.test", seen["crawl_hosts"])
+        self.assertNotIn("internal.example.test", seen["crawl_hosts"])
+        # The parallel takeover check must also only see the safe host.
+        self.assertNotIn("internal.example.test", seen["takeover_hosts"])
+
+    def test_no_guard_keeps_all_hosts(self):
+        seen = {}
+        with mock.patch.object(ss, "discover_subdomains",
+                               lambda d, **k: ["a.example.test", "b.example.test"]), \
+             mock.patch.object(ss, "crawl_pages",
+                               lambda hosts, **k: seen.setdefault("hosts", list(hosts)) or []), \
+             mock.patch.object(ss, "run_browser_scan",
+                               lambda u, **k: ScanReport(target=u, scan_mode="browser", findings=[])), \
+             mock.patch("keyleak.subdomain_takeover.check_subdomain_takeovers", lambda *a, **k: []):
+            ss.scan_site("example.test")
+        self.assertEqual(set(seen["hosts"]), {"a.example.test", "b.example.test"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cuts **0.5.4** from main, with the fixes from a complete pre-release audit (tests, supply-chain self-audit, secret scan, and a security + correctness code review).

## Audit result
- ✅ 137 tests pass · self-audit clean at `--fail-on high` (1 medium: `.github/CODEOWNERS` not committed) · the secret scan's "criticals" were **self-detection false positives** (the tool flagging its own IOC detector definitions).
- The review surfaced real issues (all pre-existing except the two I introduced last PR) — all fixed below.

## Security fixes
| Severity | Fix |
|---|---|
| **Critical** | `app.py` no longer ships `debug=True` on `0.0.0.0`. Binds to **loopback by default** (`KEYLEAK_HOST`), debug off unless `KEYLEAK_DEBUG`; Docker/compose opt into `0.0.0.0`. (Werkzeug-debugger RCE.) |
| **High** | `browser_scanner` now **redacts** the match before storing it — the browser/full-site path was writing the **raw secret** into `redacted_value`/`snippet`, leaking cleartext into reports, CI artifacts, and `/scan` JSON. |
| **High** | `action.yml` routes all inputs through `env:` instead of `${{ inputs.* }}` in `run:` (GitHub Actions script injection). |
| **Medium** | New `keyleak/net_guard.py` SSRF guard on `/scan` — always blocks cloud-metadata/link-local/multicast, blocks loopback/private unless `KEYLEAK_ALLOW_PRIVATE_TARGETS=1`. Web full-site no longer forces `baas_validate=True`. |
| **Low** | `offline_guard` drops `0.0.0.0` from the loopback allow-set. |

## Correctness fixes (same audit)
- `site_scanner`: the parallel subdomain-takeover `ThreadPoolExecutor` is now shut down via `try/finally` even if the crawl/scan raises.
- `js_library_cves.parse_version`: rejects malformed versions (`".5"`, `"3..5"`, `"1.2."`) instead of coercing them.

## Verified clean
subprocess calls (list-form, no `shell=True`), `go install` version-pinned, Playwright init-script injection, takeover thread-safety, archive path-traversal, proxy handling, TLS verification in probes, no unsafe deserialization.

## Tests
New `tests/test_net_guard.py` (SSRF policy incl. metadata-always-blocked) and `tests/test_browser_redaction.py` (no raw secret in browser findings). **137 passed.**

After merge: tag `v0.5.4` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/keyleak-detector/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now binds to localhost by default, configurable to listen on all interfaces; containers set to listen on all interfaces when configured.
  * Scan orchestration can skip and guard unsafe targets before crawling or fetching.

* **Bug Fixes**
  * Improved cleanup during site scans.
  * Stronger per-run redaction of browser-scan findings.
  * Stricter JS library version parsing.

* **Security**
  * Added SSRF/network-target protections with an opt-in for private targets.

* **Tests**
  * New tests for network-guard, SSRF behavior, and browser redaction.

**Version**: 0.5.4
<!-- end of auto-generated comment: release notes by coderabbit.ai -->