### PR TITLE
Improve report reliability and finding identity

### DIFF
--- a/keyleak/browser_scanner.py
+++ b/keyleak/browser_scanner.py
@@ -35,6 +35,7 @@ from .local_scanner import scan_text
 from .models import Evidence, Finding, ScanReport
 from .proxy import playwright_proxy
 from .redaction import new_run_salt, redact_url, redact_value, stable_id
+from .fingerprints import finding_fingerprint
 from .reporting import build_report
 
 
@@ -503,8 +504,15 @@ class _CdpNetworkCapture:
             return
         if len(text.encode("utf-8", errors="ignore")) > CDP_MAX_BODY_BYTES:
             return
-        for finding in scan_text(text, source, self._detectors, run_salt=self.run_salt):
-            finding.evidence.request_url = redact_url(request_url)
+        safe_request_url = redact_url(request_url)
+        for finding in scan_text(
+            text,
+            source,
+            self._detectors,
+            run_salt=self.run_salt,
+            request_url=safe_request_url,
+        ):
+            finding.evidence.request_url = safe_request_url
             if response_status is not None:
                 finding.evidence.response_status = response_status
             finding.id = stable_id(
@@ -786,6 +794,7 @@ def _run_baas_validation(
 def _to_finding(entry: Dict[str, Any], target: str, run_salt: Optional[bytes] = None) -> Finding:
     source = entry.get("source") or target
     value = str(entry.get("value") or "")
+    safe_target = redact_url(target)
     # Redact before the value ever leaves this process. The browser path used to
     # store the raw match in ``redacted_value``/``snippet``, leaking cleartext
     # secrets into reports, CI artifacts, and the /scan JSON response. Always use
@@ -798,7 +807,7 @@ def _to_finding(entry: Dict[str, Any], target: str, run_salt: Optional[bytes] = 
         source=source,
         snippet=redacted,
         redacted_value=redacted,
-        request_url=target,
+        request_url=safe_target,
     )
     detector_id = str(entry.get("detector_id") or "browser:unknown")
     return Finding(
@@ -812,6 +821,12 @@ def _to_finding(entry: Dict[str, Any], target: str, run_salt: Optional[bytes] = 
         remediation="Rotate the exposed credential and remove it from the bundle / storage.",
         validation_status="lead",
         category="leak",
+        fingerprint=finding_fingerprint(
+            detector_id=detector_id,
+            source=source,
+            raw_value=value,
+            request_url=safe_target,
+        ),
     )
 
 

--- a/keyleak/diff.py
+++ b/keyleak/diff.py
@@ -9,8 +9,8 @@ Inputs accepted:
 - KeyLeak JSON reports (the native format).
 - SARIF 2.1.0 reports.
 
-We identify findings by their stable ``id`` field (already a SHA256 over
-detector + source + line + value, set in :meth:`Finding.__post_init__`).
+    We identify findings by their stable ``fingerprint`` field when available,
+falling back to the older ``id`` field for legacy reports.
 """
 
 from __future__ import annotations
@@ -54,6 +54,7 @@ def _sarif_to_report(sarif: Dict[str, Any], target: str = "") -> ScanReport:
             region = phys.get("region") or {}
             findings.append({
                 "id": (result.get("partialFingerprints") or {}).get("findingId") or "",
+                "fingerprint": (result.get("partialFingerprints") or {}).get("findingFingerprint") or "",
                 "type": (rules_by_id.get(rule_id, {}).get("name")) or rule_id,
                 "severity": _sarif_level_to_severity(result.get("level")),
                 "detector_id": rule_id,
@@ -83,8 +84,8 @@ def _sarif_level_to_severity(level: Any) -> str:
 def diff_reports(baseline: ScanReport, current: ScanReport) -> ScanReport:
     """Return a ScanReport containing only findings *new* in ``current``."""
 
-    baseline_ids: Set[str] = {f.id for f in baseline.findings if f.id}
-    new_findings = [f for f in current.findings if f.id and f.id not in baseline_ids]
+    baseline_ids: Set[str] = {_identity(f) for f in baseline.findings if _identity(f)}
+    new_findings = [f for f in current.findings if _identity(f) and _identity(f) not in baseline_ids]
     return build_report(
         current.target or baseline.target,
         new_findings,
@@ -92,3 +93,7 @@ def diff_reports(baseline: ScanReport, current: ScanReport) -> ScanReport:
         profile=current.extra.get("profile") if isinstance(current.extra, dict) else "diff",
         packs=current.extra.get("packs") if isinstance(current.extra, dict) else None,
     )
+
+
+def _identity(finding: Finding) -> str:
+    return finding.fingerprint or finding.id

--- a/keyleak/diff.py
+++ b/keyleak/diff.py
@@ -84,8 +84,15 @@ def _sarif_level_to_severity(level: Any) -> str:
 def diff_reports(baseline: ScanReport, current: ScanReport) -> ScanReport:
     """Return a ScanReport containing only findings *new* in ``current``."""
 
-    baseline_ids: Set[str] = {_identity(f) for f in baseline.findings if _identity(f)}
-    new_findings = [f for f in current.findings if _identity(f) and _identity(f) not in baseline_ids]
+    baseline_ids: Set[str] = {
+        key
+        for finding in baseline.findings
+        for key in _identity_keys(finding)
+    }
+    new_findings = [
+        f for f in current.findings
+        if not _identity_keys(f).intersection(baseline_ids)
+    ]
     return build_report(
         current.target or baseline.target,
         new_findings,
@@ -95,5 +102,5 @@ def diff_reports(baseline: ScanReport, current: ScanReport) -> ScanReport:
     )
 
 
-def _identity(finding: Finding) -> str:
-    return finding.fingerprint or finding.id
+def _identity_keys(finding: Finding) -> Set[str]:
+    return {key for key in (finding.fingerprint, finding.id) if key}

--- a/keyleak/fingerprints.py
+++ b/keyleak/fingerprints.py
@@ -36,7 +36,6 @@ def finding_fingerprint(
         "" if detector_id is None else str(detector_id),
         "" if source is None else str(source),
         "" if request_url is None else str(request_url),
-        "" if line is None else str(line),
         text,
     ]
     payload = "\0".join(parts).encode("utf-8", errors="replace")

--- a/keyleak/fingerprints.py
+++ b/keyleak/fingerprints.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
+import os
 from typing import Optional
 
 
 FINGERPRINT_PREFIX = "klfp1"
+FINDING_FINGERPRINT_HMAC_KEY_ENV = "KEYLEAK_FINDING_FINGERPRINT_KEY"
 
 
 def finding_fingerprint(
@@ -36,5 +39,10 @@ def finding_fingerprint(
         "" if line is None else str(line),
         text,
     ]
-    digest = hashlib.sha256("\0".join(parts).encode("utf-8", errors="replace")).hexdigest()[:24]
+    payload = "\0".join(parts).encode("utf-8", errors="replace")
+    key = os.environ.get(FINDING_FINGERPRINT_HMAC_KEY_ENV)
+    if key:
+        digest = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()[:24]
+    else:
+        digest = hashlib.sha256(payload).hexdigest()[:24]
     return f"{FINGERPRINT_PREFIX}_{digest}"

--- a/keyleak/fingerprints.py
+++ b/keyleak/fingerprints.py
@@ -1,0 +1,40 @@
+"""Stable, privacy-preserving finding fingerprints."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Optional
+
+
+FINGERPRINT_PREFIX = "klfp1"
+
+
+def finding_fingerprint(
+    *,
+    detector_id: object,
+    source: object,
+    raw_value: object,
+    request_url: object = "",
+    line: Optional[object] = None,
+) -> str:
+    """Return a stable report fingerprint without storing the raw value.
+
+    ``Finding.id`` intentionally stays tied to the rendered report identity for
+    backwards compatibility. This fingerprint is a separate baseline/diff key
+    computed while the raw match is still in memory, then only the digest is
+    persisted.
+    """
+
+    text = "" if raw_value is None else str(raw_value)
+    if not text:
+        return ""
+    parts = [
+        FINGERPRINT_PREFIX,
+        "" if detector_id is None else str(detector_id),
+        "" if source is None else str(source),
+        "" if request_url is None else str(request_url),
+        "" if line is None else str(line),
+        text,
+    ]
+    digest = hashlib.sha256("\0".join(parts).encode("utf-8", errors="replace")).hexdigest()[:24]
+    return f"{FINGERPRINT_PREFIX}_{digest}"

--- a/keyleak/fingerprints.py
+++ b/keyleak/fingerprints.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import os
 from typing import Optional
 
 
 FINGERPRINT_PREFIX = "klfp1"
 FINDING_FINGERPRINT_HMAC_KEY_ENV = "KEYLEAK_FINDING_FINGERPRINT_KEY"
+logger = logging.getLogger(__name__)
+_warned_missing_key = False
 
 
 def finding_fingerprint(
@@ -41,6 +44,13 @@ def finding_fingerprint(
     payload = "\0".join(parts).encode("utf-8", errors="replace")
     key = os.environ.get(FINDING_FINGERPRINT_HMAC_KEY_ENV)
     if not key:
+        global _warned_missing_key
+        if not _warned_missing_key:
+            logger.warning(
+                "%s is not set; finding fingerprints are disabled.",
+                FINDING_FINGERPRINT_HMAC_KEY_ENV,
+            )
+            _warned_missing_key = True
         return ""
     digest = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()[:24]
     return f"{FINGERPRINT_PREFIX}_{digest}"

--- a/keyleak/fingerprints.py
+++ b/keyleak/fingerprints.py
@@ -40,8 +40,7 @@ def finding_fingerprint(
     ]
     payload = "\0".join(parts).encode("utf-8", errors="replace")
     key = os.environ.get(FINDING_FINGERPRINT_HMAC_KEY_ENV)
-    if key:
-        digest = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()[:24]
-    else:
-        digest = hashlib.sha256(payload).hexdigest()[:24]
+    if not key:
+        return ""
+    digest = hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()[:24]
     return f"{FINGERPRINT_PREFIX}_{digest}"

--- a/keyleak/local_scanner.py
+++ b/keyleak/local_scanner.py
@@ -12,9 +12,10 @@ from .detectors import Detector, categories_for_packs, detectors_for_categories,
 from .detectors_ast import detect_worm_shape, is_worm_shape_target
 from .detectors_fuzzy import FingerprintHit, load_corpus, match_fingerprints
 from .detectors_splittoken import SplitTokenMatch, collect_fragments, find_split_tokens
+from .fingerprints import finding_fingerprint
 from .models import Evidence, Finding, confidence_for_severity
 from .privacy_filter import scrub_snippet as pii_scrub_snippet
-from .redaction import new_run_salt, redact_snippet, redact_value
+from .redaction import new_run_salt, redact_snippet, redact_url, redact_value
 from .reporting import build_report
 from .sourcemaps import SourceMapError, reconstruct_originals
 
@@ -247,9 +248,11 @@ def scan_text(
     detectors: Iterable[Detector],
     *,
     run_salt: Optional[bytes] = None,
+    request_url: str = "",
 ) -> List[Finding]:
     findings: List[Finding] = []
     seen = set()
+    safe_request_url = redact_url(request_url) if request_url else ""
     for detector in detectors:
         regex = detector.compile()
         for match in regex.finditer(content):
@@ -308,6 +311,7 @@ def scan_text(
                 source=source,
                 snippet=redacted_snippet,
                 line=line,
+                request_url=safe_request_url,
                 redacted_value=redacted_value,
             )
             findings.append(
@@ -323,6 +327,13 @@ def scan_text(
                     validation_status=detector.validation_status,
                     category=detector.pack,
                     references=list(detector.references),
+                    fingerprint=finding_fingerprint(
+                        detector_id=detector.canonical_id,
+                        source=source,
+                        raw_value=raw_value,
+                        request_url=safe_request_url,
+                        line=line,
+                    ),
                     remediation_v2=detector.get_remediation().to_dict(),
                 )
             )

--- a/keyleak/models.py
+++ b/keyleak/models.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from .fingerprints import finding_fingerprint
 from .redaction import redact_snippet, redact_url, redact_value, stable_id
 
 
@@ -120,6 +121,7 @@ class Finding:
     category: str = ""
     references: List[str] = field(default_factory=list)
     id: str = ""
+    fingerprint: str = ""
     # Wave 1.6 — Structured Remediation card. Optional dict (kept dict-shaped
     # for backward compat with from_dict consumers). Populated by ``scan_text``
     # from the detector. Reporters render it if present.
@@ -154,6 +156,8 @@ class Finding:
             "references": self.references,
             "validation_status": self.validation_status,
         }
+        if self.fingerprint:
+            payload["fingerprint"] = self.fingerprint
         if self.remediation_v2:
             payload["remediation_v2"] = dict(self.remediation_v2)
         return payload
@@ -181,6 +185,7 @@ class Finding:
             category=str(payload.get("category") or payload.get("pack") or ""),
             references=list(payload.get("references") or []),
             id=str(payload.get("id") or ""),
+            fingerprint=str(payload.get("fingerprint") or ""),
             remediation_v2=payload.get("remediation_v2"),
         )
 
@@ -316,6 +321,8 @@ def finding_from_legacy(raw: Dict[str, Any], detector_prefix: str = "runtime") -
     raw_value = raw.get("value") if raw.get("value") is not None else raw.get("match", "")
     redacted_value = redact_value(raw_value)
     snippet = raw.get("context_lines") or raw.get("context") or raw.get("details") or ""
+    detector_id = str(raw.get("detector_id") or f"{detector_prefix}:{finding_type}")
+    request_url = redact_url(raw.get("url", ""))
     confidence = (
         float(raw.get("confidence"))
         if raw.get("confidence") is not None
@@ -326,7 +333,7 @@ def finding_from_legacy(raw: Dict[str, Any], detector_prefix: str = "runtime") -
         source=source,
         snippet=redact_snippet(snippet, raw_value),
         line=raw.get("line"),
-        request_url=redact_url(raw.get("url", "")),
+        request_url=request_url,
         response_status=raw.get("status_code"),
         redacted_value=redacted_value,
     )
@@ -335,7 +342,7 @@ def finding_from_legacy(raw: Dict[str, Any], detector_prefix: str = "runtime") -
         type=finding_type,
         severity=severity,
         confidence=confidence,
-        detector_id=str(raw.get("detector_id") or f"{detector_prefix}:{finding_type}"),
+        detector_id=detector_id,
         source=source,
         evidence=evidence,
         risk_reason=str(raw.get("context") or raw.get("details") or f"{finding_type} detected in {source}"),
@@ -343,4 +350,11 @@ def finding_from_legacy(raw: Dict[str, Any], detector_prefix: str = "runtime") -
         validation_status=str(raw.get("validation_status") or ("lead" if category != "leak" else "validated")),
         category=category,
         references=list(raw.get("references") or []),
+        fingerprint=finding_fingerprint(
+            detector_id=detector_id,
+            source=source,
+            raw_value=raw_value,
+            request_url=request_url,
+            line=raw.get("line"),
+        ),
     )

--- a/keyleak/reporting.py
+++ b/keyleak/reporting.py
@@ -201,15 +201,17 @@ def format_html(report: ScanReport) -> str:
         remediation_text = e(item["remediation"])
         validation = item.get("validation_status", "")
 
-        confirmed_badge = ""
-        if validation == "confirmed" or validation == "validated":
-            confirmed_badge = '<span class="badge-confirmed">confirmed</span>'
+        validation_badge = ""
+        if validation == "confirmed":
+            validation_badge = '<span class="badge-confirmed">confirmed</span>'
+        elif validation == "validated":
+            validation_badge = '<span class="badge-validated">validated</span>'
 
         card = f"""    <div class="finding {e(sev_lower)}">
       <div class="finding-head">
         <span class="sev {e(sev_lower)}">{sev.upper()}</span>
         <span class="finding-type">{finding_type}</span>
-        {confirmed_badge}
+        {validation_badge}
       </div>
       <div class="finding-detail">{risk}</div>
       <div class="finding-evidence">{evidence_text}</div>
@@ -322,6 +324,7 @@ def format_html(report: ScanReport) -> str:
   .sev.medium {{ background: var(--yellow); color: #0a0a0f; }}
   .sev.low {{ background: var(--blue); color: #0a0a0f; }}
   .badge-confirmed {{ font-size: 10px; color: var(--green); border: 1px solid rgba(81,207,102,.3); padding: 1px 6px; border-radius: 3px; }}
+  .badge-validated {{ font-size: 10px; color: var(--blue); border: 1px solid rgba(77,171,247,.35); padding: 1px 6px; border-radius: 3px; }}
   .badge-lead {{ font-size: 10px; color: var(--yellow); border: 1px solid rgba(255,212,59,.35); padding: 1px 6px; border-radius: 3px; }}
   .finding-type {{ font-size: 14px; font-weight: 600; color: var(--text); }}
   .finding-detail {{ font-size: 13px; color: var(--text2); margin-bottom: 6px; }}
@@ -402,7 +405,10 @@ def format_sarif(report: ScanReport) -> str:
                         }
                     }
                 ],
-                "partialFingerprints": {"findingId": item["id"]},
+                "partialFingerprints": {
+                    "findingId": item["id"],
+                    **({"findingFingerprint": item["fingerprint"]} if item.get("fingerprint") else {}),
+                },
                 "properties": {"category": item.get("category") or ""},
             }
         )
@@ -511,6 +517,10 @@ def _retest_command(target: str, scan_mode: str) -> str:
     safe_target = shlex.quote(redact_url(target))
     if scan_mode == "local":
         return f"keyleak local {safe_target}"
+    if scan_mode == "browser":
+        return f"keyleak browser-scan {safe_target}"
+    if scan_mode == "full-site":
+        return f"keyleak site-scan {safe_target}"
     return f"keyleak scan {safe_target}"
 
 

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -28,6 +28,7 @@ import tldextract
 from .browser_scanner import run_browser_scan
 from .models import Evidence, Finding, ScanReport, confidence_for_severity
 from .proxy import playwright_proxy, requests_proxies
+from .redaction import redact_url
 from .reporting import build_report
 
 
@@ -620,6 +621,7 @@ def scan_site(
     takeover_count = 0
     total = 0
     urls: List[str] = []
+    scan_failures: List[Dict[str, str]] = []
     # Everything from the crawl through the takeover join runs inside a
     # try/finally so the background takeover pool is always shut down — even if
     # crawl_pages or the per-host scan raises.
@@ -637,7 +639,8 @@ def scan_site(
             # SSRF guard: a crawled link may resolve to an internal address.
             if target_guard is not None and target_guard(urlparse(url).hostname) is not None:
                 continue
-            _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {url}", i + 1, total)
+            safe_url = redact_url(url)
+            _emit(on_progress, "scan", f"Scanning [{i + 1}/{total}] {safe_url}", i + 1, total)
             try:
                 report = run_browser_scan(
                     url,
@@ -651,7 +654,9 @@ def scan_site(
                 for f in report.findings:
                     pairs.append((f, url))
             except Exception as exc:
-                print(f"[keyleak]   Error scanning {url}: {exc}", file=sys.stderr)
+                safe_error = redact_url(str(exc))
+                print(f"[keyleak]   Error scanning {safe_url}: {safe_error}", file=sys.stderr)
+                scan_failures.append({"url": safe_url, "error": safe_error})
                 continue
 
         # Join the parallel subdomain-takeover check and fold its findings in.
@@ -688,6 +693,8 @@ def scan_site(
         "subdomains": subdomains,
         "hosts_scanned": len(subdomains),
         "pages_scanned": total,
+        "pages_failed": len(scan_failures),
+        "scan_failures": scan_failures,
         "scanned_urls": urls,
         "provenance": provenance,
         "subdomain_takeovers": takeover_count,

--- a/keyleak/site_scanner.py
+++ b/keyleak/site_scanner.py
@@ -654,7 +654,7 @@ def scan_site(
                 for f in report.findings:
                     pairs.append((f, url))
             except Exception as exc:
-                safe_error = redact_url(str(exc))
+                safe_error = f"{type(exc).__name__} during page scan"
                 print(f"[keyleak]   Error scanning {safe_url}: {safe_error}", file=sys.stderr)
                 scan_failures.append({"url": safe_url, "error": safe_error})
                 continue

--- a/keyleak/suppressions.py
+++ b/keyleak/suppressions.py
@@ -141,6 +141,7 @@ DEFAULT_FIXTURE_SUPPRESSIONS: List[str] = [
 @dataclass
 class SuppressionSet:
     ids: Set[str] = field(default_factory=set)
+    fingerprints: Set[str] = field(default_factory=set)
     detector_ids: Set[str] = field(default_factory=set)
     types: Set[str] = field(default_factory=set)
     signatures: Set[str] = field(default_factory=set)
@@ -172,6 +173,7 @@ def apply_suppressions(
     if not any(
         [
             suppressions.ids,
+            suppressions.fingerprints,
             suppressions.detector_ids,
             suppressions.types,
             suppressions.signatures,
@@ -194,6 +196,7 @@ def apply_suppressions(
 def merge_suppressions(left: SuppressionSet, right: SuppressionSet) -> SuppressionSet:
     return SuppressionSet(
         ids=left.ids | right.ids,
+        fingerprints=left.fingerprints | right.fingerprints,
         detector_ids=left.detector_ids | right.detector_ids,
         types=left.types | right.types,
         signatures=left.signatures | right.signatures,
@@ -231,6 +234,7 @@ def _from_yaml(text: str) -> SuppressionSet:
         entries:
           - id: "..."                 # optional; derived if absent
             detector: "leak.<id>"     # Detector.canonical_id; required if no source_contains
+            fingerprint: "klfp1_..."  # optional stable finding fingerprint
             source_contains: "..."    # optional
             reason: "..."             # required
             owner: "@user"            # required
@@ -290,6 +294,8 @@ def _from_yaml(text: str) -> SuppressionSet:
 
         if raw_entry.get("id"):
             suppressions.ids.add(str(raw_entry["id"]).strip())
+        if raw_entry.get("fingerprint"):
+            suppressions.fingerprints.add(str(raw_entry["fingerprint"]).strip())
         if raw_entry.get("detector"):
             suppressions.detector_ids.add(str(raw_entry["detector"]).strip())
         if raw_entry.get("type"):
@@ -301,6 +307,7 @@ def _from_yaml(text: str) -> SuppressionSet:
 
         if not (
             raw_entry.get("id")
+            or raw_entry.get("fingerprint")
             or raw_entry.get("detector")
             or raw_entry.get("type")
             or raw_entry.get("source_contains")
@@ -382,6 +389,8 @@ def sign_entries_hmac(entries: List[Any], key: str) -> str:
 def is_suppressed(finding: Finding, suppressions: SuppressionSet) -> bool:
     if finding.id in suppressions.ids:
         return True
+    if finding.fingerprint and finding.fingerprint in suppressions.fingerprints:
+        return True
     if finding.detector_id in suppressions.detector_ids:
         return True
     # Honor detector id_aliases: a suppression that references an old detector
@@ -431,6 +440,7 @@ def _from_json(payload: Any, baseline_mode: bool = False) -> SuppressionSet:
         raise ValueError("suppression JSON must be an object or list")
 
     _add_strings(suppressions.ids, payload.get("ids") or payload.get("finding_ids"))
+    _add_strings(suppressions.fingerprints, payload.get("fingerprints"))
     _add_strings(suppressions.detector_ids, payload.get("detector_ids"))
     _add_strings(suppressions.types, payload.get("types"))
     _add_strings(suppressions.signatures, payload.get("signatures"))
@@ -474,6 +484,10 @@ def _add_items(suppressions: SuppressionSet, items: Iterable[Any], baseline_mode
             continue
 
         _add_optional(suppressions.ids, item.get("id"))
+        _add_optional(suppressions.fingerprints, item.get("fingerprint"))
+        if baseline_mode:
+            _add_optional(suppressions.signatures, _signature_from_dict(item))
+            continue
         _add_optional(suppressions.detector_ids, item.get("detector_id"))
         _add_optional(suppressions.types, item.get("type"))
         _add_optional(suppressions.signatures, _signature_from_dict(item))

--- a/keyleak/suppressions.py
+++ b/keyleak/suppressions.py
@@ -489,7 +489,8 @@ def _add_items(suppressions: SuppressionSet, items: Iterable[Any], baseline_mode
         _add_optional(suppressions.types, item.get("type"))
         _add_optional(suppressions.signatures, _signature_from_dict(item))
         _add_optional(suppressions.source_contains, item.get("source_contains"))
-        _add_optional(suppressions.source_contains, item.get("source"))
+        if baseline_mode:
+            _add_optional(suppressions.source_contains, item.get("source"))
 
 
 def _signature_from_dict(item: Dict[str, Any]) -> Optional[str]:

--- a/keyleak/suppressions.py
+++ b/keyleak/suppressions.py
@@ -485,15 +485,11 @@ def _add_items(suppressions: SuppressionSet, items: Iterable[Any], baseline_mode
 
         _add_optional(suppressions.ids, item.get("id"))
         _add_optional(suppressions.fingerprints, item.get("fingerprint"))
-        if baseline_mode:
-            _add_optional(suppressions.signatures, _signature_from_dict(item))
-            continue
         _add_optional(suppressions.detector_ids, item.get("detector_id"))
         _add_optional(suppressions.types, item.get("type"))
         _add_optional(suppressions.signatures, _signature_from_dict(item))
         _add_optional(suppressions.source_contains, item.get("source_contains"))
-        if not baseline_mode:
-            _add_optional(suppressions.source_contains, item.get("source"))
+        _add_optional(suppressions.source_contains, item.get("source"))
 
 
 def _signature_from_dict(item: Dict[str, Any]) -> Optional[str]:

--- a/tests/test_browser_redaction.py
+++ b/tests/test_browser_redaction.py
@@ -8,6 +8,7 @@ CI artifacts, and the /scan JSON. These tests pin the redaction.
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 
 from keyleak.browser_scanner import _to_finding, evaluate_findings_payload
 
@@ -16,11 +17,16 @@ SECRET = "sk-proj-ABCDEF1234567890SECRETVALUE0987654321"
 
 class BrowserRedactionTests(unittest.TestCase):
     def test_to_finding_redacts_value(self):
-        f = _to_finding(
-            {"detector_id": "leak.openai_api_key", "type": "openai_api_key",
-             "severity": "critical", "source": "localStorage:t", "value": SECRET},
-            "https://app.example.test/",
-        )
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            f = _to_finding(
+                {"detector_id": "leak.openai_api_key", "type": "openai_api_key",
+                 "severity": "critical", "source": "localStorage:t", "value": SECRET},
+                "https://app.example.test/",
+            )
         self.assertNotIn(SECRET, f.evidence.redacted_value)
         self.assertNotIn(SECRET, f.evidence.snippet)
         self.assertIn("[redacted", f.evidence.redacted_value)
@@ -31,8 +37,13 @@ class BrowserRedactionTests(unittest.TestCase):
         entry = {"detector_id": "leak.openai_api_key", "type": "openai_api_key",
                  "severity": "critical", "source": "localStorage:t", "value": SECRET}
 
-        first = _to_finding(entry, "https://app.example.test/", b"\x00" * 32)
-        second = _to_finding(entry, "https://app.example.test/", b"\x11" * 32)
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            first = _to_finding(entry, "https://app.example.test/", b"\x00" * 32)
+            second = _to_finding(entry, "https://app.example.test/", b"\x11" * 32)
 
         self.assertNotEqual(first.evidence.redacted_value, second.evidence.redacted_value)
         self.assertNotEqual(first.id, second.id)

--- a/tests/test_browser_redaction.py
+++ b/tests/test_browser_redaction.py
@@ -24,6 +24,19 @@ class BrowserRedactionTests(unittest.TestCase):
         self.assertNotIn(SECRET, f.evidence.redacted_value)
         self.assertNotIn(SECRET, f.evidence.snippet)
         self.assertIn("[redacted", f.evidence.redacted_value)
+        self.assertTrue(f.fingerprint.startswith("klfp1_"))
+        self.assertNotIn(SECRET, f.fingerprint)
+
+    def test_to_finding_fingerprint_survives_redaction_salt_rotation(self):
+        entry = {"detector_id": "leak.openai_api_key", "type": "openai_api_key",
+                 "severity": "critical", "source": "localStorage:t", "value": SECRET}
+
+        first = _to_finding(entry, "https://app.example.test/", b"\x00" * 32)
+        second = _to_finding(entry, "https://app.example.test/", b"\x11" * 32)
+
+        self.assertNotEqual(first.evidence.redacted_value, second.evidence.redacted_value)
+        self.assertNotEqual(first.id, second.id)
+        self.assertEqual(first.fingerprint, second.fingerprint)
 
     def test_report_dict_contains_no_raw_secret(self):
         report = evaluate_findings_payload(

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -196,6 +196,22 @@ class ReportingTests(unittest.TestCase):
         self.assertEqual(filtered.findings, [])
         self.assertEqual(filtered.verdict["status"], "SAFE_TO_SHIP")
 
+    def test_rules_source_fallback_does_not_create_repo_wide_substring_suppression(self):
+        rules = {
+            "rules": [
+                {
+                    "detector_id": "other.detector",
+                    "source": "app.py",
+                }
+            ]
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as handle:
+            json.dump(rules, handle)
+            handle.flush()
+            suppressions = load_suppressions(handle.name, baseline_mode=False)
+
+        self.assertEqual(suppressions.source_contains, [])
+
     def test_diff_reports_uses_fingerprint_across_redaction_salt_rotation(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -160,6 +160,42 @@ class ReportingTests(unittest.TestCase):
         self.assertEqual(filtered.findings, [])
         self.assertEqual(filtered.verdict["status"], "SAFE_TO_SHIP")
 
+    def test_baseline_preserves_legacy_detector_and_source_suppressions(self):
+        baseline = {
+            "findings": [
+                {
+                    "id": "baseline-id",
+                    "detector_id": "leak.openai_api_key",
+                    "type": "openai_api_key",
+                    "source": "app.py",
+                    "evidence": {"source": "app.py", "line": 1, "redacted_value": "[redacted:11111111]"},
+                }
+            ]
+        }
+        current = ScanReport(
+            "app.py",
+            "local",
+            [
+                Finding(
+                    type="openai_api_key",
+                    severity="critical",
+                    confidence=0.9,
+                    detector_id="leak.openai_api_key",
+                    source="app.py",
+                    evidence=Evidence(source="app.py", line=99, redacted_value="[redacted:22222222]"),
+                    risk_reason="risk",
+                    remediation="fix",
+                )
+            ],
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as handle:
+            json.dump(baseline, handle)
+            handle.flush()
+            filtered = apply_suppressions(current, baseline_path=handle.name, apply_defaults=False)
+
+        self.assertEqual(filtered.findings, [])
+        self.assertEqual(filtered.verdict["status"], "SAFE_TO_SHIP")
+
     def test_diff_reports_uses_fingerprint_across_redaction_salt_rotation(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -135,9 +135,13 @@ class ReportingTests(unittest.TestCase):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'
         detector = _detector("openai_api_key")
-
-        first = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
-        second = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            first = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
+            second = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
 
         self.assertNotEqual(first.evidence.redacted_value, second.evidence.redacted_value)
         self.assertNotEqual(first.id, second.id)
@@ -170,21 +174,38 @@ class ReportingTests(unittest.TestCase):
         self.assertTrue(first.startswith("klfp1_"))
         self.assertNotIn("sk-proj-secret-value", first)
 
+    def test_finding_fingerprint_skips_output_without_key(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            fingerprint = finding_fingerprint(
+                detector_id="test:openai_api_key",
+                source="app.py",
+                raw_value="sk-proj-secret-value",
+                request_url="https://example.com/app.js",
+                line=12,
+            )
+
+        self.assertEqual(fingerprint, "")
+
     def test_finding_fingerprint_ignores_line_shifts(self):
-        first = finding_fingerprint(
-            detector_id="test:openai_api_key",
-            source="app.py",
-            raw_value="sk-proj-secret-value",
-            request_url="https://example.com/app.js",
-            line=12,
-        )
-        second = finding_fingerprint(
-            detector_id="test:openai_api_key",
-            source="app.py",
-            raw_value="sk-proj-secret-value",
-            request_url="https://example.com/app.js",
-            line=99,
-        )
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            first = finding_fingerprint(
+                detector_id="test:openai_api_key",
+                source="app.py",
+                raw_value="sk-proj-secret-value",
+                request_url="https://example.com/app.js",
+                line=12,
+            )
+            second = finding_fingerprint(
+                detector_id="test:openai_api_key",
+                source="app.py",
+                raw_value="sk-proj-secret-value",
+                request_url="https://example.com/app.js",
+                line=99,
+            )
 
         self.assertEqual(first, second)
 
@@ -192,8 +213,13 @@ class ReportingTests(unittest.TestCase):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'
         detector = _detector("openai_api_key")
-        baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
-        current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
+            current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
 
         current = ScanReport("app.py", "local", [current_finding])
         baseline = {"findings": [baseline_finding.to_dict()]}
@@ -261,8 +287,13 @@ class ReportingTests(unittest.TestCase):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'
         detector = _detector("openai_api_key")
-        baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
-        current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
+            current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
 
         diff = diff_reports(
             ScanReport("app.py", "local", [baseline_finding]),
@@ -274,7 +305,12 @@ class ReportingTests(unittest.TestCase):
     def test_diff_reports_matches_legacy_ids_against_current_fingerprints(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         detector = _detector("openai_api_key")
-        current_finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x11" * 32)[0]
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            current_finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x11" * 32)[0]
         legacy_baseline = Finding.from_dict(
             {
                 **current_finding.to_dict(),
@@ -294,7 +330,12 @@ class ReportingTests(unittest.TestCase):
     def test_sarif_partial_fingerprints_include_stable_fingerprint(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         detector = _detector("openai_api_key")
-        finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x00" * 32)[0]
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x00" * 32)[0]
         sarif = json.loads(format_sarif(ScanReport("app.py", "local", [finding])))
         partials = sarif["runs"][0]["results"][0]["partialFingerprints"]
 

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -305,11 +305,7 @@ class ReportingTests(unittest.TestCase):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'
         detector = _detector("openai_api_key")
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
             current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
 
@@ -323,11 +319,7 @@ class ReportingTests(unittest.TestCase):
     def test_diff_reports_matches_legacy_ids_against_current_fingerprints(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         detector = _detector("openai_api_key")
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             current_finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x11" * 32)[0]
         legacy_baseline = Finding.from_dict(
             {
@@ -348,11 +340,7 @@ class ReportingTests(unittest.TestCase):
     def test_sarif_partial_fingerprints_include_stable_fingerprint(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         detector = _detector("openai_api_key")
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x00" * 32)[0]
         sarif = json.loads(format_sarif(ScanReport("app.py", "local", [finding])))
         partials = sarif["runs"][0]["results"][0]["partialFingerprints"]

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -3,11 +3,13 @@ import tempfile
 import unittest
 from argparse import Namespace
 from pathlib import Path
+from unittest import mock
 
 from keyleak.access_control import compare_access_control_urls
 from keyleak.cli import _scan_request_payload
 from keyleak.diff import diff_reports
 from keyleak.extension_bundle import extension_pattern_payload, extension_patterns_js
+from keyleak.fingerprints import finding_fingerprint
 from keyleak.local_scanner import _is_generated_file, scan_file, scan_path, scan_text
 from keyleak.detectors import DETECTORS, DETECTOR_PACKS, HEATMAP_ROWS, detectors_for_packs, normalize_packs
 from keyleak.local_scanner import _is_placeholder
@@ -142,6 +144,31 @@ class ReportingTests(unittest.TestCase):
         self.assertEqual(first.fingerprint, second.fingerprint)
         self.assertTrue(first.fingerprint.startswith("klfp1_"))
         self.assertNotIn(raw_key, json.dumps(first.to_dict()))
+
+    def test_finding_fingerprint_uses_hmac_when_key_configured(self):
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
+            clear=False,
+        ):
+            first = finding_fingerprint(
+                detector_id="test:openai_api_key",
+                source="app.py",
+                raw_value="sk-proj-secret-value",
+                request_url="https://example.com/app.js",
+                line=12,
+            )
+            second = finding_fingerprint(
+                detector_id="test:openai_api_key",
+                source="app.py",
+                raw_value="sk-proj-secret-value",
+                request_url="https://example.com/app.js",
+                line=12,
+            )
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("klfp1_"))
+        self.assertNotIn("sk-proj-secret-value", first)
 
     def test_baseline_suppresses_across_redaction_salt_rotation(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import tempfile
 import unittest
@@ -5,6 +6,7 @@ from argparse import Namespace
 from pathlib import Path
 from unittest import mock
 
+import keyleak.fingerprints as fingerprints_module
 from keyleak.access_control import compare_access_control_urls
 from keyleak.cli import _scan_request_payload
 from keyleak.diff import diff_reports
@@ -20,6 +22,15 @@ from keyleak.suppressions import apply_suppressions, load_suppressions
 
 
 class ReportingTests(unittest.TestCase):
+    @contextlib.contextmanager
+    def _fingerprint_key(self, key: str = "unit-test-fingerprint-key"):
+        with mock.patch.dict(
+            "os.environ",
+            {"KEYLEAK_FINDING_FINGERPRINT_KEY": key},
+            clear=False,
+        ):
+            yield
+
     def test_redacts_long_values(self):
         self.assertEqual(redact_value("sk-proj-abcdefghijklmnopqrstuvwxyz"), "sk-pro...[redacted]...wxyz")
 
@@ -135,11 +146,7 @@ class ReportingTests(unittest.TestCase):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'
         detector = _detector("openai_api_key")
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             first = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
             second = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
 
@@ -150,11 +157,7 @@ class ReportingTests(unittest.TestCase):
         self.assertNotIn(raw_key, json.dumps(first.to_dict()))
 
     def test_finding_fingerprint_uses_hmac_when_key_configured(self):
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             first = finding_fingerprint(
                 detector_id="test:openai_api_key",
                 source="app.py",
@@ -175,23 +178,42 @@ class ReportingTests(unittest.TestCase):
         self.assertNotIn("sk-proj-secret-value", first)
 
     def test_finding_fingerprint_skips_output_without_key(self):
-        with mock.patch.dict("os.environ", {}, clear=True):
-            fingerprint = finding_fingerprint(
-                detector_id="test:openai_api_key",
-                source="app.py",
-                raw_value="sk-proj-secret-value",
-                request_url="https://example.com/app.js",
-                line=12,
-            )
+        with mock.patch.object(fingerprints_module, "_warned_missing_key", False):
+            with self.assertLogs("keyleak.fingerprints", level="WARNING") as captured:
+                with mock.patch.dict("os.environ", {}, clear=True):
+                    fingerprint = finding_fingerprint(
+                        detector_id="test:openai_api_key",
+                        source="app.py",
+                        raw_value="sk-proj-secret-value",
+                        request_url="https://example.com/app.js",
+                        line=12,
+                    )
 
         self.assertEqual(fingerprint, "")
+        self.assertEqual(
+            captured.output,
+            ["WARNING:keyleak.fingerprints:KEYLEAK_FINDING_FINGERPRINT_KEY is not set; finding fingerprints are disabled."],
+        )
+
+    def test_finding_fingerprint_warns_once_without_key(self):
+        with mock.patch.object(fingerprints_module, "_warned_missing_key", False):
+            with mock.patch.dict("os.environ", {}, clear=True):
+                with self.assertLogs("keyleak.fingerprints", level="WARNING") as captured:
+                    finding_fingerprint(
+                        detector_id="test:openai_api_key",
+                        source="app.py",
+                        raw_value="sk-proj-secret-value",
+                    )
+                self.assertEqual(len(captured.output), 1)
+                with self.assertNoLogs("keyleak.fingerprints", level="WARNING"):
+                    finding_fingerprint(
+                        detector_id="test:openai_api_key",
+                        source="app.py",
+                        raw_value="sk-proj-secret-value",
+                    )
 
     def test_finding_fingerprint_ignores_line_shifts(self):
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             first = finding_fingerprint(
                 detector_id="test:openai_api_key",
                 source="app.py",
@@ -213,11 +235,7 @@ class ReportingTests(unittest.TestCase):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'
         detector = _detector("openai_api_key")
-        with mock.patch.dict(
-            "os.environ",
-            {"KEYLEAK_FINDING_FINGERPRINT_KEY": "unit-test-fingerprint-key"},
-            clear=False,
-        ):
+        with self._fingerprint_key():
             baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
             current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
 

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -174,6 +174,26 @@ class ReportingTests(unittest.TestCase):
 
         self.assertEqual(diff.findings, [])
 
+    def test_diff_reports_matches_legacy_ids_against_current_fingerprints(self):
+        raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
+        detector = _detector("openai_api_key")
+        current_finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x11" * 32)[0]
+        legacy_baseline = Finding.from_dict(
+            {
+                **current_finding.to_dict(),
+                "fingerprint": "",
+                "id": "legacy-baseline-id",
+            }
+        )
+        current_finding.id = "legacy-baseline-id"
+
+        diff = diff_reports(
+            ScanReport("app.py", "local", [legacy_baseline]),
+            ScanReport("app.py", "local", [current_finding]),
+        )
+
+        self.assertEqual(diff.findings, [])
+
     def test_sarif_partial_fingerprints_include_stable_fingerprint(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         detector = _detector("openai_api_key")

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from keyleak.access_control import compare_access_control_urls
 from keyleak.cli import _scan_request_payload
+from keyleak.diff import diff_reports
 from keyleak.extension_bundle import extension_pattern_payload, extension_patterns_js
 from keyleak.local_scanner import _is_generated_file, scan_file, scan_path, scan_text
 from keyleak.detectors import DETECTORS, DETECTOR_PACKS, HEATMAP_ROWS, detectors_for_packs, normalize_packs
@@ -69,6 +70,15 @@ class ReportingTests(unittest.TestCase):
 
         self.assertEqual(report.retest_command, "keyleak local '/tmp/my repo'")
 
+    def test_retest_command_matches_scan_mode(self):
+        browser_report = build_report("https://preview.example.com", [], scan_mode="browser")
+        site_report = build_report("example.com", [], scan_mode="full-site")
+        basic_report = build_report("https://preview.example.com", [], scan_mode="basic")
+
+        self.assertEqual(browser_report.retest_command, "keyleak browser-scan https://preview.example.com")
+        self.assertEqual(site_report.retest_command, "keyleak site-scan example.com")
+        self.assertEqual(basic_report.retest_command, "keyleak scan https://preview.example.com")
+
     def test_report_round_trips_server_payload(self):
         report = build_report("https://preview.example.com", [], scan_mode="basic")
         payload = report.to_dict()
@@ -118,6 +128,61 @@ class ReportingTests(unittest.TestCase):
         )
 
         self.assertNotEqual(first.id, second.id)
+
+    def test_finding_fingerprint_survives_redaction_salt_rotation(self):
+        raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
+        content = f'OPENAI_API_KEY="{raw_key}"\n'
+        detector = _detector("openai_api_key")
+
+        first = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
+        second = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
+
+        self.assertNotEqual(first.evidence.redacted_value, second.evidence.redacted_value)
+        self.assertNotEqual(first.id, second.id)
+        self.assertEqual(first.fingerprint, second.fingerprint)
+        self.assertTrue(first.fingerprint.startswith("klfp1_"))
+        self.assertNotIn(raw_key, json.dumps(first.to_dict()))
+
+    def test_baseline_suppresses_across_redaction_salt_rotation(self):
+        raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
+        content = f'OPENAI_API_KEY="{raw_key}"\n'
+        detector = _detector("openai_api_key")
+        baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
+        current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
+
+        current = ScanReport("app.py", "local", [current_finding])
+        baseline = {"findings": [baseline_finding.to_dict()]}
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as handle:
+            json.dump(baseline, handle)
+            handle.flush()
+            filtered = apply_suppressions(current, baseline_path=handle.name, apply_defaults=False)
+
+        self.assertEqual(filtered.findings, [])
+        self.assertEqual(filtered.verdict["status"], "SAFE_TO_SHIP")
+
+    def test_diff_reports_uses_fingerprint_across_redaction_salt_rotation(self):
+        raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
+        content = f'OPENAI_API_KEY="{raw_key}"\n'
+        detector = _detector("openai_api_key")
+        baseline_finding = scan_text(content, "app.py", [detector], run_salt=b"\x00" * 32)[0]
+        current_finding = scan_text(content, "app.py", [detector], run_salt=b"\x11" * 32)[0]
+
+        diff = diff_reports(
+            ScanReport("app.py", "local", [baseline_finding]),
+            ScanReport("app.py", "local", [current_finding]),
+        )
+
+        self.assertEqual(diff.findings, [])
+
+    def test_sarif_partial_fingerprints_include_stable_fingerprint(self):
+        raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
+        detector = _detector("openai_api_key")
+        finding = scan_text(f'OPENAI_API_KEY="{raw_key}"\n', "app.py", [detector], run_salt=b"\x00" * 32)[0]
+        sarif = json.loads(format_sarif(ScanReport("app.py", "local", [finding])))
+        partials = sarif["runs"][0]["results"][0]["partialFingerprints"]
+
+        self.assertEqual(partials["findingFingerprint"], finding.fingerprint)
+        self.assertNotIn(raw_key, json.dumps(sarif))
 
 
 class HtmlReportTests(unittest.TestCase):
@@ -189,6 +254,38 @@ class HtmlReportTests(unittest.TestCase):
         self.assertIn("confirmed", output)
         self.assertIn("leak, baas", output)
         self.assertIn("browser", output)
+
+    def test_html_distinguishes_static_validated_from_active_confirmed(self):
+        findings = [
+            Finding(
+                type="active_secret",
+                severity="critical",
+                confidence=0.95,
+                detector_id="leak:active_secret",
+                source="bundle.js",
+                evidence=Evidence(source="bundle.js", redacted_value="[redacted:11111111]"),
+                risk_reason="Actively confirmed secret.",
+                remediation="Rotate the key.",
+                validation_status="confirmed",
+                category="leak",
+            ),
+            Finding(
+                type="static_secret",
+                severity="high",
+                confidence=0.9,
+                detector_id="leak:static_secret",
+                source="bundle.js",
+                evidence=Evidence(source="bundle.js", redacted_value="[redacted:22222222]"),
+                risk_reason="Static detector match.",
+                remediation="Review and rotate if live.",
+                validation_status="validated",
+                category="leak",
+            ),
+        ]
+        output = format_html(build_report("https://preview.example.com", findings, scan_mode="browser"))
+
+        self.assertEqual(output.count('class="badge-confirmed">confirmed</span>'), 1)
+        self.assertIn('class="badge-validated">validated</span>', output)
 
     def test_html_report_escapes_dynamic_content(self):
         finding = Finding(

--- a/tests/test_core_reporting.py
+++ b/tests/test_core_reporting.py
@@ -170,6 +170,24 @@ class ReportingTests(unittest.TestCase):
         self.assertTrue(first.startswith("klfp1_"))
         self.assertNotIn("sk-proj-secret-value", first)
 
+    def test_finding_fingerprint_ignores_line_shifts(self):
+        first = finding_fingerprint(
+            detector_id="test:openai_api_key",
+            source="app.py",
+            raw_value="sk-proj-secret-value",
+            request_url="https://example.com/app.js",
+            line=12,
+        )
+        second = finding_fingerprint(
+            detector_id="test:openai_api_key",
+            source="app.py",
+            raw_value="sk-proj-secret-value",
+            request_url="https://example.com/app.js",
+            line=99,
+        )
+
+        self.assertEqual(first, second)
+
     def test_baseline_suppresses_across_redaction_salt_rotation(self):
         raw_key = "sk-proj-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz9876543210"
         content = f'OPENAI_API_KEY="{raw_key}"\n'

--- a/tests/test_site_scanner.py
+++ b/tests/test_site_scanner.py
@@ -192,14 +192,24 @@ class ScanSiteTests(unittest.TestCase):
 
     def test_handles_page_scan_errors(self):
         def boom(url, **kwargs):
-            raise RuntimeError("playwright exploded")
+            raise RuntimeError(f"playwright exploded for {url}")
 
         with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["example.com"]), \
-             mock.patch.object(ss, "crawl_pages", lambda hosts, **k: ["https://example.com/"]), \
+             mock.patch.object(
+                 ss,
+                 "crawl_pages",
+                 lambda hosts, **k: ["https://example.com/?token=supersecretvalue-long"],
+             ), \
              mock.patch.object(ss, "run_browser_scan", boom):
             report = ss.scan_site("example.com")   # must not raise
         self.assertEqual(report.findings, [])
         self.assertEqual(report.extra["pages_scanned"], 1)
+        self.assertEqual(report.extra["pages_failed"], 1)
+        self.assertIn("playwright exploded", report.extra["scan_failures"][0]["error"])
+        self.assertIn("[redacted]", report.extra["scan_failures"][0]["error"])
+        self.assertNotIn("supersecretvalue", report.extra["scan_failures"][0]["error"])
+        self.assertIn("[redacted]", report.extra["scan_failures"][0]["url"])
+        self.assertNotIn("supersecretvalue", report.extra["scan_failures"][0]["url"])
 
     def test_proxy_threaded_to_crawl_and_browser_scan(self):
         seen = {}

--- a/tests/test_site_scanner.py
+++ b/tests/test_site_scanner.py
@@ -192,7 +192,7 @@ class ScanSiteTests(unittest.TestCase):
 
     def test_handles_page_scan_errors(self):
         def boom(url, **kwargs):
-            raise RuntimeError(f"playwright exploded for {url}")
+            raise RuntimeError(f"playwright exploded for {url} owner jane.doe@example.com")
 
         with mock.patch.object(ss, "discover_subdomains", lambda d, **k: ["example.com"]), \
              mock.patch.object(
@@ -205,11 +205,10 @@ class ScanSiteTests(unittest.TestCase):
         self.assertEqual(report.findings, [])
         self.assertEqual(report.extra["pages_scanned"], 1)
         self.assertEqual(report.extra["pages_failed"], 1)
-        self.assertIn("playwright exploded", report.extra["scan_failures"][0]["error"])
-        self.assertIn("[redacted]", report.extra["scan_failures"][0]["error"])
-        self.assertNotIn("supersecretvalue", report.extra["scan_failures"][0]["error"])
+        self.assertEqual(report.extra["scan_failures"][0]["error"], "RuntimeError during page scan")
         self.assertIn("[redacted]", report.extra["scan_failures"][0]["url"])
         self.assertNotIn("supersecretvalue", report.extra["scan_failures"][0]["url"])
+        self.assertNotIn("jane.doe@example.com", report.extra["scan_failures"][0]["error"])
 
     def test_proxy_threaded_to_crawl_and_browser_scan(self):
         seen = {}


### PR DESCRIPTION
## Summary
- add stable privacy-preserving finding fingerprints for scanner findings, reports, SARIF, diffing, and suppressions
- make reports more reproducible with scan-mode-specific retest commands
- make report output more honest by separating static `validated` findings from active `confirmed` findings and surfacing redacted site-scan page failures

## Validation
- `rtk poetry run pytest tests/test_core_reporting.py tests/test_site_scanner.py -q` -> 68 passed, 3 existing urllib3 Brotli warnings
- `rtk poetry run pytest` -> 269 passed, 3 existing urllib3 Brotli warnings

## Notes
- `.superplan/` and `video/` were left uncommitted; they are local workflow/unrelated artifacts outside this PR scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable finding fingerprints to improve consistent matching across scans and reports.
  * Expanded suppression support so findings can be ignored by fingerprint as well as existing criteria.
  * Added clearer scan-mode-specific rerun commands in reporting.

* **Bug Fixes**
  * Redacts sensitive URLs and error details in scan output and saved findings.
  * Improves diffing so unchanged findings are less likely to reappear after scan noise changes.
  * Distinguishes “confirmed” vs. “validated” statuses in HTML reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->