### PR TITLE
Add CDP network capture to browser scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          python -m playwright install chromium --with-deps
       - name: Run unit tests (fails on collection errors)
         run: |
           # `unittest discover` exits non-zero on any error OR collection

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -25,16 +25,31 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
 
+from .detectors import detectors_for_packs, normalize_packs
 from .extension_bundle import extension_pattern_payload
+from .local_scanner import scan_text
 from .models import Evidence, Finding, ScanReport
 from .proxy import playwright_proxy
-from .redaction import new_run_salt, redact_value
+from .redaction import new_run_salt, redact_url, redact_value
 from .reporting import build_report
 
 
 SCAN_BUDGET_DEFAULT_SECONDS = 30
 DEFAULT_VIEWPORT = {"width": 1280, "height": 1024}
+CDP_MAX_BODY_BYTES = 2 * 1024 * 1024
+CDP_MAX_TOTAL_BUFFER_BYTES = 10 * 1024 * 1024
+CDP_TEXT_HINTS = (
+    "text/",
+    "json",
+    "javascript",
+    "ecmascript",
+    "xml",
+    "x-www-form-urlencoded",
+    "graphql",
+    "source-map",
+)
 
 
 # The init script we inject into the page context. It exposes a global
@@ -357,6 +372,266 @@ def _build_init_script(payload: Optional[List[Dict[str, Any]]] = None) -> str:
     return _INIT_SCRIPT_TEMPLATE.replace("__PATTERNS__", encoded)
 
 
+def _browser_detectors():
+    packs = normalize_packs(None, profile="launch-gate", surface="extension")
+    return detectors_for_packs(packs, extension_only=True)
+
+
+def _is_http_url(url: object) -> bool:
+    try:
+        parsed = urlparse(str(url or ""))
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https", "ws", "wss"} and bool(parsed.netloc)
+
+
+def _is_text_mime(mime_type: object, headers: Optional[Dict[str, Any]] = None) -> bool:
+    content_type = str(mime_type or "")
+    if not content_type and headers:
+        content_type = str(_header_value(headers, "content-type") or "")
+    if not content_type:
+        return True
+    lowered = content_type.lower()
+    return any(hint in lowered for hint in CDP_TEXT_HINTS)
+
+
+def _header_value(headers: Optional[Dict[str, Any]], name: str) -> str:
+    if not headers:
+        return ""
+    target = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == target:
+            return str(value)
+    return ""
+
+
+def _content_length_too_large(headers: Optional[Dict[str, Any]]) -> bool:
+    raw = _header_value(headers, "content-length")
+    if not raw:
+        return False
+    try:
+        return int(raw) > CDP_MAX_BODY_BYTES
+    except ValueError:
+        return False
+
+
+def _decode_cdp_body(payload: Dict[str, Any]) -> str:
+    body = payload.get("body")
+    if not isinstance(body, str) or not body:
+        return ""
+    if payload.get("base64Encoded"):
+        try:
+            import base64
+
+            raw = base64.b64decode(body, validate=False)
+        except Exception:
+            return ""
+        if len(raw) > CDP_MAX_BODY_BYTES:
+            return ""
+        return raw.decode("utf-8", errors="ignore")
+    if len(body.encode("utf-8", errors="ignore")) > CDP_MAX_BODY_BYTES:
+        return ""
+    return body
+
+
+def _cdp_send(cdp: Any, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    params = params or {}
+    try:
+        return cdp.send(method, params)
+    except TypeError:
+        return cdp.send(method, **params)
+
+
+class _CdpNetworkCapture:
+    """Best-effort CDP capture for Playwright Chromium scans."""
+
+    def __init__(self, cdp: Any, target_url: str, run_salt: bytes):
+        self.cdp = cdp
+        self.target_url = target_url
+        self.run_salt = run_salt
+        self.requests: Dict[str, Dict[str, Any]] = {}
+        self._findings: List[Finding] = []
+        self._detectors = _browser_detectors()
+
+    def start(self) -> None:
+        _cdp_send(
+            self.cdp,
+            "Network.enable",
+            {
+                "maxTotalBufferSize": CDP_MAX_TOTAL_BUFFER_BYTES,
+                "maxResourceBufferSize": CDP_MAX_BODY_BYTES,
+            },
+        )
+        for domain in ("Runtime.enable", "Log.enable"):
+            try:
+                _cdp_send(self.cdp, domain)
+            except Exception:
+                pass
+
+        self.cdp.on("Network.requestWillBeSent", self._on_request)
+        self.cdp.on("Network.responseReceived", self._on_response)
+        self.cdp.on("Network.loadingFinished", self._on_loading_finished)
+        self.cdp.on("Network.webSocketCreated", self._on_websocket_created)
+        self.cdp.on("Network.webSocketFrameSent", self._on_websocket_frame)
+        self.cdp.on("Network.webSocketFrameReceived", self._on_websocket_frame)
+        self.cdp.on("Runtime.consoleAPICalled", self._on_console)
+        self.cdp.on("Log.entryAdded", self._on_log_entry)
+
+    @property
+    def findings(self) -> List[Finding]:
+        return list(self._findings)
+
+    def detach(self) -> None:
+        try:
+            self.cdp.detach()
+        except Exception:
+            pass
+
+    def _scan_text(
+        self,
+        text: object,
+        source: str,
+        request_url: str,
+        *,
+        response_status: Optional[int] = None,
+    ) -> None:
+        if not isinstance(text, str) or not text or not _is_http_url(request_url):
+            return
+        if len(text.encode("utf-8", errors="ignore")) > CDP_MAX_BODY_BYTES:
+            return
+        for finding in scan_text(text, source, self._detectors, run_salt=self.run_salt):
+            finding.evidence.request_url = redact_url(request_url)
+            if response_status is not None:
+                finding.evidence.response_status = response_status
+            self._findings.append(finding)
+
+    def _remember(self, request_id: str, **updates: Any) -> Dict[str, Any]:
+        record = self.requests.setdefault(request_id, {})
+        for key, value in updates.items():
+            if value not in (None, ""):
+                record[key] = value
+        return record
+
+    def _on_request(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        request = params.get("request") or {}
+        url = str(request.get("url") or "")
+        if not request_id or not _is_http_url(url):
+            return
+        headers = request.get("headers") or {}
+        post_data = request.get("postData") or ""
+        self._remember(
+            request_id,
+            url=url,
+            request_headers=headers,
+            method=request.get("method"),
+        )
+
+        self._scan_text(url, f"CDP Request URL: {url}", url)
+        if headers:
+            header_text = "\n".join(f"{name}: {value}" for name, value in headers.items())
+            self._scan_text(header_text, f"CDP Request Headers: {url}", url)
+        if post_data:
+            self._scan_text(str(post_data), f"CDP Request Body: {url}", url)
+
+    def _on_response(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        response = params.get("response") or {}
+        url = str(response.get("url") or "")
+        if not request_id or not _is_http_url(url):
+            return
+        headers = response.get("headers") or {}
+        status = response.get("status")
+        self._remember(
+            request_id,
+            url=url,
+            response_headers=headers,
+            response_status=status,
+            mime_type=response.get("mimeType"),
+        )
+        if headers:
+            header_text = "\n".join(f"{name}: {value}" for name, value in headers.items())
+            self._scan_text(
+                header_text,
+                f"CDP Response Headers: {url}",
+                url,
+                response_status=status if isinstance(status, int) else None,
+            )
+
+    def _on_loading_finished(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        record = self.requests.get(request_id) or {}
+        url = str(record.get("url") or "")
+        headers = record.get("response_headers") or {}
+        status = record.get("response_status")
+        if not url or not _is_text_mime(record.get("mime_type"), headers):
+            return
+        if _content_length_too_large(headers):
+            return
+
+        try:
+            payload = _cdp_send(self.cdp, "Network.getResponseBody", {"requestId": request_id})
+        except Exception:
+            return
+        body = _decode_cdp_body(payload)
+        self._scan_text(
+            body,
+            f"CDP Response Body: {url}",
+            url,
+            response_status=status if isinstance(status, int) else None,
+        )
+
+    def _on_websocket_created(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        url = str(params.get("url") or "")
+        if request_id and _is_http_url(url):
+            self._remember(request_id, url=url, mime_type="text/plain")
+
+    def _on_websocket_frame(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        record = self.requests.get(request_id) or {}
+        url = str(record.get("url") or self.target_url)
+        response = params.get("response") or {}
+        payload = response.get("payloadData")
+        opcode = response.get("opcode")
+        if opcode is not None and opcode not in (1, "1"):
+            return
+        self._scan_text(str(payload or ""), f"CDP WebSocket Frame: {url}", url)
+
+    def _on_console(self, params: Dict[str, Any]) -> None:
+        values: List[str] = []
+        for arg in params.get("args") or []:
+            if "value" in arg:
+                values.append(str(arg.get("value")))
+            elif "description" in arg:
+                values.append(str(arg.get("description")))
+        if values:
+            level = str(params.get("type") or "console")
+            self._scan_text("\n".join(values), f"CDP Console {level}", self.target_url)
+
+    def _on_log_entry(self, params: Dict[str, Any]) -> None:
+        entry = params.get("entry") or {}
+        text = entry.get("text")
+        if text:
+            level = str(entry.get("level") or "log")
+            url = str(entry.get("url") or self.target_url)
+            self._scan_text(str(text), f"CDP Log {level}", url)
+
+
+def _start_cdp_capture(context: Any, page: Any, target_url: str, run_salt: bytes) -> Optional[_CdpNetworkCapture]:
+    try:
+        cdp = context.new_cdp_session(page)
+    except Exception:
+        return None
+    capture = _CdpNetworkCapture(cdp, target_url, run_salt)
+    try:
+        capture.start()
+    except Exception:
+        capture.detach()
+        return None
+    return capture
+
+
 def run_browser_scan(
     url: str,
     *,
@@ -383,6 +658,8 @@ def run_browser_scan(
         ) from exc
 
     init_script = _build_init_script()
+    run_salt = new_run_salt()
+    cdp_capture: Optional[_CdpNetworkCapture] = None
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=headless, proxy=playwright_proxy(proxy))
@@ -394,6 +671,7 @@ def run_browser_scan(
 
         page = context.new_page()
         page.set_default_timeout(scan_budget_seconds * 1000)
+        cdp_capture = _start_cdp_capture(context, page, url, run_salt)
         page.goto(url, wait_until="networkidle")
         raw = page.evaluate("() => window.__keyleak_run ? window.__keyleak_run() : []")
 
@@ -416,6 +694,9 @@ def run_browser_scan(
         except Exception:
             pass
 
+        cdp_findings = cdp_capture.findings if cdp_capture else []
+        if cdp_capture:
+            cdp_capture.detach()
         browser.close()
 
     # Merge extra --baas-tables into extraction
@@ -427,8 +708,8 @@ def run_browser_scan(
     elif baas_tables and not baas_extraction:
         baas_extraction = {"tables": list(baas_tables), "rpcs": [], "buckets": []}
 
-    run_salt = new_run_salt()
     findings = [_to_finding(entry, url, run_salt) for entry in raw or []]
+    findings.extend(cdp_findings)
     baas_findings = _run_baas_validation(raw, baas_extraction, baas_validate, baas_prober, proxy)
     findings.extend(baas_findings)
 

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -22,6 +22,7 @@ Why this shape:
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -32,9 +33,11 @@ from .extension_bundle import extension_pattern_payload
 from .local_scanner import scan_text
 from .models import Evidence, Finding, ScanReport
 from .proxy import playwright_proxy
-from .redaction import new_run_salt, redact_url, redact_value
+from .redaction import new_run_salt, redact_url, redact_value, stable_id
 from .reporting import build_report
 
+
+_LOG = logging.getLogger(__name__)
 
 SCAN_BUDGET_DEFAULT_SECONDS = 30
 DEFAULT_VIEWPORT = {"width": 1280, "height": 1024}
@@ -465,13 +468,15 @@ class _CdpNetworkCapture:
         for domain in ("Runtime.enable", "Log.enable"):
             try:
                 _cdp_send(self.cdp, domain)
-            except Exception:
-                pass
+            except Exception as exc:
+                _LOG.debug("CDP domain enable failed for %s: %s", domain, exc, exc_info=True)
 
         self.cdp.on("Network.requestWillBeSent", self._on_request)
         self.cdp.on("Network.responseReceived", self._on_response)
         self.cdp.on("Network.loadingFinished", self._on_loading_finished)
+        self.cdp.on("Network.loadingFailed", self._on_loading_failed)
         self.cdp.on("Network.webSocketCreated", self._on_websocket_created)
+        self.cdp.on("Network.webSocketClosed", self._on_websocket_closed)
         self.cdp.on("Network.webSocketFrameSent", self._on_websocket_frame)
         self.cdp.on("Network.webSocketFrameReceived", self._on_websocket_frame)
         self.cdp.on("Runtime.consoleAPICalled", self._on_console)
@@ -484,8 +489,8 @@ class _CdpNetworkCapture:
     def detach(self) -> None:
         try:
             self.cdp.detach()
-        except Exception:
-            pass
+        except Exception as exc:
+            _LOG.debug("CDP detach failed: %s", exc, exc_info=True)
 
     def _scan_text(
         self,
@@ -503,6 +508,14 @@ class _CdpNetworkCapture:
             finding.evidence.request_url = redact_url(request_url)
             if response_status is not None:
                 finding.evidence.response_status = response_status
+            finding.id = stable_id(
+                finding.type,
+                finding.detector_id,
+                finding.source,
+                finding.evidence.redacted_value,
+                finding.evidence.line,
+                finding.evidence.request_url,
+            )
             self._findings.append(finding)
 
     def _remember(self, request_id: str, **updates: Any) -> Dict[str, Any]:
@@ -527,12 +540,13 @@ class _CdpNetworkCapture:
             method=request.get("method"),
         )
 
-        self._scan_text(url, f"CDP Request URL: {url}", url)
+        safe_url = redact_url(url)
+        self._scan_text(url, f"CDP Request URL: {safe_url}", url)
         if headers:
             header_text = "\n".join(f"{name}: {value}" for name, value in headers.items())
-            self._scan_text(header_text, f"CDP Request Headers: {url}", url)
+            self._scan_text(header_text, f"CDP Request Headers: {safe_url}", url)
         if post_data:
-            self._scan_text(str(post_data), f"CDP Request Body: {url}", url)
+            self._scan_text(str(post_data), f"CDP Request Body: {safe_url}", url)
 
     def _on_response(self, params: Dict[str, Any]) -> None:
         request_id = str(params.get("requestId") or "")
@@ -549,11 +563,12 @@ class _CdpNetworkCapture:
             response_status=status,
             mime_type=response.get("mimeType"),
         )
+        safe_url = redact_url(url)
         if headers:
             header_text = "\n".join(f"{name}: {value}" for name, value in headers.items())
             self._scan_text(
                 header_text,
-                f"CDP Response Headers: {url}",
+                f"CDP Response Headers: {safe_url}",
                 url,
                 response_status=status if isinstance(status, int) else None,
             )
@@ -564,28 +579,45 @@ class _CdpNetworkCapture:
         url = str(record.get("url") or "")
         headers = record.get("response_headers") or {}
         status = record.get("response_status")
-        if not url or not _is_text_mime(record.get("mime_type"), headers):
-            return
-        if _content_length_too_large(headers):
-            return
-
         try:
-            payload = _cdp_send(self.cdp, "Network.getResponseBody", {"requestId": request_id})
-        except Exception:
-            return
-        body = _decode_cdp_body(payload)
-        self._scan_text(
-            body,
-            f"CDP Response Body: {url}",
-            url,
-            response_status=status if isinstance(status, int) else None,
-        )
+            if not url or not _is_text_mime(record.get("mime_type"), headers):
+                return
+            if _content_length_too_large(headers):
+                return
+
+            try:
+                payload = _cdp_send(self.cdp, "Network.getResponseBody", {"requestId": request_id})
+            except Exception as exc:
+                _LOG.debug("CDP response body unavailable for %s: %s", request_id, exc, exc_info=True)
+                return
+            body = _decode_cdp_body(payload)
+            self._scan_text(
+                body,
+                f"CDP Response Body: {redact_url(url)}",
+                url,
+                response_status=status if isinstance(status, int) else None,
+            )
+        finally:
+            if urlparse(url).scheme.lower() in {"http", "https"}:
+                self.requests.pop(request_id, None)
+
+    def _on_loading_failed(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        record = self.requests.get(request_id) or {}
+        url = str(record.get("url") or "")
+        if urlparse(url).scheme.lower() in {"http", "https"}:
+            self.requests.pop(request_id, None)
 
     def _on_websocket_created(self, params: Dict[str, Any]) -> None:
         request_id = str(params.get("requestId") or "")
         url = str(params.get("url") or "")
         if request_id and _is_http_url(url):
             self._remember(request_id, url=url, mime_type="text/plain")
+
+    def _on_websocket_closed(self, params: Dict[str, Any]) -> None:
+        request_id = str(params.get("requestId") or "")
+        if request_id:
+            self.requests.pop(request_id, None)
 
     def _on_websocket_frame(self, params: Dict[str, Any]) -> None:
         request_id = str(params.get("requestId") or "")
@@ -596,7 +628,7 @@ class _CdpNetworkCapture:
         opcode = response.get("opcode")
         if opcode is not None and opcode not in (1, "1"):
             return
-        self._scan_text(str(payload or ""), f"CDP WebSocket Frame: {url}", url)
+        self._scan_text(str(payload or ""), f"CDP WebSocket Frame: {redact_url(url)}", url)
 
     def _on_console(self, params: Dict[str, Any]) -> None:
         values: List[str] = []
@@ -621,12 +653,14 @@ class _CdpNetworkCapture:
 def _start_cdp_capture(context: Any, page: Any, target_url: str, run_salt: bytes) -> Optional[_CdpNetworkCapture]:
     try:
         cdp = context.new_cdp_session(page)
-    except Exception:
+    except Exception as exc:
+        _LOG.debug("CDP session attach failed: %s", exc, exc_info=True)
         return None
     capture = _CdpNetworkCapture(cdp, target_url, run_salt)
     try:
         capture.start()
-    except Exception:
+    except Exception as exc:
+        _LOG.debug("CDP capture start failed: %s", exc, exc_info=True)
         capture.detach()
         return None
     return capture

--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -21,6 +21,7 @@ Why this shape:
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -424,8 +425,6 @@ def _decode_cdp_body(payload: Dict[str, Any]) -> str:
         return ""
     if payload.get("base64Encoded"):
         try:
-            import base64
-
             raw = base64.b64decode(body, validate=False)
         except Exception:
             return ""

--- a/tests/test_browser_cdp_capture.py
+++ b/tests/test_browser_cdp_capture.py
@@ -1,0 +1,130 @@
+"""CDP network capture tests for browser-scan."""
+
+from __future__ import annotations
+
+import base64
+import json
+import unittest
+
+from keyleak.browser_scanner import (
+    CDP_MAX_BODY_BYTES,
+    _CdpNetworkCapture,
+    _decode_cdp_body,
+    _is_text_mime,
+)
+
+
+SECRET = "sk-proj-ABCDEF1234567890SECRETVALUE0987654321"
+
+
+class FakeCdpSession:
+    def __init__(self, bodies=None):
+        self.handlers = {}
+        self.sent = []
+        self.bodies = bodies or {}
+        self.detached = False
+
+    def send(self, method, params=None):
+        self.sent.append((method, params or {}))
+        if method == "Network.getResponseBody":
+            return self.bodies.get((params or {}).get("requestId"), {"body": "", "base64Encoded": False})
+        return {}
+
+    def on(self, event_name, handler):
+        self.handlers[event_name] = handler
+
+    def emit(self, event_name, params):
+        self.handlers[event_name](params)
+
+    def detach(self):
+        self.detached = True
+
+
+class CdpBodyDecodingTests(unittest.TestCase):
+    def test_base64_body_decodes_as_text(self):
+        encoded = base64.b64encode(b'{"token":"value"}').decode("ascii")
+        self.assertEqual(_decode_cdp_body({"body": encoded, "base64Encoded": True}), '{"token":"value"}')
+
+    def test_oversized_body_is_skipped(self):
+        body = "x" * (CDP_MAX_BODY_BYTES + 1)
+        self.assertEqual(_decode_cdp_body({"body": body, "base64Encoded": False}), "")
+
+    def test_text_mime_accepts_json_and_javascript(self):
+        self.assertTrue(_is_text_mime("application/json"))
+        self.assertTrue(_is_text_mime("", {"content-type": "application/javascript"}))
+        self.assertFalse(_is_text_mime("image/png"))
+
+
+class CdpNetworkCaptureTests(unittest.TestCase):
+    def test_response_body_findings_are_redacted_and_keep_request_metadata(self):
+        cdp = FakeCdpSession(bodies={
+            "1": {"body": json.dumps({"api_key": SECRET}), "base64Encoded": False},
+        })
+        capture = _CdpNetworkCapture(cdp, "https://app.example.test/", b"0" * 32)
+        capture.start()
+        cdp.emit("Network.responseReceived", {
+            "requestId": "1",
+            "response": {
+                "url": "https://app.example.test/api/config",
+                "status": 200,
+                "mimeType": "application/json",
+                "headers": {"content-type": "application/json"},
+            },
+        })
+        cdp.emit("Network.loadingFinished", {"requestId": "1"})
+
+        self.assertTrue(any(f.detector_id == "leak.openai_api_key" for f in capture.findings))
+        payload = json.dumps([finding.to_dict() for finding in capture.findings])
+        self.assertNotIn(SECRET, payload)
+        finding = next(f for f in capture.findings if f.detector_id == "leak.openai_api_key")
+        self.assertEqual(finding.evidence.request_url, "https://app.example.test/api/config")
+        self.assertEqual(finding.evidence.response_status, 200)
+        self.assertTrue(finding.source.startswith("CDP Response Body:"))
+
+    def test_request_body_and_console_output_are_scanned(self):
+        cdp = FakeCdpSession()
+        capture = _CdpNetworkCapture(cdp, "https://app.example.test/", b"1" * 32)
+        capture.start()
+        cdp.emit("Network.requestWillBeSent", {
+            "requestId": "2",
+            "request": {
+                "url": "https://app.example.test/api/infer",
+                "method": "POST",
+                "headers": {"content-type": "application/json"},
+                "postData": json.dumps({"token": SECRET}),
+            },
+        })
+        cdp.emit("Runtime.consoleAPICalled", {
+            "type": "log",
+            "args": [{"value": SECRET}],
+        })
+
+        sources = [finding.source for finding in capture.findings]
+        self.assertTrue(any(source.startswith("CDP Request Body:") for source in sources))
+        self.assertTrue(any(source == "CDP Console log" for source in sources))
+
+    def test_unavailable_response_body_does_not_fail_capture(self):
+        class FailingBodySession(FakeCdpSession):
+            def send(self, method, params=None):
+                if method == "Network.getResponseBody":
+                    raise RuntimeError("body evicted")
+                return super().send(method, params)
+
+        cdp = FailingBodySession()
+        capture = _CdpNetworkCapture(cdp, "https://app.example.test/", b"2" * 32)
+        capture.start()
+        cdp.emit("Network.responseReceived", {
+            "requestId": "3",
+            "response": {
+                "url": "https://app.example.test/api/config",
+                "status": 200,
+                "mimeType": "application/json",
+                "headers": {"content-type": "application/json"},
+            },
+        })
+        cdp.emit("Network.loadingFinished", {"requestId": "3"})
+        self.assertEqual(capture.findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_browser_cdp_capture.py
+++ b/tests/test_browser_cdp_capture.py
@@ -137,6 +137,7 @@ class CdpNetworkCaptureTests(unittest.TestCase):
             "requestId": "ws-1",
             "url": f"wss://app.example.test/socket?token={SECRET}#fragment",
         })
+        self.assertIn("ws-1", capture.requests)
         cdp.emit("Network.webSocketFrameReceived", {
             "requestId": "ws-1",
             "response": {"opcode": 1, "payloadData": json.dumps({"token": SECRET})},
@@ -144,6 +145,8 @@ class CdpNetworkCaptureTests(unittest.TestCase):
 
         finding = next(f for f in capture.findings if f.detector_id == "leak.openai_api_key")
         self.assertTrue(finding.source.startswith("CDP WebSocket Frame:"))
+        self.assertTrue(finding.evidence.request_url.startswith("wss://app.example.test/socket?token="))
+        self.assertNotIn(SECRET, finding.evidence.request_url)
         self.assertNotIn(SECRET, json.dumps([finding.to_dict() for finding in capture.findings]))
         cdp.emit("Network.webSocketClosed", {"requestId": "ws-1"})
         self.assertNotIn("ws-1", capture.requests)

--- a/tests/test_browser_cdp_capture.py
+++ b/tests/test_browser_cdp_capture.py
@@ -15,10 +15,15 @@ from keyleak.browser_scanner import (
     _decode_cdp_body,
     _is_text_mime,
 )
+from keyleak.redaction import stable_id
 
 
-SECRET = "sk-proj-ABCDEF1234567890SECRETVALUE0987654321"
-FETCH_ONLY_SECRET = "sk-proj-XT9mQ2vL7pR4sN8wY3cH6zD1aF5uG0kJbE9tM2qV7"
+def _fake_openai_key(*chunks):
+    return "".join(("sk", "-proj-", *chunks))
+
+
+SECRET = _fake_openai_key("ABCDEF123456", "7890SECRET", "VALUE0987654321")
+FETCH_ONLY_SECRET = _fake_openai_key("XT9mQ2vL7pR4", "sN8wY3cH6zD1", "aF5uG0kJbE9tM2qV7")
 HAS_PLAYWRIGHT = importlib.util.find_spec("playwright") is not None
 
 
@@ -70,7 +75,7 @@ class CdpNetworkCaptureTests(unittest.TestCase):
         cdp.emit("Network.responseReceived", {
             "requestId": "1",
             "response": {
-                "url": "https://app.example.test/api/config",
+                "url": f"https://app.example.test/api/config?token={SECRET}#fragment",
                 "status": 200,
                 "mimeType": "application/json",
                 "headers": {"content-type": "application/json"},
@@ -82,9 +87,23 @@ class CdpNetworkCaptureTests(unittest.TestCase):
         payload = json.dumps([finding.to_dict() for finding in capture.findings])
         self.assertNotIn(SECRET, payload)
         finding = next(f for f in capture.findings if f.detector_id == "leak.openai_api_key")
-        self.assertEqual(finding.evidence.request_url, "https://app.example.test/api/config")
+        self.assertTrue(finding.evidence.request_url.startswith("https://app.example.test/api/config?token="))
+        self.assertNotIn(SECRET, finding.evidence.request_url)
         self.assertEqual(finding.evidence.response_status, 200)
         self.assertTrue(finding.source.startswith("CDP Response Body:"))
+        self.assertNotIn(SECRET, finding.source)
+        self.assertEqual(
+            finding.id,
+            stable_id(
+                finding.type,
+                finding.detector_id,
+                finding.source,
+                finding.evidence.redacted_value,
+                finding.evidence.line,
+                finding.evidence.request_url,
+            ),
+        )
+        self.assertNotIn("1", capture.requests)
 
     def test_request_body_and_console_output_are_scanned(self):
         cdp = FakeCdpSession()
@@ -93,7 +112,7 @@ class CdpNetworkCaptureTests(unittest.TestCase):
         cdp.emit("Network.requestWillBeSent", {
             "requestId": "2",
             "request": {
-                "url": "https://app.example.test/api/infer",
+                "url": f"https://app.example.test/api/infer?token={SECRET}#fragment",
                 "method": "POST",
                 "headers": {"content-type": "application/json"},
                 "postData": json.dumps({"token": SECRET}),
@@ -107,6 +126,43 @@ class CdpNetworkCaptureTests(unittest.TestCase):
         sources = [finding.source for finding in capture.findings]
         self.assertTrue(any(source.startswith("CDP Request Body:") for source in sources))
         self.assertTrue(any(source == "CDP Console log" for source in sources))
+        payload = json.dumps([finding.to_dict() for finding in capture.findings])
+        self.assertNotIn(SECRET, payload)
+
+    def test_websocket_frames_are_scanned(self):
+        cdp = FakeCdpSession()
+        capture = _CdpNetworkCapture(cdp, "https://app.example.test/", b"3" * 32)
+        capture.start()
+        cdp.emit("Network.webSocketCreated", {
+            "requestId": "ws-1",
+            "url": f"wss://app.example.test/socket?token={SECRET}#fragment",
+        })
+        cdp.emit("Network.webSocketFrameReceived", {
+            "requestId": "ws-1",
+            "response": {"opcode": 1, "payloadData": json.dumps({"token": SECRET})},
+        })
+
+        finding = next(f for f in capture.findings if f.detector_id == "leak.openai_api_key")
+        self.assertTrue(finding.source.startswith("CDP WebSocket Frame:"))
+        self.assertNotIn(SECRET, json.dumps([finding.to_dict() for finding in capture.findings]))
+        cdp.emit("Network.webSocketClosed", {"requestId": "ws-1"})
+        self.assertNotIn("ws-1", capture.requests)
+
+    def test_log_entries_are_scanned(self):
+        cdp = FakeCdpSession()
+        capture = _CdpNetworkCapture(cdp, "https://app.example.test/", b"4" * 32)
+        capture.start()
+        cdp.emit("Log.entryAdded", {
+            "entry": {
+                "level": "warning",
+                "url": f"https://app.example.test/log?token={SECRET}#fragment",
+                "text": SECRET,
+            },
+        })
+
+        sources = [finding.source for finding in capture.findings]
+        self.assertIn("CDP Log warning", sources)
+        self.assertNotIn(SECRET, json.dumps([finding.to_dict() for finding in capture.findings]))
 
     def test_unavailable_response_body_does_not_fail_capture(self):
         class FailingBodySession(FakeCdpSession):
@@ -129,6 +185,19 @@ class CdpNetworkCaptureTests(unittest.TestCase):
         })
         cdp.emit("Network.loadingFinished", {"requestId": "3"})
         self.assertEqual(capture.findings, [])
+        self.assertNotIn("3", capture.requests)
+
+    def test_failed_http_request_is_forgotten(self):
+        cdp = FakeCdpSession()
+        capture = _CdpNetworkCapture(cdp, "https://app.example.test/", b"5" * 32)
+        capture.start()
+        cdp.emit("Network.requestWillBeSent", {
+            "requestId": "failed-1",
+            "request": {"url": "https://app.example.test/missing", "method": "GET"},
+        })
+        self.assertIn("failed-1", capture.requests)
+        cdp.emit("Network.loadingFailed", {"requestId": "failed-1"})
+        self.assertNotIn("failed-1", capture.requests)
 
 
 class _CdpFixtureHandler(BaseHTTPRequestHandler):

--- a/tests/test_browser_cdp_capture.py
+++ b/tests/test_browser_cdp_capture.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import base64
+import importlib.util
 import json
+import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from keyleak.browser_scanner import (
     CDP_MAX_BODY_BYTES,
@@ -15,6 +18,8 @@ from keyleak.browser_scanner import (
 
 
 SECRET = "sk-proj-ABCDEF1234567890SECRETVALUE0987654321"
+FETCH_ONLY_SECRET = "sk-proj-XT9mQ2vL7pR4sN8wY3cH6zD1aF5uG0kJbE9tM2qV7"
+HAS_PLAYWRIGHT = importlib.util.find_spec("playwright") is not None
 
 
 class FakeCdpSession:
@@ -124,6 +129,73 @@ class CdpNetworkCaptureTests(unittest.TestCase):
         })
         cdp.emit("Network.loadingFinished", {"requestId": "3"})
         self.assertEqual(capture.findings, [])
+
+
+class _CdpFixtureHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/config":
+            body = json.dumps({"api_key": FETCH_ONLY_SECRET}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        body = b"""
+<!doctype html>
+<html>
+<body>
+  <script>
+    fetch('/config').then(function (response) {
+      return response.json();
+    }).then(function () {
+      document.body.dataset.loaded = 'true';
+    });
+  </script>
+</body>
+</html>
+"""
+        self.send_response(200)
+        self.send_header("content-type", "text/html")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+@unittest.skipUnless(HAS_PLAYWRIGHT, "Playwright not installed; live CDP integration skipped.")
+class BrowserCdpIntegrationTests(unittest.TestCase):
+    def test_browser_scan_captures_fetch_response_body_via_cdp(self):
+        from keyleak.browser_scanner import run_browser_scan
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _CdpFixtureHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}/"
+            try:
+                report = run_browser_scan(url, scan_budget_seconds=5)
+            except Exception as exc:
+                message = str(exc)
+                if "playwright install" in message or "Executable doesn't exist" in message:
+                    self.skipTest(f"Playwright Chromium is not installed: {message}")
+                raise
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        matching = [
+            finding for finding in report.findings
+            if finding.detector_id == "leak.openai_api_key"
+            and finding.source.startswith("CDP Response Body:")
+        ]
+        self.assertTrue(matching, "expected CDP response body to surface the fetch-only key")
+        payload = json.dumps(report.to_dict())
+        self.assertNotIn(FETCH_ONLY_SECRET, payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Attach a best-effort CDP session to Playwright Chromium browser scans.
- Capture request URLs, request/response headers, request bodies, text response bodies via Network.getResponseBody, WebSocket text frames, and console/log output.
- Feed CDP text through the existing detector and redaction pipeline so findings keep request metadata without emitting raw secrets.

## Testing

- [x] `python3 -m unittest tests.test_browser_cdp_capture tests.test_browser_redaction tests.test_browser_library_scan tests.test_baas_validator`
- [x] `python3 -m py_compile keyleak/browser_scanner.py tests/test_browser_cdp_capture.py`
- [ ] `python3 -m unittest` attempted, but this clean clone environment is missing `tldextract`, so site-scanner imports fail before those tests can run.
- [ ] `poetry run keyleak local fixtures/vulnerable-demo` not run.
- [ ] Manual web UI check not applicable.
- [ ] Chrome extension check not applicable.

## Security Checklist

- [x] No real secrets, tokens, cookies, or credentials are included.
- [x] Findings, screenshots, and logs are redacted.
- [x] New detectors include fixtures or tests. Not a new detector, but CDP capture has regression tests.
- [x] User-facing remediation is actionable. Existing detector remediation is reused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/keyleak-detector/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser scan now captures network traffic, WebSocket frames, console output and response bodies via a secondary capture path, merging additional redacted findings with in-page results.

* **Tests**
  * Expanded coverage for body decoding, MIME/size filtering, request/response/console/WS capture paths, redaction and error handling, plus an optional live browser integration test (skipped if Playwright/Chromium unavailable).

* **Chores**
  * CI updated to install Chromium runtime to support browser-based tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->